### PR TITLE
Add missing includes to file.h and file.cc

### DIFF
--- a/open_spiel/utils/file.cc
+++ b/open_spiel/utils/file.cc
@@ -29,8 +29,8 @@
 #include <unistd.h>
 #endif
 
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 
 #include "open_spiel/spiel_utils.h"
 

--- a/open_spiel/utils/file.cc
+++ b/open_spiel/utils/file.cc
@@ -30,6 +30,7 @@
 #endif
 
 #include <cstdio>
+#include <cstdint>
 
 #include "open_spiel/spiel_utils.h"
 

--- a/open_spiel/utils/file.h
+++ b/open_spiel/utils/file.h
@@ -15,6 +15,7 @@
 #ifndef OPEN_SPIEL_UTILS_FILE_H_
 #define OPEN_SPIEL_UTILS_FILE_H_
 
+#include <cstdint>
 #include <string>
 #include <memory>
 


### PR DESCRIPTION
I noticed that the C++ compilation was failing after upgrade to Ubuntu 23.10, this fixed it.