### PR TITLE
Modularize the CMake build targets of each game

### DIFF
--- a/open_spiel/games/CMakeLists.txt
+++ b/open_spiel/games/CMakeLists.txt
@@ -1,189 +1,4 @@
-set(GAME_SOURCES
-  amazons/amazons.cc
-  amazons/amazons.h
-  backgammon/backgammon.cc
-  backgammon/backgammon.h
-  bargaining/bargaining.cc
-  bargaining/bargaining.h
-  battleship/battleship.cc
-  battleship/battleship.h
-  battleship/battleship_types.h
-  battleship/battleship_types.cc
-  blackjack/blackjack.cc
-  blackjack/blackjack.h
-  blotto/blotto.cc
-  blotto/blotto.h
-  breakthrough/breakthrough.cc
-  breakthrough/breakthrough.h
-  bridge/bridge.cc
-  bridge/bridge.h
-  bridge/bridge_scoring.cc
-  bridge/bridge_scoring.h
-  bridge/bridge_uncontested_bidding.cc
-  bridge/bridge_uncontested_bidding.h
-  catch/catch.cc
-  catch/catch.h
-  checkers/checkers.cc
-  checkers/checkers.h
-  chess/chess.cc
-  chess/chess.h
-  chess/chess_board.cc
-  chess/chess_board.h
-  chess/chess_common.cc
-  chess/chess_common.h
-  cliff_walking/cliff_walking.cc
-  cliff_walking/cliff_walking.h
-  clobber/clobber.cc
-  clobber/clobber.h
-  coin_game/coin_game.cc
-  coin_game/coin_game.h
-  colored_trails/colored_trails.cc
-  colored_trails/colored_trails.h
-  colored_trails/colored_trails_utils.cc
-  connect_four/connect_four.cc
-  connect_four/connect_four.h
-  coop_box_pushing/coop_box_pushing.cc
-  coop_box_pushing/coop_box_pushing.h
-  coordinated_mp/coordinated_mp.cc
-  coordinated_mp/coordinated_mp.h
-  crazy_eights/crazy_eights.cc
-  crazy_eights/crazy_eights.h
-  cursor_go/cursor_go.cc
-  cursor_go/cursor_go.h
-  dark_chess/dark_chess.cc
-  dark_chess/dark_chess.h
-  dark_hex/dark_hex.cc
-  dark_hex/dark_hex.h
-  deep_sea/deep_sea.cc
-  deep_sea/deep_sea.h
-  dots_and_boxes/dots_and_boxes.cc
-  dots_and_boxes/dots_and_boxes.h
-  dynamic_routing/dynamic_routing_data.cc
-  dynamic_routing/dynamic_routing_data.h
-  dynamic_routing/dynamic_routing_utils.cc
-  dynamic_routing/dynamic_routing_utils.h
-  dou_dizhu/dou_dizhu.cc
-  dou_dizhu/dou_dizhu.h
-  dou_dizhu/dou_dizhu_utils.cc
-  dou_dizhu/dou_dizhu_utils.h
-  efg_game/efg_game.cc
-  efg_game/efg_game.h
-  efg_game/efg_game_data.cc
-  efg_game/efg_game_data.h
-  euchre/euchre.cc
-  euchre/euchre.h
-  first_sealed_auction/first_sealed_auction.cc
-  first_sealed_auction/first_sealed_auction.h
-  gin_rummy/gin_rummy.cc
-  gin_rummy/gin_rummy.h
-  gin_rummy/gin_rummy_utils.cc
-  gin_rummy/gin_rummy_utils.h
-  go/go.cc
-  go/go.h
-  go/go_board.cc
-  go/go_board.h
-  goofspiel/goofspiel.cc
-  goofspiel/goofspiel.h
-  havannah/havannah.cc
-  havannah/havannah.h
-  hearts/hearts.cc
-  hearts/hearts.h
-  hex/hex.cc
-  hex/hex.h
-  kriegspiel/kriegspiel.cc
-  kriegspiel/kriegspiel.h
-  kuhn_poker/kuhn_poker.cc
-  kuhn_poker/kuhn_poker.h
-  laser_tag/laser_tag.cc
-  laser_tag/laser_tag.h
-  leduc_poker/leduc_poker.cc
-  leduc_poker/leduc_poker.h
-  lewis_signaling/lewis_signaling.cc
-  lewis_signaling/lewis_signaling.h
-  liars_dice/liars_dice.cc
-  liars_dice/liars_dice.h
-  maedn/maedn.cc
-  maedn/maedn.h
-  mancala/mancala.cc
-  mancala/mancala.h
-  markov_soccer/markov_soccer.cc
-  markov_soccer/markov_soccer.h
-  matching_pennies_3p/matching_pennies_3p.cc
-  matching_pennies_3p/matching_pennies_3p.h
-  matrix_games/matrix_games.cc
-  mfg/crowd_modelling.cc
-  mfg/crowd_modelling.h
-  mfg/crowd_modelling_2d.cc
-  mfg/crowd_modelling_2d.h
-  mfg/dynamic_routing.cc
-  mfg/dynamic_routing.h
-  mfg/garnet.cc
-  mfg/garnet.h
-  morpion_solitaire/morpion_solitaire.cc
-  morpion_solitaire/morpion_solitaire.h
-  negotiation/negotiation.cc
-  negotiation/negotiation.h
-  nfg_game/nfg_game.cc
-  nfg_game/nfg_game.h
-  nine_mens_morris/nine_mens_morris.cc
-  nine_mens_morris/nine_mens_morris.h
-  nim/nim.cc
-  nim/nim.h
-  oh_hell/oh_hell.cc
-  oh_hell/oh_hell.h
-  oshi_zumo/oshi_zumo.cc
-  oshi_zumo/oshi_zumo.h
-  othello/othello.cc
-  othello/othello.h
-  oware/oware.cc
-  oware/oware.h
-  oware/oware_board.cc
-  oware/oware_board.h
-  pathfinding/pathfinding.cc
-  pathfinding/pathfinding.h
-  pentago/pentago.cc
-  pentago/pentago.h
-  phantom_go/phantom_go.h
-  phantom_go/phantom_go.cc
-  phantom_go/phantom_go_board.h
-  phantom_go/phantom_go_board.cc
-  phantom_ttt/phantom_ttt.cc
-  phantom_ttt/phantom_ttt.h
-  pig/pig.cc
-  pig/pig.h
-  quoridor/quoridor.cc
-  quoridor/quoridor.h
-  rbc/rbc.cc
-  rbc/rbc.h
-  sheriff/sheriff.cc
-  sheriff/sheriff.h
-  skat/skat.cc
-  skat/skat.h
-  solitaire/solitaire.cc
-  solitaire/solitaire.h
-  stones_and_gems/stones_and_gems.cc
-  stones_and_gems/stones_and_gems.h
-  tarok/tarok.cc
-  tarok/tarok.h
-  tarok/cards.cc
-  tarok/cards.h
-  tarok/contracts.cc
-  tarok/contracts.h
-  tic_tac_toe/tic_tac_toe.cc
-  tic_tac_toe/tic_tac_toe.h
-  tiny_bridge/tiny_bridge.cc
-  tiny_bridge/tiny_bridge.h
-  tiny_hanabi/tiny_hanabi.cc
-  tiny_hanabi/tiny_hanabi.h
-  trade_comm/trade_comm.cc
-  trade_comm/trade_comm.h
-  twenty_forty_eight/2048.cc
-  twenty_forty_eight/2048.h
-  ultimate_tic_tac_toe/ultimate_tic_tac_toe.h
-  ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
-  y/y.cc
-  y/y.h
-)
+set(GAME_SOURCES)
 
 if (${OPEN_SPIEL_BUILD_WITH_HANABI})
   set(GAME_SOURCES ${GAME_SOURCES} hanabi/hanabi.cc hanabi/hanabi.h)
