### PR TITLE
Improve test compilation speed and space usage by linking tests against `libopen_spiel.so`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,6 @@ jobs:
           OS_PYTHON_VERSION: "3.11"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "ON"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         # Standard (most current) platforms and versions.
@@ -24,21 +23,18 @@ jobs:
           OS_PYTHON_VERSION: "3.10"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "ON"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "ON"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: "https://github.com/google/or-tools/releases/download/v9.6/or-tools_amd64_ubuntu-22.04_cpp_v9.6.2534.tar.gz"
         - os: ubuntu-22.04
           OS_PYTHON_VERSION: "3.10"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         - os: macos-12
           OS_PYTHON_VERSION: "3.9"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         # Standard or older platforms with older Python versions.
@@ -46,7 +42,6 @@ jobs:
           OS_PYTHON_VERSION: "3.8"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         # Older Python version on Ubuntu 20.04
@@ -54,7 +49,6 @@ jobs:
           OS_PYTHON_VERSION: "3.9"
           DEFAULT_OPTIONAL_DEPENDENCY: "ON"
           TRAVIS_USE_NOX: 0
-          BUILD_SHARED_LIB: "ON"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         # One older platform with oldest Python version on that platform.
@@ -62,7 +56,6 @@ jobs:
           OS_PYTHON_VERSION: "3.8"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
 
@@ -76,7 +69,6 @@ jobs:
       TRAVIS_USE_NOX:  ${{ matrix.TRAVIS_USE_NOX }}
       DEFAULT_OPTIONAL_DEPENDENCY: ${{ matrix.DEFAULT_OPTIONAL_DEPENDENCY }}
       OPEN_SPIEL_BUILD_WITH_JULIA: ${{ matrix.OPEN_SPIEL_BUILD_WITH_JULIA }}
-      BUILD_SHARED_LIB:  ${{ matrix.BUILD_SHARED_LIB }}
       OPEN_SPIEL_BUILD_WITH_ORTOOLS:  ${{ matrix.OPEN_SPIEL_BUILD_WITH_ORTOOLS }}
       OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL:  ${{ matrix.OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL }}
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -29,7 +29,7 @@ To build OpenSpiel as a shared library, simply run:
 ```
 mkdir build
 cd build
-BUILD_SHARED_LIB=ON CXX=clang++ cmake -DPython3_EXECUTABLE=$(which python3) -DCMAKE_CXX_COMPILER=${CXX} ../open_spiel
+CXX=clang++ cmake -DPython3_EXECUTABLE=$(which python3) -DCMAKE_CXX_COMPILER=${CXX} ../open_spiel
 make -j$(nproc) open_spiel
 ```
 

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -167,6 +167,57 @@ set (BUILD_TESTING OFF)
 # For now, let's enable all the tests.
 enable_testing()
 
+# Define a C++ executable that links against the shared open_spiel library.
+# Convenience macro to replace the common pattern
+#
+#     add_executable(my_exe my_exe.cc ${OPEN_SPIEL_OBJECTS})
+#
+# with
+#     add_open_spiel_executable(my_exe my_exe.cc)
+#
+macro(add_open_spiel_executable)
+  set(ARGS ${ARGV})
+  list(GET ARGS 0 EXE_NAME)
+  add_executable(${ARGV})
+  target_link_libraries("${EXE_NAME}" open_spiel)
+endmacro()
+
+# Define a C++ executable and register it as a test.
+# Convenience macro to replace the common pattern
+#
+#     add_executable(my_exe my_exe.cc ${OPEN_SPIEL_OBJECTS})
+#     add_test(my_exe my_exe)
+#
+# with
+#     add_open_spiel_test(my_exe my_exe.cc)
+macro(add_open_spiel_test)
+  set(ARGS ${ARGV})
+  list(GET ARGS 0 EXE_NAME)
+  add_open_spiel_executable(${ARGV})
+  add_test("${EXE_NAME}" "${EXE_NAME}")
+endmacro()
+
+# We add the subdirectory here so open_spiel_core can #include absl.
+set(ABSL_PROPAGATE_CXX_STD ON)
+add_subdirectory (abseil-cpp)
+include_directories (abseil-cpp)
+
+# The abseil libraries we use within open_spiel
+add_library(absl INTERFACE)
+target_link_libraries(absl
+  INTERFACE
+    absl::algorithm
+    absl::flags
+    absl::flags_parse
+    absl::flat_hash_map
+    absl::optional
+    absl::random_random
+    absl::str_format
+    absl::strings
+    absl::time
+)
+
+# Just the minimal base library: no games.
 set (OPEN_SPIEL_CORE_FILES
   action_view.h
   action_view.cc
@@ -196,32 +247,23 @@ set (OPEN_SPIEL_CORE_FILES
   utils/usage_logging.cc
 )
 
-# We add the subdirectory here so open_spiel_core can #include absl.
-set(ABSL_PROPAGATE_CXX_STD ON)
-add_subdirectory (abseil-cpp)
-include_directories (abseil-cpp)
-
 # Just the core without any of the games
-add_library(open_spiel_core OBJECT ${OPEN_SPIEL_CORE_FILES})
-target_include_directories (
-  open_spiel_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} abseil-cpp)
-link_libraries(open_spiel_core
-  absl::algorithm
-  absl::flags
-  absl::flags_parse
-  absl::flat_hash_map
-  absl::optional
-  absl::random_random
-  absl::str_format
-  absl::strings
-  absl::time
-)
+add_library(open_spiel_core STATIC ${OPEN_SPIEL_CORE_FILES})
 
