### PR TITLE
Upgrade version of cibuildwheel to 2.16.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,7 +80,7 @@ jobs:
           ${CI_PYBIN} -m pip install --no-cache-dir --upgrade $OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS
           ${CI_PYBIN} -m pip install --no-cache-dir --upgrade $OPEN_SPIEL_PYTHON_MISC_DEPS
           ${CI_PYBIN} -m pip install twine
-          ${CI_PYBIN} -m pip install cibuildwheel==2.11.1
+          ${CI_PYBIN} -m pip install cibuildwheel==2.16.2
       - name: Build sdist
         run: |
           pipx run build --sdist


### PR DESCRIPTION
Might need this for Python 3.12 wheels