@@ -192,7 +7,7 @@ if (${OPEN_SPIEL_BUILD_WITH_ACPC})
   set(GAME_SOURCES ${GAME_SOURCES} universal_poker/universal_poker.cc universal_poker/universal_poker.h)
 endif()
 
-add_library (games OBJECT ${GAME_SOURCES})
+add_library (games OBJECT)
 
 target_include_directories (games PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -272,346 +87,470 @@ add_library(bridge_double_dummy_solver OBJECT
 target_include_directories (bridge_double_dummy_solver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(bridge_double_dummy_solver PUBLIC DDS_NO_STATIC_INIT)
 
-add_executable(2048_test twenty_forty_eight/2048_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(2048_test 2048_test)
-
-add_executable(amazons_test amazons/amazons_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(amazons_test amazons_test)
-
-add_executable(backgammon_test backgammon/backgammon_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(backgammon_test backgammon_test)
-
-add_executable(bargaining_instance_generator bargaining/bargaining_instance_generator.cc
-               ${OPEN_SPIEL_OBJECTS})
-add_executable(bargaining_test bargaining/bargaining_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(bargaining_test bargaining_test)
-
-add_executable(battleship_test battleship/battleship_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(battleship_test battleship_test)
-
-add_executable(blackjack_test blackjack/blackjack_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(blackjack_test blackjack_test)
-
-add_executable(blotto_test blotto/blotto_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(blotto_test blotto_test)
-
-add_executable(breakthrough_test breakthrough/breakthrough_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(breakthrough_test breakthrough_test)
-
-add_executable(bridge_test bridge/bridge_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(bridge_test bridge_test)
-
-add_executable(catch_test catch/catch_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(catch_test catch_test)
-
-add_executable(checkers_test checkers/checkers_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(checkers_test checkers_test)
-
-add_executable(chess_test chess/chess_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(chess_test chess_test)
-
-add_executable(cliff_walking_test cliff_walking/cliff_walking_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(cliff_walking_test cliff_walking_test)
-
-add_executable(clobber_test clobber/clobber_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(clobber_test clobber_test)
-
-add_executable(coin_game_test coin_game/coin_game_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(coin_game_test coin_game_test)
-
-add_executable(colored_trails_board_generator
-               colored_trails/colored_trails_board_generator.cc
-               ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:tests>)
-
-add_executable(colored_trails_test colored_trails/colored_trails_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(colored_trails_test colored_trails_test)
-
-add_executable(connect_four_test connect_four/connect_four_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(connect_four_test connect_four_test)
-
-add_executable(coop_box_pushing_test coop_box_pushing/coop_box_pushing_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(coop_box_pushing_test coop_box_pushing_test)
-
-add_executable(coordinated_mp_test coordinated_mp/coordinated_mp_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>
-        $<TARGET_OBJECTS:algorithms>)
-add_test(coordinated_mp_test coordinated_mp_test)
-
-add_executable(crazy_eights_test crazy_eights/crazy_eights_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(crazy_eights_test crazy_eights_test)
-
-add_executable(crowd_modelling_test mfg/crowd_modelling_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(crowd_modelling_test crowd_modelling_test)
-
-add_executable(crowd_modelling_2d_test mfg/crowd_modelling_2d_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(crowd_modelling_2d_test crowd_modelling_2d_test)
-
-add_executable(cursor_go_test cursor_go/cursor_go_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(cursor_go_test cursor_go_test)
-
-add_executable(dark_chess_test dark_chess/dark_chess_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(dark_chess_test dark_chess_test)
-
-add_executable(dark_hex_test dark_hex/dark_hex_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dark_hex_test dark_hex_test)
-
-add_executable(deep_sea_test deep_sea/deep_sea_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(deep_sea_test deep_sea_test)
-
-add_executable(dots_and_boxes_test dots_and_boxes/dots_and_boxes_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dots_and_boxes_test dots_and_boxes_test)
-
-add_executable(dynamic_routing_data_test dynamic_routing/dynamic_routing_data_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dynamic_routing_data_test dynamic_routing_data_test)
-
-add_executable(dynamic_routing_test mfg/dynamic_routing_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dynamic_routing_test dynamic_routing_test)
-
-add_executable(dynamic_routing_utils_test dynamic_routing/dynamic_routing_utils_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dynamic_routing_utils_test dynamic_routing_utils_test)
-
-add_executable(dou_dizhu_test dou_dizhu/dou_dizhu_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dou_dizhu_test dou_dizhu_test)
-
-add_executable(dou_dizhu_utils_test dou_dizhu/dou_dizhu_utils_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dou_dizhu_utils_test dou_dizhu_utils_test)
-
-add_executable(efg_game_test efg_game/efg_game_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(efg_game_test efg_game_test)
-
-add_executable(euchre_test euchre/euchre_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(euchre_test euchre_test)
-
-add_executable(first_sealed_auction_test first_sealed_auction/first_sealed_auction_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(first_sealed_auction_test first_sealed_auction_test)
-
-add_executable(garnet_test mfg/garnet_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(garnet_test garnet_test)
-
-add_executable(gin_rummy_test gin_rummy/gin_rummy_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(gin_rummy_test gin_rummy_test)
-
-add_executable(go_test go/go_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(go_test go_test)
-
-add_executable(phantom_go_test phantom_go/phantom_go_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(phantom_go_test phantom_go_test)
-
-add_executable(goofspiel_test goofspiel/goofspiel_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(goofspiel_test goofspiel_test)
-
-add_executable(havannah_test havannah/havannah_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(havannah_test havannah_test)
-
-add_executable(hearts_test hearts/hearts_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(hearts_test hearts_test)
-
-add_executable(hex_test hex/hex_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(hex_test hex_test)
-
-add_executable(kriegspiel_test kriegspiel/kriegspiel_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(kriegspiel_test kriegspiel_test)
-
-add_executable(kuhn_poker_test kuhn_poker/kuhn_poker_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(kuhn_poker_test kuhn_poker_test)
-
-add_executable(leduc_poker_test leduc_poker/leduc_poker_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(leduc_poker_test leduc_poker_test)
-
-add_executable(lewis_signaling_test lewis_signaling/lewis_signaling_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(lewis_signaling_test lewis_signaling_test)
-
-add_executable(liars_dice_test liars_dice/liars_dice_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(liars_dice_test liars_dice_test)
-
-add_executable(maedn_test maedn/maedn_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(maedn_test maedn_test)
-
-add_executable(mancala_test mancala/mancala_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(mancala_test mancala_test)
-
-add_executable(markov_soccer_test markov_soccer/markov_soccer_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(markov_soccer_test markov_soccer_test)
-
-add_executable(matching_pennies_3p_test matching_pennies_3p/matching_pennies_3p_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(matching_pennies_3p_test matching_pennies_3p_test)
-
-add_executable(matrix_games_test matrix_games/matrix_games_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(matrix_games_test matrix_games_test)
-
-add_executable(morpion_solitaire_test morpion_solitaire/morpion_solitaire_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(morpion_solitaire_test morpion_solitaire_test)
-
-add_executable(negotiation_test negotiation/negotiation_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(negotiation_test negotiation_test)
-
-add_executable(nfg_game_test nfg_game/nfg_game_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(nfg_game_test nfg_game_test)
-
-add_executable(nim_test nim/nim_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(nim_test nim_test)
-
-add_executable(nine_mens_morris_test nine_mens_morris/nine_mens_morris_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(nine_mens_morris_test nine_mens_morris_test)
-
-add_executable(oh_hell_test oh_hell/oh_hell_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(oh_hell_test oh_hell_test)
-
-add_executable(oshi_zumo_test oshi_zumo/oshi_zumo_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(oshi_zumo_test oshi_zumo_test)
-
-add_executable(othello_test othello/othello_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(othello_test othello_test)
-
-add_executable(oware_test oware/oware_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(oware_test oware_test)
-
-add_executable(pathfinding_test pathfinding/pathfinding_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(pathfinding_test pathfinding_test)
-
-add_executable(pentago_test pentago/pentago_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(pentago_test pentago_test)
-
-add_executable(phantom_ttt_test phantom_ttt/phantom_ttt_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(phantom_ttt_test phantom_ttt_test)
-
-add_executable(pig_test pig/pig_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(pig_test pig_test)
-
-add_executable(quoridor_test quoridor/quoridor_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(quoridor_test quoridor_test)
-
-add_executable(rbc_test rbc/rbc_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(rbc_test rbc_test)
-
-add_executable(sheriff_test sheriff/sheriff_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(sheriff_test sheriff_test)
-
-add_executable(skat_test skat/skat_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(skat_test skat_test)
-
-add_executable(solitaire_test solitaire/solitaire_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(solitaire_test solitaire_test)
-
-add_executable(stones_and_gems_test stones_and_gems/stones_and_gems_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(stones_and_gems_test stones_and_gems_test)
-
-add_executable(tarok_test tarok/tarok_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(tarok_test tarok_test)
-
-add_executable(tic_tac_toe_test tic_tac_toe/tic_tac_toe_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(tic_tac_toe_test tic_tac_toe_test)
-
-add_executable(laser_tag_test laser_tag/laser_tag_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(laser_tag_test laser_tag_test)
-
-add_executable(tiny_bridge_test tiny_bridge/tiny_bridge_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(tiny_bridge_test tiny_bridge_test)
-
-add_executable(tiny_hanabi_test tiny_hanabi/tiny_hanabi_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(tiny_hanabi_test tiny_hanabi_test)
-
-add_executable(trade_comm_test trade_comm/trade_comm_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(trade_comm_test trade_comm_test)
-
-add_executable(ultimate_tic_tac_toe_test ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc
-               ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:tests>)
-add_test(ultimate_tic_tac_toe_test ultimate_tic_tac_toe_test)
+# Convenience macro to register a game and one of its tests.
+macro(add_game)
+  set(options)
+  set(oneValueArgs NAME)
+  set(multiValueArgs SOURCES LIBRARIES TEST_SOURCES TEST_LIBRARIES TEST_ARGS)
+  cmake_parse_arguments("" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Create a library that others can link against to play the game
+  add_library("${_NAME}" ${_SOURCES})
+  target_link_libraries("${_NAME}" open_spiel_core ${_LIBRARIES})
+  
+  # Register the game's source files.
+  # This line is needed so that the variable ${OPEN_SPIEL_OBJECTS} includes
+  # the source files of every game. We would like to replace usages of
+  # ${OPEN_SPIEL_OBJECTS} with proper library linkage, and eventually remove
+  # this line once we no longer rely on ${OPEN_SPIEL_OBJECTS}.
+  list(APPEND GAME_SOURCES ${_SOURCES})
+  
+  add_game_test(NAME "${_NAME}_test"
+    SOURCES ${_TEST_SOURCES}
+    LIBRARIES "${_NAME}" ${_TEST_LIBRARIES}
+    ARGS ${_TEST_ARGS})
+endmacro()
+  
+# Build and register an OpenSpiel test
+macro(add_game_test)
+  set(options)
+  set(oneValueArgs NAME)
+  set(multiValueArgs SOURCES LIBRARIES ARGS)
+  cmake_parse_arguments("" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  add_game_executable(NAME "${_NAME}" SOURCES ${_SOURCES} LIBRARIES tests ${_LIBRARIES})
+  add_test(NAME "${_NAME}" COMMAND "${_NAME}" ${_ARGS})
+endmacro()
+
+macro(add_game_executable)
+  set(options)
+  set(oneValueArgs NAME)
+  set(multiValueArgs SOURCES LIBRARIES)
+  cmake_parse_arguments("" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  add_executable("${_NAME}" ${_SOURCES})
+  target_link_libraries("${_NAME}" open_spiel_core ${_LIBRARIES})
+endmacro()
+
+add_game(NAME 2048
+  SOURCES twenty_forty_eight/2048.cc twenty_forty_eight/2048.h
+  TEST_SOURCES twenty_forty_eight/2048_test.cc)
+
+add_game(NAME amazons
+  SOURCES amazons/amazons.cc amazons/amazons.h
+  TEST_SOURCES amazons/amazons_test.cc)
+
+add_game(NAME backgammon
+  SOURCES backgammon/backgammon.cc backgammon/backgammon.h
+  TEST_SOURCES backgammon/backgammon_test.cc)
+
+add_game(NAME bargaining
+  SOURCES bargaining/bargaining.cc bargaining/bargaining.h
+  LIBRARIES utils
+  TEST_SOURCES bargaining/bargaining_test.cc
+  TEST_LIBRARIES utils)
+add_game_executable(NAME bargaining_instance_generator
+  SOURCES bargaining/bargaining_instance_generator.cc
+  LIBRARIES bargaining utils)
+
+add_game(NAME battleship
+  SOURCES
+    battleship/battleship.cc
+    battleship/battleship.h
+    battleship/battleship_types.h
+    battleship/battleship_types.cc
+  TEST_SOURCES
+    battleship/battleship_test.cc
+  TEST_LIBRARIES
+    algorithms game_transforms utils)
+
+add_game(NAME blackjack
+  SOURCES blackjack/blackjack.cc blackjack/blackjack.h
+  TEST_SOURCES blackjack/blackjack_test.cc)
+
+add_game(NAME blotto
+  SOURCES blotto/blotto.cc blotto/blotto.h
+  TEST_SOURCES blotto/blotto_test.cc)
+
+add_game(NAME breakthrough
+  SOURCES breakthrough/breakthrough.cc breakthrough/breakthrough.h
+  TEST_SOURCES breakthrough/breakthrough_test.cc)
+
+add_game(NAME bridge
+  SOURCES
+    bridge/bridge.cc
+    bridge/bridge.h
+    bridge/bridge_scoring.cc
+    bridge/bridge_scoring.h
+    bridge/bridge_uncontested_bidding.cc
+    bridge/bridge_uncontested_bidding.h
+  LIBRARIES
+    bridge_double_dummy_solver
+  TEST_SOURCES
+    bridge/bridge_test.cc)
+
+add_game(NAME catch
+  SOURCES catch/catch.cc catch/catch.h
+  TEST_SOURCES catch/catch_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME checkers
+  SOURCES checkers/checkers.cc checkers/checkers.h
+  TEST_SOURCES checkers/checkers_test.cc)
+
+add_game(NAME chess
+  SOURCES
+    chess/chess.cc
+    chess/chess.h
+    chess/chess_board.cc
+    chess/chess_board.h
+    chess/chess_common.cc
+    chess/chess_common.h
+  TEST_SOURCES
+    chess/chess_test.cc)
+
+add_game(NAME cliff_walking
+  SOURCES cliff_walking/cliff_walking.cc cliff_walking/cliff_walking.h
+  TEST_SOURCES cliff_walking/cliff_walking_test.cc)
+
+add_game(NAME clobber
+  SOURCES clobber/clobber.cc clobber/clobber.h
+  TEST_SOURCES clobber/clobber_test.cc)
+
+add_game(NAME coin_game
+  SOURCES coin_game/coin_game.cc coin_game/coin_game.h
+  TEST_SOURCES coin_game/coin_game_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME colored_trails
+  SOURCES
+    colored_trails/colored_trails.cc
+    colored_trails/colored_trails.h
+    colored_trails/colored_trails_utils.cc
+  LIBRARIES
+    utils
+  TEST_SOURCES
+    colored_trails/colored_trails_test.cc
+  TEST_LIBRARIES
+    utils)
+add_game_executable(NAME colored_trails_board_generator
+  SOURCES colored_trails/colored_trails_board_generator.cc
+  LIBRARIES colored_trails utils)
+
+add_game(NAME connect_four
+  SOURCES connect_four/connect_four.cc connect_four/connect_four.h
+  TEST_SOURCES connect_four/connect_four_test.cc)
+
+add_game(NAME coop_box_pushing
+  SOURCES coop_box_pushing/coop_box_pushing.cc coop_box_pushing/coop_box_pushing.h
+  TEST_SOURCES coop_box_pushing/coop_box_pushing_test.cc)
+
+add_game(NAME coordinated_mp
+  SOURCES coordinated_mp/coordinated_mp.cc coordinated_mp/coordinated_mp.h
+  TEST_SOURCES coordinated_mp/coordinated_mp_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME crazy_eights
+  SOURCES crazy_eights/crazy_eights.cc crazy_eights/crazy_eights.h
+  TEST_SOURCES crazy_eights/crazy_eights_test.cc)
+
+add_game(NAME crowd_modelling
+  SOURCES
+    dynamic_routing/dynamic_routing_data.cc
+    dynamic_routing/dynamic_routing_data.h
+    dynamic_routing/dynamic_routing_utils.cc
+    dynamic_routing/dynamic_routing_utils.h
+    mfg/crowd_modelling.cc
+    mfg/crowd_modelling.h
+    mfg/crowd_modelling_2d.cc
+    mfg/crowd_modelling_2d.h
+    mfg/dynamic_routing.cc
+    mfg/dynamic_routing.h
+    mfg/garnet.cc
+    mfg/garnet.h
+  TEST_SOURCES
+    mfg/crowd_modelling_test.cc)
+
+add_game_test(NAME crowd_modelling_2d_test
+  SOURCES mfg/crowd_modelling_2d_test.cc
+  LIBRARIES crowd_modelling)
+
+add_game_test(NAME dynamic_routing_test
+  SOURCES mfg/dynamic_routing_test.cc
+  LIBRARIES crowd_modelling)
+
+add_game_test(NAME dynamic_routing_data_test
+  SOURCES dynamic_routing/dynamic_routing_data_test.cc
+  LIBRARIES crowd_modelling)
+
+add_game_test(NAME dynamic_routing_utils_test
+  SOURCES dynamic_routing/dynamic_routing_utils_test.cc
+  LIBRARIES crowd_modelling)
+
+add_game_test(NAME garnet_test
+  SOURCES mfg/garnet_test.cc
+  LIBRARIES crowd_modelling)
+
+add_game(NAME cursor_go
+  SOURCES cursor_go/cursor_go.cc cursor_go/cursor_go.h
+  LIBRARIES go
+  TEST_SOURCES cursor_go/cursor_go_test.cc
+  TEST_LIBRARIES go)
+
+add_game(NAME dark_chess
+  SOURCES dark_chess/dark_chess.cc dark_chess/dark_chess.h
+  LIBRARIES chess
+  TEST_SOURCES dark_chess/dark_chess_test.cc
+  TEST_LIBRARIES chess)
+
+add_game(NAME dark_hex
+  SOURCES dark_hex/dark_hex.cc dark_hex/dark_hex.h
+  LIBRARIES hex
+  TEST_SOURCES dark_hex/dark_hex_test.cc)
+
+add_game(NAME deep_sea
+  SOURCES deep_sea/deep_sea.cc deep_sea/deep_sea.h
+  TEST_SOURCES deep_sea/deep_sea_test.cc)
+
+add_game(NAME dots_and_boxes
+  SOURCES dots_and_boxes/dots_and_boxes.cc dots_and_boxes/dots_and_boxes.h
+  TEST_SOURCES dots_and_boxes/dots_and_boxes_test.cc)
+
+add_game(NAME dou_dizhu
+  SOURCES
+    dou_dizhu/dou_dizhu.cc
+    dou_dizhu/dou_dizhu.h
+    dou_dizhu/dou_dizhu_utils.cc
+    dou_dizhu/dou_dizhu_utils.h
+  TEST_SOURCES
+    dou_dizhu/dou_dizhu_test.cc)
+add_game_test(NAME dou_dizhu_utils_test
+  SOURCES dou_dizhu/dou_dizhu_utils_test.cc
+  LIBRARIES dou_dizhu)
+
+add_game(NAME efg_game
+  SOURCES
+    efg_game/efg_game.cc
+    efg_game/efg_game.h
+    efg_game/efg_game_data.cc
+    efg_game/efg_game_data.h
+  LIBRARIES
+    utils
+  TEST_SOURCES
+    efg_game/efg_game_test.cc
+  TEST_LIBRARIES
+    utils)
+
+add_game(NAME euchre
+  SOURCES euchre/euchre.cc euchre/euchre.h
+  TEST_SOURCES euchre/euchre_test.cc)
+
+add_game(NAME first_sealed_auction
+  SOURCES first_sealed_auction/first_sealed_auction.cc first_sealed_auction/first_sealed_auction.h
+  TEST_SOURCES first_sealed_auction/first_sealed_auction_test.cc)
+
+add_game(NAME gin_rummy
+  SOURCES
+    gin_rummy/gin_rummy.cc
+    gin_rummy/gin_rummy.h
+    gin_rummy/gin_rummy_utils.cc
+    gin_rummy/gin_rummy_utils.h
+  LIBRARIES
+    algorithms
+    game_transforms
+    utils
+  TEST_SOURCES
+    gin_rummy/gin_rummy_test.cc)
+
+add_game(NAME go
+  SOURCES
+    go/go.cc
+    go/go.h
+    go/go_board.cc
+    go/go_board.h
+  TEST_SOURCES
+    go/go_test.cc)
+
+add_game(NAME goofspiel
+  SOURCES goofspiel/goofspiel.cc goofspiel/goofspiel.h
+  TEST_SOURCES goofspiel/goofspiel_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME havannah
+  SOURCES havannah/havannah.cc havannah/havannah.h
+  TEST_SOURCES havannah/havannah_test.cc)
+
+add_game(NAME hearts
+  SOURCES hearts/hearts.cc hearts/hearts.h
+  TEST_SOURCES hearts/hearts_test.cc)
+
+add_game(NAME hex
+  SOURCES hex/hex.cc hex/hex.h
+  TEST_SOURCES hex/hex_test.cc)
+
+add_game(NAME kriegspiel
+  SOURCES kriegspiel/kriegspiel.cc kriegspiel/kriegspiel.h
+  LIBRARIES chess
+  TEST_SOURCES kriegspiel/kriegspiel_test.cc)
+
+add_game(NAME kuhn_poker
+  SOURCES kuhn_poker/kuhn_poker.cc kuhn_poker/kuhn_poker.h
+  TEST_SOURCES kuhn_poker/kuhn_poker_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME laser_tag
+  SOURCES laser_tag/laser_tag.cc laser_tag/laser_tag.h
+  TEST_SOURCES laser_tag/laser_tag_test.cc)
+
+add_game(NAME leduc_poker
+  SOURCES leduc_poker/leduc_poker.cc leduc_poker/leduc_poker.h
+  TEST_SOURCES leduc_poker/leduc_poker_test.cc)
+
+add_game(NAME lewis_signaling
+  SOURCES lewis_signaling/lewis_signaling.cc lewis_signaling/lewis_signaling.h
+  TEST_SOURCES lewis_signaling/lewis_signaling_test.cc)
+
+add_game(NAME liars_dice
+  SOURCES liars_dice/liars_dice.cc liars_dice/liars_dice.h
+  TEST_SOURCES liars_dice/liars_dice_test.cc)
+
+add_game(NAME maedn
+  SOURCES maedn/maedn.cc maedn/maedn.h
+  TEST_SOURCES maedn/maedn_test.cc)
+
+add_game(NAME mancala
+  SOURCES mancala/mancala.cc mancala/mancala.h
+  TEST_SOURCES mancala/mancala_test.cc)
+
+add_game(NAME markov_soccer
+  SOURCES markov_soccer/markov_soccer.cc markov_soccer/markov_soccer.h
+  TEST_SOURCES markov_soccer/markov_soccer_test.cc)
+
+add_game(NAME matching_pennies_3p
+  SOURCES matching_pennies_3p/matching_pennies_3p.cc matching_pennies_3p/matching_pennies_3p.h
+  TEST_SOURCES matching_pennies_3p/matching_pennies_3p_test.cc)
+
+add_game(NAME matrix_games
+  SOURCES matrix_games/matrix_games.cc
+  TEST_SOURCES matrix_games/matrix_games_test.cc)
+
+add_game(NAME morpion_solitaire
+  SOURCES morpion_solitaire/morpion_solitaire.cc morpion_solitaire/morpion_solitaire.h
+  TEST_SOURCES morpion_solitaire/morpion_solitaire_test.cc)
+
+add_game(NAME negotiation
+  SOURCES negotiation/negotiation.cc negotiation/negotiation.h
+  TEST_SOURCES negotiation/negotiation_test.cc)
+
+add_game(NAME nfg_game
+  SOURCES nfg_game/nfg_game.cc nfg_game/nfg_game.h
+  TEST_SOURCES nfg_game/nfg_game_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME nine_mens_morris
+  SOURCES nine_mens_morris/nine_mens_morris.cc nine_mens_morris/nine_mens_morris.h
+  TEST_SOURCES nine_mens_morris/nine_mens_morris_test.cc)
+
+add_game(NAME nim
+  SOURCES nim/nim.cc nim/nim.h
+  TEST_SOURCES nim/nim_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME oh_hell
+  SOURCES oh_hell/oh_hell.cc oh_hell/oh_hell.h
+  TEST_SOURCES oh_hell/oh_hell_test.cc)
+
+add_game(NAME oshi_zumo
+  SOURCES oshi_zumo/oshi_zumo.cc oshi_zumo/oshi_zumo.h
+  TEST_SOURCES oshi_zumo/oshi_zumo_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME othello
+  SOURCES othello/othello.cc othello/othello.h
+  TEST_SOURCES othello/othello_test.cc)
+
+add_game(NAME oware
+  SOURCES oware/oware.cc oware/oware.h oware/oware_board.cc oware/oware_board.h
+  TEST_SOURCES oware/oware_test.cc)
+
+add_game(NAME pathfinding
+  SOURCES pathfinding/pathfinding.cc pathfinding/pathfinding.h
+  LIBRARIES utils
+  TEST_SOURCES pathfinding/pathfinding_test.cc)
+
+add_game(NAME pentago
+  SOURCES pentago/pentago.cc pentago/pentago.h
+  TEST_SOURCES pentago/pentago_test.cc)
+
+add_game(NAME phantom_go
+  SOURCES phantom_go/phantom_go.h phantom_go/phantom_go.cc phantom_go/phantom_go_board.h phantom_go/phantom_go_board.cc
+  TEST_SOURCES phantom_go/phantom_go_test.cc)
+
+add_game(NAME phantom_ttt
+  SOURCES phantom_ttt/phantom_ttt.cc phantom_ttt/phantom_ttt.h
+  LIBRARIES tic_tac_toe
+  TEST_SOURCES phantom_ttt/phantom_ttt_test.cc)
+
+add_game(NAME pig
+  SOURCES pig/pig.cc pig/pig.h
+  TEST_SOURCES pig/pig_test.cc)
+
+add_game(NAME quoridor
+  SOURCES quoridor/quoridor.cc quoridor/quoridor.h
+  TEST_SOURCES quoridor/quoridor_test.cc)
+
+add_game(NAME rbc
+  SOURCES rbc/rbc.cc rbc/rbc.h
+  LIBRARIES chess
+  TEST_SOURCES rbc/rbc_test.cc)
+
+add_game(NAME sheriff
+  SOURCES sheriff/sheriff.cc sheriff/sheriff.h
+  TEST_SOURCES sheriff/sheriff_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME skat
+  SOURCES skat/skat.cc skat/skat.h
+  TEST_SOURCES skat/skat_test.cc)
+
+add_game(NAME solitaire
+  SOURCES solitaire/solitaire.cc solitaire/solitaire.h
+  TEST_SOURCES solitaire/solitaire_test.cc)
+
+add_game(NAME stones_and_gems
+  SOURCES stones_and_gems/stones_and_gems.cc stones_and_gems/stones_and_gems.h
+  TEST_SOURCES stones_and_gems/stones_and_gems_test.cc)
+
+add_game(NAME tarok
+  SOURCES tarok/tarok.cc tarok/tarok.h tarok/cards.cc tarok/cards.h tarok/contracts.cc tarok/contracts.h
+  TEST_SOURCES tarok/tarok_test.cc)
+
+add_game(NAME tic_tac_toe
+  SOURCES tic_tac_toe/tic_tac_toe.cc tic_tac_toe/tic_tac_toe.h
+  TEST_SOURCES tic_tac_toe/tic_tac_toe_test.cc)
+
+add_game(NAME tiny_bridge
+  SOURCES tiny_bridge/tiny_bridge.cc tiny_bridge/tiny_bridge.h
+  TEST_SOURCES tiny_bridge/tiny_bridge_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME tiny_hanabi
+  SOURCES tiny_hanabi/tiny_hanabi.cc tiny_hanabi/tiny_hanabi.h
+  TEST_SOURCES tiny_hanabi/tiny_hanabi_test.cc
+  TEST_LIBRARIES algorithms game_transforms utils)
+
+add_game(NAME trade_comm
+  SOURCES trade_comm/trade_comm.cc trade_comm/trade_comm.h
+  TEST_SOURCES trade_comm/trade_comm_test.cc)
+
+add_game(NAME ultimate_tic_tac_toe
+  SOURCES ultimate_tic_tac_toe/ultimate_tic_tac_toe.h ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
+  LIBRARIES tic_tac_toe
+  TEST_SOURCES ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc)
+
+add_game(NAME y
+  SOURCES y/y.cc y/y.h
+  TEST_SOURCES y/y_test.cc)
 
 if (${OPEN_SPIEL_BUILD_WITH_ACPC})
   add_executable(universal_poker_test universal_poker/universal_poker_test.cc ${OPEN_SPIEL_OBJECTS}
@@ -621,6 +560,4 @@ if (${OPEN_SPIEL_BUILD_WITH_ACPC})
            --subgames_data_dir=${CMAKE_CURRENT_SOURCE_DIR}/universal_poker/endgames)
 endif()
 
-add_executable(y_test y/y_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(y_test y_test)
+target_sources(games PRIVATE ${GAME_SOURCES})


### PR DESCRIPTION
This PR modularizes the dependencies for `amazons`. If you approve of my general direction, I'll extend this to all the games, which should cut the test folder's size from 600MB to 100MB and reduce test linkage time by 33%.

While trying to build the test for one of the games, I noticed the `Makefile` had me building *every* game:

```
jhemphill@CeilingComp:~/oss/open_spiel/build$ make -j$(nproc) amazons_test
[  0%] Built target absl_spinlock_wait
...
[ 52%] Built target absl_flags_parse
Consolidate compiler generated dependencies of target bots
Consolidate compiler generated dependencies of target utils
Consolidate compiler generated dependencies of target game_transforms
Consolidate compiler generated dependencies of target bridge_double_dummy_solver
[ 52%] Built target tests
Consolidate compiler generated dependencies of target algorithms
[ 52%] Built target bots
[ 54%] Built target utils
[ 54%] Building CXX object game_transforms/CMakeFiles/game_transforms.dir/start_at.cc.o
...
[ 58%] Building CXX object games/CMakeFiles/games.dir/battleship/battleship.cc.o
[ 62%] Building CXX object games/CMakeFiles/bridge_double_dummy_solver.dir/bridge/double_dummy_solver/src/TimerList.cpp.o
[ 62%] Building CXX object algorithms/CMakeFiles/algorithms.dir/evaluate_bots.cc.o
[ 62%] Building CXX object games/CMakeFiles/games.dir/blackjack/blackjack.cc.o
...
```

In addition to building everything, it seems to have linked everything in as well, resulting in a 7.4MB test:

```
jhemphill@CeilingComp:~/oss/open_spiel/build$ ls -lh games/amazons_test 
-rwxr-xr-x 1 jhemphill jhemphill 7.4M Oct 14 17:23 games/amazons_test
```

Since every test links every game in, every test is at least 7.4MB:

```
jhemphill@CeilingComp:~/oss/open_spiel/build$ ls -lh games/
total 608M
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:36 2048_test
drwxr-xr-x 86 jhemphill jhemphill 4.0K Oct 14 17:15 CMakeFiles
-rw-r--r--  1 jhemphill jhemphill  21K Oct 14 17:15 CTestTestfile.cmake
-rw-r--r--  1 jhemphill jhemphill 312K Oct 14 17:15 Makefile
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 17:23 amazons_test
-rwxr-xr-x  1 jhemphill jhemphill 7.5M Oct 14 12:36 backgammon_test
...
-rwxr-xr-x  1 jhemphill jhemphill 7.7M Oct 14 17:27 tarok_test
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:37 tic_tac_toe_test
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:37 tiny_bridge_test
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:37 tiny_hanabi_test
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:37 trade_comm_test
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:37 ultimate_tic_tac_toe_test
-rwxr-xr-x  1 jhemphill jhemphill 7.4M Oct 14 12:37 y_test
```

The directory is 608MB, which is what we expect from 80 tests, each 7.5MB:

```
jhemphill@CeilingComp:~/oss/open_spiel/build$ ls games/*_test | wc -l
80
jhemphill@CeilingComp:~/oss/open_spiel/build$ python3 -c 'print(80 * 7.5)'
600.0
```

Removing redundant linkage reduces the size of `amazons_test` by a factor of 5:

```
jhemphill@CeilingComp:~/oss/open_spiel/build$ ls -lh games/amazons_test 
-rwxr-xr-x 1 jhemphill jhemphill 1.3M Oct 14 17:32 games/amazons_test
```

And cuts a third off of the link time of `amazons_test`:

```
# Before (with all object files prebuilt)
jhemphill@CeilingComp:~/oss/open_spiel/build$ rm games/amazons_test && time make -j$(nproc) amazons_test
real    0m1.487s
user    0m1.961s
sys     0m0.688s
```

```
# After (with all object files prebuilt)
jhemphill@CeilingComp:~/oss/open_spiel/build$ rm games/amazons_test && time make -j$(nproc) amazons_test
real    0m0.863s
user    0m1.411s
sys     0m0.449s
```

I expect this change will do the same for each test.