-# Just the minimal base library: no games.
-set (OPEN_SPIEL_CORE_OBJECTS $<TARGET_OBJECTS:open_spiel_core>)
+# Use an interface library and `link_libraries()` to ensure that every library
+# and executable below this line will be linked against abseil and
+# open_spiel_core
+add_library(open_spiel_interface INTERFACE)
+target_include_directories(
+  open_spiel_interface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} abseil-cpp)
+target_link_libraries(open_spiel_interface
+  INTERFACE
+    absl
+    open_spiel_core
+)
+link_libraries(open_spiel_interface)
 
 set (OPEN_SPIEL_OBJECTS
-  $<TARGET_OBJECTS:open_spiel_core>
   $<TARGET_OBJECTS:bots>
   $<TARGET_OBJECTS:games>
   $<TARGET_OBJECTS:game_transforms>
@@ -330,40 +372,21 @@ if (OPEN_SPIEL_BUILD_WITH_JULIA)
   add_subdirectory (julia)
 endif()
 
-# Build a shared library, i.e. libopen_spiel.so. We generally only enable this
-# for binary releases.
-# Note that there are known problems when trying to use absl::flags within a
-# shared library, hence is intentionally left out. To use ABSL flags, link with
-# absl::flags and absl::flags_parse separately.
-set (BUILD_SHARED_LIB OFF CACHE BOOL "Build a shared library?")
-if(NOT DEFINED ENV{BUILD_SHARED_LIB})
-  set (ENV{BUILD_SHARED_LIB} OFF)
+# Build a shared library, i.e. libopen_spiel.so. Used for tests and
+# binary releases.
+add_library(open_spiel SHARED ${OPEN_SPIEL_OBJECTS})
+if (OPEN_SPIEL_BUILD_WITH_ORTOOLS)
+  # Optionally include files that use external dependencies, for example
+  # linear program specification for finding Nash equilibria.
+  target_link_libraries(open_spiel PUBLIC $<TARGET_OBJECTS:open_spiel_ortools>)
 endif()
-set (BUILD_SHARED_LIB $ENV{BUILD_SHARED_LIB})
-if (BUILD_SHARED_LIB)
-  if (OPEN_SPIEL_BUILD_WITH_ORTOOLS)
-    add_library(open_spiel SHARED ${OPEN_SPIEL_OBJECTS}
-      # Optionally include files that use external dependencies, for example
-      # linear program specification for finding Nash equilibria.
-      $<TARGET_OBJECTS:open_spiel_ortools>
-    )
-  else()
-    add_library(open_spiel SHARED ${OPEN_SPIEL_OBJECTS})
-  endif()
-  target_include_directories(open_spiel PUBLIC
-      ${CMAKE_CURRENT_SOURCE_DIR} abseil-cpp)
-  target_link_libraries(open_spiel PUBLIC
-    absl::algorithm
-    absl::flat_hash_map
-    absl::optional
-    absl::random_random
-    absl::str_format
-    absl::strings
-    absl::time
+target_include_directories(open_spiel PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR} abseil-cpp)
+target_link_libraries(open_spiel
+  INTERFACE
     # Optionally link external dependencies, for example OrTools for solving
     # linear programs.
     ${ORTOOLS_LIBS}
-  )
-endif()
+)
 
 add_subdirectory (tests)

--- a/open_spiel/algorithms/CMakeLists.txt
+++ b/open_spiel/algorithms/CMakeLists.txt
@@ -84,109 +84,57 @@ if (${OPEN_SPIEL_BUILD_WITH_ORTOOLS})
   add_subdirectory (ortools)
 endif()
 
-add_executable(best_response_test best_response_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(best_response_test best_response_test)
+add_open_spiel_test(best_response_test best_response_test.cc)
 
-add_executable(cfr_test cfr_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(cfr_test cfr_test)
+add_open_spiel_test(cfr_test cfr_test.cc)
 
-add_executable(cfr_br_test cfr_br_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(cfr_br_test cfr_br_test)
+add_open_spiel_test(cfr_br_test cfr_br_test.cc)
 
-add_executable(corr_dist_test corr_dist_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(corr_dist_test corr_dist_test)
+add_open_spiel_test(corr_dist_test corr_dist_test.cc)
 
-add_executable(corr_dev_builder_test corr_dev_builder_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(corr_dev_builder_test corr_dev_builder_test)
+add_open_spiel_test(corr_dev_builder_test corr_dev_builder_test.cc)
 
-add_executable(deterministic_policy_test deterministic_policy_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(deterministic_policy_test deterministic_policy_test)
+add_open_spiel_test(deterministic_policy_test deterministic_policy_test.cc)
 
-add_executable(evaluate_bots_test evaluate_bots_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(evaluate_bots_test evaluate_bots_test)
+add_open_spiel_test(evaluate_bots_test evaluate_bots_test.cc)
 
-add_executable(external_sampling_mccfr_test external_sampling_mccfr_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(external_sampling_mccfr_test external_sampling_mccfr_test)
+add_open_spiel_test(external_sampling_mccfr_test external_sampling_mccfr_test.cc)
 
-add_executable(get_all_histories_test get_all_histories_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(get_all_histories_test get_all_histories_test)
+add_open_spiel_test(get_all_histories_test get_all_histories_test.cc)
 
-add_executable(get_all_states_test get_all_states_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(get_all_states_test get_all_states_test)
+add_open_spiel_test(get_all_states_test get_all_states_test.cc)
 
-add_executable(get_legal_actions_map_test get_legal_actions_map_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(get_legal_actions_map_test get_legal_actions_map_test)
+add_open_spiel_test(get_legal_actions_map_test get_legal_actions_map_test.cc)
 
-add_executable(history_tree_test history_tree_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(history_tree_test history_tree_test)
+add_open_spiel_test(history_tree_test history_tree_test.cc)
 
-add_executable(infostate_tree_test   infostate_tree_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(infostate_tree_test infostate_tree_test)
+add_open_spiel_test(infostate_tree_test   infostate_tree_test.cc)
 
-add_executable(is_mcts_test is_mcts_test.cc
-        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(is_mcts_test is_mcts_test)
+add_open_spiel_test(is_mcts_test is_mcts_test.cc)
 
-add_executable(matrix_game_utils_test matrix_game_utils_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(matrix_game_utils_test matrix_game_utils_test)
+add_open_spiel_test(matrix_game_utils_test matrix_game_utils_test.cc)
 
-add_executable(minimax_test minimax_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(minimax_test minimax_test)
+add_open_spiel_test(minimax_test minimax_test.cc)
 
-add_executable(observation_history_test observation_history_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(observation_history_test observation_history_test)
+add_open_spiel_test(observation_history_test observation_history_test.cc)
 
-add_executable(oos_test oos_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(oos_test oos_test)
+add_open_spiel_test(oos_test oos_test.cc)
 
-add_executable(outcome_sampling_mccfr_test outcome_sampling_mccfr_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(outcome_sampling_mccfr_test outcome_sampling_mccfr_test)
+add_open_spiel_test(outcome_sampling_mccfr_test outcome_sampling_mccfr_test.cc)
 
-add_executable(state_distribution_test state_distribution_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(state_distribution_test state_distribution_test)
+add_open_spiel_test(state_distribution_test state_distribution_test.cc)
 
-add_executable(tabular_best_response_mdp_test tabular_best_response_mdp_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(tabular_best_response_mdp_test tabular_best_response_mdp_test)
+add_open_spiel_test(tabular_best_response_mdp_test tabular_best_response_mdp_test.cc)
 
-add_executable(tabular_exploitability_test tabular_exploitability_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(tabular_exploitability_test tabular_exploitability_test)
+add_open_spiel_test(tabular_exploitability_test tabular_exploitability_test.cc)
 
-add_executable(tabular_sarsa_test tabular_sarsa_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(tabular_sarsa_test tabular_sarsa_test)
+add_open_spiel_test(tabular_sarsa_test tabular_sarsa_test.cc)
 
-add_executable(tabular_q_learning_test tabular_q_learning_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(tabular_q_learning_test tabular_q_learning_test)
+add_open_spiel_test(tabular_q_learning_test tabular_q_learning_test.cc)
 
-add_executable(tensor_game_utils_test tensor_game_utils_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(tensor_game_utils_test tensor_game_utils_test)
+add_open_spiel_test(tensor_game_utils_test tensor_game_utils_test.cc)
 
-add_executable(trajectories_test trajectories_test.cc
-    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
-add_test(trajectories_test trajectories_test)
+add_open_spiel_test(trajectories_test trajectories_test.cc)
 
 add_subdirectory (alpha_zero)
 add_subdirectory (alpha_zero_torch)

--- a/open_spiel/examples/CMakeLists.txt
+++ b/open_spiel/examples/CMakeLists.txt
@@ -1,42 +1,40 @@
-add_executable(benchmark_game benchmark_game.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(benchmark_game benchmark_game.cc)
 add_test(benchmark_game_test benchmark_game --game=tic_tac_toe --sims=100 --attempts=2)
 
-add_executable(cfr_example cfr_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(cfr_example cfr_example.cc)
 add_test(cfr_example_test cfr_example)
 
-add_executable(cfr_multi_equilibria_example cfr_multi_equilibria_example.cc
-               ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(cfr_multi_equilibria_example cfr_multi_equilibria_example.cc)
 
-add_executable(imperfect_recall_mccfr imperfect_recall_mccfr.cc
-               ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(imperfect_recall_mccfr imperfect_recall_mccfr.cc)
 
-add_executable(example example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(example example.cc)
 add_test(example_test example --game=tic_tac_toe --seed=0)
 
-add_executable(fsicfr_liars_dice fsicfr_liars_dice.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(fsicfr_liars_dice fsicfr_liars_dice.cc)
 
-add_executable(gtp gtp.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(gtp gtp.cc)
 
-add_executable(matrix_example matrix_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(matrix_example matrix_example.cc)
 add_test(matrix_example_test matrix_example)
 
-add_executable(mcts_example mcts_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(mcts_example mcts_example.cc)
 add_test(mcts_example_test mcts_example)
 
-add_executable(minimax_example minimax_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(minimax_example minimax_example.cc)
 add_test(minimax_example_test minimax_example)
 
-add_executable(policy_iteration_example policy_iteration_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(policy_iteration_example policy_iteration_example.cc)
 add_test(policy_iteration_example_test policy_iteration_example)
 
-add_executable(value_iteration_example value_iteration_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(value_iteration_example value_iteration_example.cc)
 add_test(value_iteration_example_test value_iteration_example)
 
-add_executable(tabular_sarsa_example tabular_sarsa_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(tabular_sarsa_example tabular_sarsa_example.cc)
 
-add_executable(tabular_q_learning_example tabular_q_learning_example.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(tabular_q_learning_example tabular_q_learning_example.cc)
 
-add_executable(count_all_states count_all_states.cc ${OPEN_SPIEL_OBJECTS})
+add_open_spiel_executable(count_all_states count_all_states.cc)
 
 if (OPEN_SPIEL_BUILD_WITH_TENSORFLOW_CC)
   add_executable(alpha_zero_example alpha_zero_example.cc ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:alpha_zero>)
@@ -62,12 +60,10 @@ if (OPEN_SPIEL_BUILD_WITH_LIBTORCH)
   target_link_libraries (dqn_torch_example ${TORCH_LIBRARIES})
 endif ()
 
-if (BUILD_SHARED_LIB)
-  if (WIN32)
-    add_executable(shared_library_example shared_library_example.cc ${OPEN_SPIEL_OBJECTS})
-  else()
-    add_executable(shared_library_example shared_library_example.cc)
-  endif()
-  target_link_libraries(shared_library_example open_spiel)
-  add_test(shared_lib_test shared_lib_test)
+if (WIN32)
+  add_executable(shared_library_example shared_library_example.cc ${OPEN_SPIEL_OBJECTS})
+else()
+  add_executable(shared_library_example shared_library_example.cc)
 endif()
+target_link_libraries(shared_library_example open_spiel)
+add_test(shared_library_example shared_library_example tic_tac_toe)

--- a/open_spiel/game_transforms/CMakeLists.txt
+++ b/open_spiel/game_transforms/CMakeLists.txt
@@ -22,62 +22,22 @@ add_library (game_transforms OBJECT
 )
 target_include_directories (game_transforms PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(restricted_nash_response_test
-        restricted_nash_response_test.cc
-        ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(restricted_nash_response_test restricted_nash_response_test)
+add_open_spiel_test(restricted_nash_response_test restricted_nash_response_test.cc)
 
-add_executable(turn_based_simultaneous_game_test
-               turn_based_simultaneous_game_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(turn_based_simultaneous_game_test turn_based_simultaneous_game_test)
+add_open_spiel_test(turn_based_simultaneous_game_test turn_based_simultaneous_game_test.cc)
 
-add_executable(misere_test
-               misere_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(misere_test misere_test)
+add_open_spiel_test(misere_test misere_test.cc)
 
-add_executable(add_noise_test
-               add_noise_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(add_noise_test add_noise_test)
+add_open_spiel_test(add_noise_test add_noise_test.cc)
 
-add_executable(coop_to_1p_test
-               coop_to_1p_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(coop_to_1p_test coop_to_1p_test)
+add_open_spiel_test(coop_to_1p_test coop_to_1p_test.cc)
 
-add_executable(efg_writer_test
-               efg_writer_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(efg_writer_test efg_writer_test)
+add_open_spiel_test(efg_writer_test efg_writer_test.cc)
 
-add_executable(normal_form_extensive_game_test
-               normal_form_extensive_game_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(normal_form_extensive_game_test normal_form_extensive_game_test)
+add_open_spiel_test(normal_form_extensive_game_test normal_form_extensive_game_test.cc)
 
-add_executable(repeated_game_test
-               repeated_game_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(repeated_game_test repeated_game_test)
+add_open_spiel_test(repeated_game_test repeated_game_test.cc)
 
-add_executable(start_at_test
-  start_at_test.cc
-  ${OPEN_SPIEL_OBJECTS}
-  $<TARGET_OBJECTS:tests>)
-add_test(start_at_test start_at_test)
+add_open_spiel_test(start_at_test start_at_test.cc)
 
-add_executable(zerosum_test
-               zerosum_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(zerosum_test zerosum_test)
+add_open_spiel_test(zerosum_test zerosum_test.cc)

--- a/open_spiel/games/CMakeLists.txt
+++ b/open_spiel/games/CMakeLists.txt
@@ -272,355 +272,171 @@ add_library(bridge_double_dummy_solver OBJECT
 target_include_directories (bridge_double_dummy_solver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(bridge_double_dummy_solver PUBLIC DDS_NO_STATIC_INIT)
 
-add_executable(2048_test twenty_forty_eight/2048_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(2048_test 2048_test)
-
-add_executable(amazons_test amazons/amazons_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(amazons_test amazons_test)
-
-add_executable(backgammon_test backgammon/backgammon_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(backgammon_test backgammon_test)
-
-add_executable(bargaining_instance_generator bargaining/bargaining_instance_generator.cc
-               ${OPEN_SPIEL_OBJECTS})
-add_executable(bargaining_test bargaining/bargaining_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(bargaining_test bargaining_test)
-
-add_executable(battleship_test battleship/battleship_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(battleship_test battleship_test)
-
-add_executable(blackjack_test blackjack/blackjack_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(blackjack_test blackjack_test)
-
-add_executable(blotto_test blotto/blotto_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(blotto_test blotto_test)
-
-add_executable(breakthrough_test breakthrough/breakthrough_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(breakthrough_test breakthrough_test)
-
-add_executable(bridge_test bridge/bridge_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(bridge_test bridge_test)
-
-add_executable(catch_test catch/catch_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(catch_test catch_test)
-
-add_executable(checkers_test checkers/checkers_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(checkers_test checkers_test)
-
-add_executable(chess_test chess/chess_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(chess_test chess_test)
-
-add_executable(cliff_walking_test cliff_walking/cliff_walking_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(cliff_walking_test cliff_walking_test)
-
-add_executable(clobber_test clobber/clobber_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(clobber_test clobber_test)
-
-add_executable(coin_game_test coin_game/coin_game_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(coin_game_test coin_game_test)
-
-add_executable(colored_trails_board_generator
-               colored_trails/colored_trails_board_generator.cc
-               ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:tests>)
-
-add_executable(colored_trails_test colored_trails/colored_trails_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(colored_trails_test colored_trails_test)
-
-add_executable(connect_four_test connect_four/connect_four_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(connect_four_test connect_four_test)
-
-add_executable(coop_box_pushing_test coop_box_pushing/coop_box_pushing_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(coop_box_pushing_test coop_box_pushing_test)
-
-add_executable(coordinated_mp_test coordinated_mp/coordinated_mp_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>
-        $<TARGET_OBJECTS:algorithms>)
-add_test(coordinated_mp_test coordinated_mp_test)
-
-add_executable(crazy_eights_test crazy_eights/crazy_eights_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(crazy_eights_test crazy_eights_test)
-
-add_executable(crowd_modelling_test mfg/crowd_modelling_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(crowd_modelling_test crowd_modelling_test)
-
-add_executable(crowd_modelling_2d_test mfg/crowd_modelling_2d_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(crowd_modelling_2d_test crowd_modelling_2d_test)
-
-add_executable(cursor_go_test cursor_go/cursor_go_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(cursor_go_test cursor_go_test)
-
-add_executable(dark_chess_test dark_chess/dark_chess_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(dark_chess_test dark_chess_test)
-
-add_executable(dark_hex_test dark_hex/dark_hex_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dark_hex_test dark_hex_test)
-
-add_executable(deep_sea_test deep_sea/deep_sea_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(deep_sea_test deep_sea_test)
-
-add_executable(dots_and_boxes_test dots_and_boxes/dots_and_boxes_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dots_and_boxes_test dots_and_boxes_test)
-
-add_executable(dynamic_routing_data_test dynamic_routing/dynamic_routing_data_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dynamic_routing_data_test dynamic_routing_data_test)
-
-add_executable(dynamic_routing_test mfg/dynamic_routing_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dynamic_routing_test dynamic_routing_test)
-
-add_executable(dynamic_routing_utils_test dynamic_routing/dynamic_routing_utils_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dynamic_routing_utils_test dynamic_routing_utils_test)
-
-add_executable(dou_dizhu_test dou_dizhu/dou_dizhu_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dou_dizhu_test dou_dizhu_test)
-
-add_executable(dou_dizhu_utils_test dou_dizhu/dou_dizhu_utils_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(dou_dizhu_utils_test dou_dizhu_utils_test)
-
-add_executable(efg_game_test efg_game/efg_game_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(efg_game_test efg_game_test)
-
-add_executable(euchre_test euchre/euchre_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(euchre_test euchre_test)
-
-add_executable(first_sealed_auction_test first_sealed_auction/first_sealed_auction_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(first_sealed_auction_test first_sealed_auction_test)
-
-add_executable(garnet_test mfg/garnet_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(garnet_test garnet_test)
-
-add_executable(gin_rummy_test gin_rummy/gin_rummy_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(gin_rummy_test gin_rummy_test)
-
-add_executable(go_test go/go_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(go_test go_test)
-
-add_executable(phantom_go_test phantom_go/phantom_go_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(phantom_go_test phantom_go_test)
-
-add_executable(goofspiel_test goofspiel/goofspiel_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(goofspiel_test goofspiel_test)
-
-add_executable(havannah_test havannah/havannah_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(havannah_test havannah_test)
-
-add_executable(hearts_test hearts/hearts_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(hearts_test hearts_test)
-
-add_executable(hex_test hex/hex_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(hex_test hex_test)
-
-add_executable(kriegspiel_test kriegspiel/kriegspiel_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(kriegspiel_test kriegspiel_test)
-
-add_executable(kuhn_poker_test kuhn_poker/kuhn_poker_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(kuhn_poker_test kuhn_poker_test)
-
-add_executable(leduc_poker_test leduc_poker/leduc_poker_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(leduc_poker_test leduc_poker_test)
-
-add_executable(lewis_signaling_test lewis_signaling/lewis_signaling_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(lewis_signaling_test lewis_signaling_test)
-
-add_executable(liars_dice_test liars_dice/liars_dice_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(liars_dice_test liars_dice_test)
-
-add_executable(maedn_test maedn/maedn_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(maedn_test maedn_test)
-
-add_executable(mancala_test mancala/mancala_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(mancala_test mancala_test)
-
-add_executable(markov_soccer_test markov_soccer/markov_soccer_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(markov_soccer_test markov_soccer_test)
-
-add_executable(matching_pennies_3p_test matching_pennies_3p/matching_pennies_3p_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(matching_pennies_3p_test matching_pennies_3p_test)
-
-add_executable(matrix_games_test matrix_games/matrix_games_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(matrix_games_test matrix_games_test)
-
-add_executable(morpion_solitaire_test morpion_solitaire/morpion_solitaire_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(morpion_solitaire_test morpion_solitaire_test)
-
-add_executable(negotiation_test negotiation/negotiation_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(negotiation_test negotiation_test)
-
-add_executable(nfg_game_test nfg_game/nfg_game_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(nfg_game_test nfg_game_test)
-
-add_executable(nim_test nim/nim_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(nim_test nim_test)
-
-add_executable(nine_mens_morris_test nine_mens_morris/nine_mens_morris_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(nine_mens_morris_test nine_mens_morris_test)
-
-add_executable(oh_hell_test oh_hell/oh_hell_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(oh_hell_test oh_hell_test)
-
-add_executable(oshi_zumo_test oshi_zumo/oshi_zumo_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(oshi_zumo_test oshi_zumo_test)
-
-add_executable(othello_test othello/othello_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(othello_test othello_test)
-
-add_executable(oware_test oware/oware_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(oware_test oware_test)
-
-add_executable(pathfinding_test pathfinding/pathfinding_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(pathfinding_test pathfinding_test)
-
-add_executable(pentago_test pentago/pentago_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(pentago_test pentago_test)
-
-add_executable(phantom_ttt_test phantom_ttt/phantom_ttt_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(phantom_ttt_test phantom_ttt_test)
-
-add_executable(pig_test pig/pig_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(pig_test pig_test)
-
-add_executable(quoridor_test quoridor/quoridor_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(quoridor_test quoridor_test)
-
-add_executable(rbc_test rbc/rbc_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(rbc_test rbc_test)
-
-add_executable(sheriff_test sheriff/sheriff_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(sheriff_test sheriff_test)
-
-add_executable(skat_test skat/skat_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(skat_test skat_test)
-
-add_executable(solitaire_test solitaire/solitaire_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(solitaire_test solitaire_test)
-
-add_executable(stones_and_gems_test stones_and_gems/stones_and_gems_test.cc
-               ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(stones_and_gems_test stones_and_gems_test)
-
-add_executable(tarok_test tarok/tarok_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(tarok_test tarok_test)
-
-add_executable(tic_tac_toe_test tic_tac_toe/tic_tac_toe_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(tic_tac_toe_test tic_tac_toe_test)
-
-add_executable(laser_tag_test laser_tag/laser_tag_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(laser_tag_test laser_tag_test)
-
-add_executable(tiny_bridge_test tiny_bridge/tiny_bridge_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(tiny_bridge_test tiny_bridge_test)
-
-add_executable(tiny_hanabi_test tiny_hanabi/tiny_hanabi_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>
-               $<TARGET_OBJECTS:algorithms>)
-add_test(tiny_hanabi_test tiny_hanabi_test)
-
-add_executable(trade_comm_test trade_comm/trade_comm_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(trade_comm_test trade_comm_test)
-
-add_executable(ultimate_tic_tac_toe_test ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc
-               ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:tests>)
-add_test(ultimate_tic_tac_toe_test ultimate_tic_tac_toe_test)
+add_open_spiel_test(2048_test twenty_forty_eight/2048_test.cc)
+
+add_open_spiel_test(amazons_test amazons/amazons_test.cc)
+
+add_open_spiel_test(backgammon_test backgammon/backgammon_test.cc)
+
+add_open_spiel_executable(bargaining_instance_generator bargaining/bargaining_instance_generator.cc)
+add_open_spiel_test(bargaining_test bargaining/bargaining_test.cc)
+
+add_open_spiel_test(battleship_test battleship/battleship_test.cc)
+
+add_open_spiel_test(blackjack_test blackjack/blackjack_test.cc)
+
+add_open_spiel_test(blotto_test blotto/blotto_test.cc)
+
+add_open_spiel_test(breakthrough_test breakthrough/breakthrough_test.cc)
+
+add_open_spiel_test(bridge_test bridge/bridge_test.cc)
+
+add_open_spiel_test(catch_test catch/catch_test.cc)
+
+add_open_spiel_test(checkers_test checkers/checkers_test.cc)
+
+add_open_spiel_test(chess_test chess/chess_test.cc)
+
+add_open_spiel_test(cliff_walking_test cliff_walking/cliff_walking_test.cc)
+
+add_open_spiel_test(clobber_test clobber/clobber_test.cc)
+
+add_open_spiel_test(coin_game_test coin_game/coin_game_test.cc)
+
+add_open_spiel_executable(colored_trails_board_generator colored_trails/colored_trails_board_generator.cc)
+
+add_open_spiel_test(colored_trails_test colored_trails/colored_trails_test.cc)
+
+add_open_spiel_test(connect_four_test connect_four/connect_four_test.cc)
+
+add_open_spiel_test(coop_box_pushing_test coop_box_pushing/coop_box_pushing_test.cc)
+
+add_open_spiel_test(coordinated_mp_test coordinated_mp/coordinated_mp_test.cc)
+
+add_open_spiel_test(crazy_eights_test crazy_eights/crazy_eights_test.cc)
+
+add_open_spiel_test(crowd_modelling_test mfg/crowd_modelling_test.cc)
+
+add_open_spiel_test(crowd_modelling_2d_test mfg/crowd_modelling_2d_test.cc)
+
+add_open_spiel_test(cursor_go_test cursor_go/cursor_go_test.cc)
+
+add_open_spiel_test(dark_chess_test dark_chess/dark_chess_test.cc)
+
+add_open_spiel_test(dark_hex_test dark_hex/dark_hex_test.cc)
+
+add_open_spiel_test(deep_sea_test deep_sea/deep_sea_test.cc)
+
+add_open_spiel_test(dots_and_boxes_test dots_and_boxes/dots_and_boxes_test.cc)
+
+add_open_spiel_test(dynamic_routing_data_test dynamic_routing/dynamic_routing_data_test.cc)
+
+add_open_spiel_test(dynamic_routing_test mfg/dynamic_routing_test.cc)
+
+add_open_spiel_test(dynamic_routing_utils_test dynamic_routing/dynamic_routing_utils_test.cc)
+
+add_open_spiel_test(dou_dizhu_test dou_dizhu/dou_dizhu_test.cc)
+
+add_open_spiel_test(dou_dizhu_utils_test dou_dizhu/dou_dizhu_utils_test.cc)
+
+add_open_spiel_test(efg_game_test efg_game/efg_game_test.cc)
+
+add_open_spiel_test(euchre_test euchre/euchre_test.cc)
+
+add_open_spiel_test(first_sealed_auction_test first_sealed_auction/first_sealed_auction_test.cc)
+
+add_open_spiel_test(garnet_test mfg/garnet_test.cc)
+
+add_open_spiel_test(gin_rummy_test gin_rummy/gin_rummy_test.cc)
+
+add_open_spiel_test(go_test go/go_test.cc)
+
+add_open_spiel_test(phantom_go_test phantom_go/phantom_go_test.cc)
+
+add_open_spiel_test(goofspiel_test goofspiel/goofspiel_test.cc)
+
+add_open_spiel_test(havannah_test havannah/havannah_test.cc)
+
+add_open_spiel_test(hearts_test hearts/hearts_test.cc)
+
+add_open_spiel_test(hex_test hex/hex_test.cc)
+
+add_open_spiel_test(kriegspiel_test kriegspiel/kriegspiel_test.cc)
+
+add_open_spiel_test(kuhn_poker_test kuhn_poker/kuhn_poker_test.cc)
+
+add_open_spiel_test(leduc_poker_test leduc_poker/leduc_poker_test.cc)
+
+add_open_spiel_test(lewis_signaling_test lewis_signaling/lewis_signaling_test.cc)
+
+add_open_spiel_test(liars_dice_test liars_dice/liars_dice_test.cc)
+
+add_open_spiel_test(maedn_test maedn/maedn_test.cc)
+
+add_open_spiel_test(mancala_test mancala/mancala_test.cc)
+
+add_open_spiel_test(markov_soccer_test markov_soccer/markov_soccer_test.cc)
+
+add_open_spiel_test(matching_pennies_3p_test matching_pennies_3p/matching_pennies_3p_test.cc)
+
+add_open_spiel_test(matrix_games_test matrix_games/matrix_games_test.cc)
+
+add_open_spiel_test(morpion_solitaire_test morpion_solitaire/morpion_solitaire_test.cc)
+
+add_open_spiel_test(negotiation_test negotiation/negotiation_test.cc)
+
+add_open_spiel_test(nfg_game_test nfg_game/nfg_game_test.cc)
+
+add_open_spiel_test(nim_test nim/nim_test.cc)
+
+add_open_spiel_test(nine_mens_morris_test nine_mens_morris/nine_mens_morris_test.cc)
+
+add_open_spiel_test(oh_hell_test oh_hell/oh_hell_test.cc)
+
+add_open_spiel_test(oshi_zumo_test oshi_zumo/oshi_zumo_test.cc)
+
+add_open_spiel_test(othello_test othello/othello_test.cc)
+
+add_open_spiel_test(oware_test oware/oware_test.cc)
+
+add_open_spiel_test(pathfinding_test pathfinding/pathfinding_test.cc)
+
+add_open_spiel_test(pentago_test pentago/pentago_test.cc)
+
+add_open_spiel_test(phantom_ttt_test phantom_ttt/phantom_ttt_test.cc)
+
+add_open_spiel_test(pig_test pig/pig_test.cc)
+
+add_open_spiel_test(quoridor_test quoridor/quoridor_test.cc)
+
+add_open_spiel_test(rbc_test rbc/rbc_test.cc)
+
+add_open_spiel_test(sheriff_test sheriff/sheriff_test.cc)
+
+add_open_spiel_test(skat_test skat/skat_test.cc)
+
+add_open_spiel_test(solitaire_test solitaire/solitaire_test.cc)
+
+add_open_spiel_test(stones_and_gems_test stones_and_gems/stones_and_gems_test.cc)
+
+add_open_spiel_test(tarok_test tarok/tarok_test.cc)
+
+add_open_spiel_test(tic_tac_toe_test tic_tac_toe/tic_tac_toe_test.cc)
+
+add_open_spiel_test(laser_tag_test laser_tag/laser_tag_test.cc)
+
+add_open_spiel_test(tiny_bridge_test tiny_bridge/tiny_bridge_test.cc)
+
+add_open_spiel_test(tiny_hanabi_test tiny_hanabi/tiny_hanabi_test.cc)
+
+add_open_spiel_test(trade_comm_test trade_comm/trade_comm_test.cc)
+
+add_open_spiel_test(ultimate_tic_tac_toe_test ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc)
 
 if (${OPEN_SPIEL_BUILD_WITH_ACPC})
-  add_executable(universal_poker_test universal_poker/universal_poker_test.cc ${OPEN_SPIEL_OBJECTS}
-          $<TARGET_OBJECTS:tests>
-          $<TARGET_OBJECTS:algorithms>)
+  add_open_spiel_executable(universal_poker_test universal_poker/universal_poker_test.cc)
   add_test(universal_poker_test universal_poker_test
            --subgames_data_dir=${CMAKE_CURRENT_SOURCE_DIR}/universal_poker/endgames)
 endif()
 
-add_executable(y_test y/y_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(y_test y_test)
+add_open_spiel_test(y_test y/y_test.cc)

--- a/open_spiel/tests/CMakeLists.txt
+++ b/open_spiel/tests/CMakeLists.txt
@@ -6,20 +6,14 @@ add_library (tests OBJECT
 )
 target_include_directories (tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(spiel_test spiel_test.cc
-               $<TARGET_OBJECTS:tests> ${OPEN_SPIEL_OBJECTS})
-add_test(spiel_test spiel_test)
+add_open_spiel_test(spiel_test spiel_test.cc)
 
-add_executable(action_view_test action_view_test.cc ${OPEN_SPIEL_OBJECTS}
-  $<TARGET_OBJECTS:tests>)
-add_test(action_view_test action_view_test)
+add_open_spiel_test(action_view_test action_view_test.cc)
 
-if (BUILD_SHARED_LIB)
-  if (WIN32)
-    add_executable(shared_lib_test shared_lib_test.cc ${OPEN_SPIEL_OBJECTS})
-  else()
-    add_executable(shared_lib_test shared_lib_test.cc)
-  endif()
-  target_link_libraries(shared_lib_test open_spiel)
-  add_test(shared_lib_test shared_lib_test)
+if (WIN32)
+  add_executable(shared_lib_test shared_lib_test.cc ${OPEN_SPIEL_OBJECTS})
+else()
+  add_executable(shared_lib_test shared_lib_test.cc)
 endif()
+target_link_libraries(shared_lib_test open_spiel)
+add_test(shared_lib_test shared_lib_test)

--- a/open_spiel/utils/CMakeLists.txt
+++ b/open_spiel/utils/CMakeLists.txt
@@ -27,41 +27,23 @@ add_library (utils OBJECT
 )
 target_include_directories (utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(circular_buffer_test circular_buffer_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(circular_buffer_test circular_buffer_test)
+add_open_spiel_test(circular_buffer_test circular_buffer_test.cc)
 
-add_executable(combinatorics_test combinatorics_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(combinatorics_test combinatorics_test)
+add_open_spiel_test(combinatorics_test combinatorics_test.cc)
 
-add_executable(data_logger_test data_logger_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(data_logger_test data_logger_test)
+add_open_spiel_test(data_logger_test data_logger_test.cc)
 
-add_executable(file_test file_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(file_test file_test)
+add_open_spiel_test(file_test file_test.cc)
 
-add_executable(functional_test functional_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(functional_test functional_test)
+add_open_spiel_test(functional_test functional_test.cc)
 
-add_executable(json_test json_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(json_test json_test)
+add_open_spiel_test(json_test json_test.cc)
 
-add_executable(logger_test logger_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(logger_test logger_test)
+add_open_spiel_test(logger_test logger_test.cc)
 
-add_executable(lru_cache_test lru_cache_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(lru_cache_test lru_cache_test)
+add_open_spiel_test(lru_cache_test lru_cache_test.cc)
 
-add_executable(random_test random_test.cc ${OPEN_SPIEL_OBJECTS}
-        $<TARGET_OBJECTS:tests>)
-add_test(random_test random_test)
+add_open_spiel_test(random_test random_test.cc)
 
 if (OPEN_SPIEL_BUILD_WITH_PYTHON)
   add_executable(run_python_test run_python_test.cc ${OPEN_SPIEL_OBJECTS}
@@ -81,20 +63,12 @@ if (OPEN_SPIEL_BUILD_WITH_LIBNOP)
   add_test(serializable_circular_buffer_test serializable_circular_buffer_test)
 endif()
 
-add_executable(stats_test stats_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(stats_test stats_test)
+add_open_spiel_test(stats_test stats_test.cc)
 
-add_executable(tensor_view_test tensor_view_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(tensor_view_test tensor_view_test)
+add_open_spiel_test(tensor_view_test tensor_view_test.cc)
 
 # Failing on Ubuntu 18.04 since upgrade of abseil version (2021-05-17).
 # Disabling while we look into it.
-# add_executable(thread_test thread_test.cc ${OPEN_SPIEL_OBJECTS}
-#                $<TARGET_OBJECTS:tests>)
-# add_test(thread_test thread_test)
+# add_open_spiel_test(thread_test thread_test.cc)
 
-add_executable(threaded_queue_test threaded_queue_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(threaded_queue_test threaded_queue_test)
+add_open_spiel_test(threaded_queue_test threaded_queue_test.cc)

--- a/travis.yml.old
+++ b/travis.yml.old
@@ -46,7 +46,6 @@ matrix:
       - TRAVIS_USE_NOX=0
       - CC=/usr/bin/clang
       - CXX=/usr/bin/clang++
-      - BUILD_SHARED_LIB="ON"
       - OPEN_SPIEL_BUILD_WITH_ORTOOLS="ON"
       - OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-20.04_v8.0.8283.tar.gz"
   # Build and test on MacOS. We use a single target, with all dependencies.


### PR DESCRIPTION
This is an alternative approach to #1124. Compared to the status quo, it cuts over 500MB off of the compiled build artifacts, cuts three minutes off the single-threaded full build time, and removes a lot of thinking about which libraries you need to link your game or test against.

Before:

```
$ make clean ; time make -j8
real    5m25.136s
user    34m56.492s
sys     2m8.369s

$ du -sh games
629M    games
```

After:

```
$ ninja clean ; time ninja -j8
[757/757] Linking CXX shared module python/pyspiel.so

real    4m35.704s
user    31m10.678s
sys     1m51.133s

$ du -sh
111M    .

$ du -sh games
34M     games
```

Previously, we conditionally generated `libopen_spiel.so`. Now, we always generate it. And when creating a new executable, you'll want to use `add_open_spiel_executable()` instead of `add_executable(...${OPEN_SPIEL_OBJECTS})`.