### PR TITLE
Enable arm64 binary wheels, take 2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,6 +49,7 @@ jobs:
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
       CIBW_SKIP: pp*
+      CIBW_ARCHS_MACOS: x86_64 arm64
       CIBW_BEFORE_BUILD: python -m pip install --upgrade cmake
       CIBW_BEFORE_TEST: python -m pip install --upgrade pip
       CIBW_TEST_COMMAND: /bin/bash {project}/open_spiel/scripts/test_wheel.sh basic {project}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
           OS_TYPE: "Darwin"
           CI_PYBIN: python3.9
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
-          CIBW_BUILD: cp38-macosx_universal2 cp39-macosx_universal2 cp310-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2 cp312-macosx_universal2
+          CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_universal2 cp310-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2 cp312-macosx_universal2
     env:
       OPEN_SPIEL_BUILDING_WHEEL: ON
       OPEN_SPIEL_BUILD_WITH_ACPC: ON
@@ -47,12 +47,13 @@ jobs:
       OS_PYTHON_VERSION: "3.9"
       CI_PYBIN: ${{ matrix.CI_PYBIN }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-      CIBW_ARCHS_MACOS: universal2
+      CIBW_ARCHS_MACOS: x86_64 arm64 universal2
       CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
       CIBW_SKIP: pp*
       CIBW_BEFORE_BUILD: python -m pip install --upgrade cmake
       CIBW_BEFORE_TEST: python -m pip install --upgrade pip
       CIBW_TEST_COMMAND: /bin/bash {project}/open_spiel/scripts/test_wheel.sh basic {project}
+      CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
       CIBW_ENVIRONMENT: ${{ matrix.CIBW_ENVIRONMENT }}
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,6 +93,7 @@ jobs:
           ${CI_PYBIN} -m pip install cibuildwheel==2.16.2
       - name: Build sdist
         run: |
+          [[ "{OS_TYPE}" = "Darwin" ]] && brew install pipx
           pipx run build --sdist
           twine check dist/*.tar.gz
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,32 +31,37 @@ jobs:
         - os: ubuntu-20.04
           OS_TYPE: "Linux"
           CI_PYBIN: python3
-          ARCHS: x86_64
           CIBW_ENVIRONMENT: "CXX=$(which g++) OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
           CIBW_BUILD: cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
         - os: macOS-12
           OS_TYPE: "Darwin"
           CI_PYBIN: python3.9
-          ARCHS: "x86_64,arm64"
+          OS_PYTHON_VERSION: 3.9
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
-          CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_x86_64 cp39-macosx_arm64 cp310-macosx_x86_64 cp310-macosx_arm64 cp311-macosx_x86_64 cp311-macosx_arm64 cp312-macosx_x86_64 cp312-macosx_arm64
+          CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64 cp312-macosx_x86_64
+        # Setting to the new M1 runners to build the _arm64 wheels
+        # https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+        # TODO(lanctot): Set this to macos-13 once these runnings are no longer in beta        
+        - os: macos-13-arm64
+          OS_TYPE: "Darwin"
+          CI_PYBIN: python3.11
+          OS_PYTHON_VERSION: 3.11
+          CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
+          CIBW_BUILD: cp39-macosx_arm64 cp310-macosx_arm64 cp311-macosx_arm64 cp312-macosx_arm64
     env:
       OPEN_SPIEL_BUILDING_WHEEL: ON
       OPEN_SPIEL_BUILD_WITH_ACPC: ON
       OPEN_SPIEL_BUILD_WITH_HANABI: ON
       OPEN_SPIEL_BUILD_WITH_ROSHAMBO: ON
       OS_TYPE: ${{ matrix.OS_TYPE }}
-      OS_PYTHON_VERSION: "3.9"
+      OS_PYTHON_VERSION: ${{ matrix.OS_PYTHON_VERSION }}
       CI_PYBIN: ${{ matrix.CI_PYBIN }}
-      ARCHS: ${{ matrix.ARCHS }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
       CIBW_SKIP: pp*
-      CIBW_ARCHS_MACOS: x86_64 arm64
       CIBW_BEFORE_BUILD: python -m pip install --upgrade cmake
       CIBW_BEFORE_TEST: python -m pip install --upgrade pip
       CIBW_TEST_COMMAND: /bin/bash {project}/open_spiel/scripts/test_wheel.sh basic {project}
-      CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
       CIBW_ENVIRONMENT: ${{ matrix.CIBW_ENVIRONMENT }}
 
     steps:
@@ -96,7 +101,7 @@ jobs:
       - name: Build bdist_wheel and run tests
         run: |
           [[ "${OS_TYPE}" = "Darwin" ]] && xcodebuild -version
-          ${CI_PYBIN} -m cibuildwheel --archs ${ARCHS} --output-dir wheelhouse
+          ${CI_PYBIN} -m cibuildwheel --output-dir wheelhouse
           ls -l wheelhouse
 
       # Install the built wheel and run the full tests on this host. The full

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
           OS_TYPE: "Darwin"
           CI_PYBIN: python3.9
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
-          CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_universal2 cp310-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2 cp312-macosx_universal2
+          CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_x86_64 cp39-macosx_arm64 cp310-macosx_x86_64 cp310-macosx_arm64 cp311-macosx_x86_64 cp311-macosx_arm64 cp312-macosx_x86_64 cp312-macosx_arm64
     env:
       OPEN_SPIEL_BUILDING_WHEEL: ON
       OPEN_SPIEL_BUILD_WITH_ACPC: ON
@@ -47,7 +47,6 @@ jobs:
       OS_PYTHON_VERSION: "3.9"
       CI_PYBIN: ${{ matrix.CI_PYBIN }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-      CIBW_ARCHS_MACOS: x86_64 arm64 universal2
       CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
       CIBW_SKIP: pp*
       CIBW_BEFORE_BUILD: python -m pip install --upgrade cmake

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,9 +28,10 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           OS_TYPE: "Linux"
           CI_PYBIN: python3
+          OS_PYTHON_VERSION: 3.10
           CIBW_ENVIRONMENT: "CXX=$(which g++) OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
           CIBW_BUILD: cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
         - os: macOS-12

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,9 +71,9 @@ jobs:
         run: |
           pwd
           uname -a
-          [[ "${OS_TYPE}" = "Darwin" ]] && brew install pipx
           [[ "${OS_TYPE}" = "Darwin" ]] && brew install python@${OS_PYTHON_VERSION}
           [[ "${OS_TYPE}" = "Darwin" ]] && brew link --force python@${OS_PYTHON_VERSION}
+          [[ "${OS_TYPE}" = "Darwin" ]] && ${CI_BIN} -m pip install pipx
           which g++
           g++ --version
           chmod +x install.sh
@@ -94,7 +94,7 @@ jobs:
           ${CI_PYBIN} -m pip install cibuildwheel==2.16.2
       - name: Build sdist
         run: |
-          pipx run build --sdist --python python${OS_PYTHON_VERSION}
+          pipx run build --sdist
           twine check dist/*.tar.gz
 
       # Build all the wheels and run the basic tests (within the docker images)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
         # Setting to the new M1 runners to build the _arm64 wheels
         # https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
         # TODO(lanctot): Set this to macos-13 once these runnings are no longer in beta        
-        - os: macos-13-arm64
+        - os: macos-13-xlarge
           OS_TYPE: "Darwin"
           CI_PYBIN: python3.11
           OS_PYTHON_VERSION: 3.11

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,11 +31,13 @@ jobs:
         - os: ubuntu-20.04
           OS_TYPE: "Linux"
           CI_PYBIN: python3
+          ARCHS: x86_64
           CIBW_ENVIRONMENT: "CXX=$(which g++) OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
           CIBW_BUILD: cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
         - os: macOS-12
           OS_TYPE: "Darwin"
           CI_PYBIN: python3.9
+          ARCHS: "x86_64,arm64"
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
           CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_x86_64 cp39-macosx_arm64 cp310-macosx_x86_64 cp310-macosx_arm64 cp311-macosx_x86_64 cp311-macosx_arm64 cp312-macosx_x86_64 cp312-macosx_arm64
     env:
@@ -46,6 +48,7 @@ jobs:
       OS_TYPE: ${{ matrix.OS_TYPE }}
       OS_PYTHON_VERSION: "3.9"
       CI_PYBIN: ${{ matrix.CI_PYBIN }}
+      ARCHS: ${{ matrix.ARCHS }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
       CIBW_SKIP: pp*
@@ -92,7 +95,7 @@ jobs:
       # Basic tests are run via the CIBW_TEST_COMMAND environment variable.
       - name: Build bdist_wheel and run tests
         run: |
-          ${CI_PYBIN} -m cibuildwheel --output-dir wheelhouse
+          ${CI_PYBIN} -m cibuildwheel --archs ${ARCHS} --output-dir wheelhouse
           ls -l wheelhouse
 
       # Install the built wheel and run the full tests on this host. The full

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -95,6 +95,7 @@ jobs:
       # Basic tests are run via the CIBW_TEST_COMMAND environment variable.
       - name: Build bdist_wheel and run tests
         run: |
+          xcodebuild -version
           ${CI_PYBIN} -m cibuildwheel --archs ${ARCHS} --output-dir wheelhouse
           ls -l wheelhouse
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -95,7 +95,7 @@ jobs:
       # Basic tests are run via the CIBW_TEST_COMMAND environment variable.
       - name: Build bdist_wheel and run tests
         run: |
-          xcodebuild -version
+          [[ "${OS_TYPE}" = "Darwin" ]] && xcodebuild -version
           ${CI_PYBIN} -m cibuildwheel --archs ${ARCHS} --output-dir wheelhouse
           ls -l wheelhouse
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,8 +44,8 @@ jobs:
         # TODO(lanctot): Set this to macos-13 once these runnings are no longer in beta        
         - os: macos-13-xlarge
           OS_TYPE: "Darwin"
-          CI_PYBIN: python3.12
-          OS_PYTHON_VERSION: 3.12
+          CI_PYBIN: python3.11
+          OS_PYTHON_VERSION: 3.11
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
           CIBW_BUILD: cp39-macosx_arm64 cp310-macosx_arm64 cp311-macosx_arm64 cp312-macosx_arm64
     env:
@@ -71,6 +71,7 @@ jobs:
         run: |
           pwd
           uname -a
+          [[ "${OS_TYPE}" = "Darwin" ]] && brew install pipx
           [[ "${OS_TYPE}" = "Darwin" ]] && brew install python@${OS_PYTHON_VERSION}
           [[ "${OS_TYPE}" = "Darwin" ]] && brew link --force python@${OS_PYTHON_VERSION}
           which g++
@@ -93,8 +94,7 @@ jobs:
           ${CI_PYBIN} -m pip install cibuildwheel==2.16.2
       - name: Build sdist
         run: |
-          [[ "${OS_TYPE}" = "Darwin" ]] && brew install pipx
-          pipx run build --sdist
+          pipx run build --sdist --python python${OS_PYTHON_VERSION}
           twine check dist/*.tar.gz
 
       # Build all the wheels and run the basic tests (within the docker images)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,7 +73,6 @@ jobs:
           uname -a
           [[ "${OS_TYPE}" = "Darwin" ]] && brew install python@${OS_PYTHON_VERSION}
           [[ "${OS_TYPE}" = "Darwin" ]] && brew link --force python@${OS_PYTHON_VERSION}
-          [[ "${OS_TYPE}" = "Darwin" ]] && brew install pipx
           which g++
           g++ --version
           chmod +x install.sh
@@ -94,6 +93,7 @@ jobs:
           ${CI_PYBIN} -m pip install cibuildwheel==2.16.2
       - name: Build sdist
         run: |
+          [[ "${OS_TYPE}" = "Darwin" ]] && brew install pipx
           pipx run build --sdist
           twine check dist/*.tar.gz
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,8 +44,8 @@ jobs:
         # TODO(lanctot): Set this to macos-13 once these runnings are no longer in beta        
         - os: macos-13-xlarge
           OS_TYPE: "Darwin"
-          CI_PYBIN: python3.11
-          OS_PYTHON_VERSION: 3.11
+          CI_PYBIN: python3.12
+          OS_PYTHON_VERSION: 3.12
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
           CIBW_BUILD: cp39-macosx_arm64 cp310-macosx_arm64 cp311-macosx_arm64 cp312-macosx_arm64
     env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,6 +73,7 @@ jobs:
           uname -a
           [[ "${OS_TYPE}" = "Darwin" ]] && brew install python@${OS_PYTHON_VERSION}
           [[ "${OS_TYPE}" = "Darwin" ]] && brew link --force python@${OS_PYTHON_VERSION}
+          [[ "${OS_TYPE}" = "Darwin" ]] && brew install pipx
           which g++
           g++ --version
           chmod +x install.sh
@@ -93,7 +94,6 @@ jobs:
           ${CI_PYBIN} -m pip install cibuildwheel==2.16.2
       - name: Build sdist
         run: |
-          [[ "{OS_TYPE}" = "Darwin" ]] && brew install pipx
           pipx run build --sdist
           twine check dist/*.tar.gz
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,7 +73,6 @@ jobs:
           uname -a
           [[ "${OS_TYPE}" = "Darwin" ]] && brew install python@${OS_PYTHON_VERSION}
           [[ "${OS_TYPE}" = "Darwin" ]] && brew link --force python@${OS_PYTHON_VERSION}
-          [[ "${OS_TYPE}" = "Darwin" ]] && ${CI_BIN} -m pip install pipx
           which g++
           g++ --version
           chmod +x install.sh
@@ -83,6 +82,7 @@ jobs:
           # These are necessary to install what is necessary for the build and for the full tests below.
           ${CI_PYBIN} -m pip install --upgrade pip
           ${CI_PYBIN} -m pip --version
+          [[ "${OS_TYPE}" = "Darwin" ]] && ${CI_PYBIN} -m pip install pipx
           ${CI_PYBIN} -m pip install --upgrade setuptools
           ${CI_PYBIN} -m pip install --upgrade -r requirements.txt -q
           source ./open_spiel/scripts/python_extra_deps.sh ${CI_PYBIN}

--- a/open_spiel/python/algorithms/cfr_br_test.py
+++ b/open_spiel/python/algorithms/cfr_br_test.py
@@ -94,7 +94,7 @@ class CFRBRTest(parameterized.TestCase, absltest.TestCase):
       else:
         exploitability_ = exploitability.nash_conv(game, avg_policy)
 
-      self.assertEqual(expected_exploitability[step], exploitability_)
+      self.assertAlmostEqual(expected_exploitability[step], exploitability_, places=10)
 
 
 if __name__ == "__main__":

--- a/open_spiel/python/algorithms/cfr_test.py
+++ b/open_spiel/python/algorithms/cfr_test.py
@@ -269,7 +269,7 @@ class CFRTest(parameterized.TestCase, absltest.TestCase):
     python_current_policy = python_solver.current_policy()
     cpp_expl = pyspiel.nash_conv(game, cpp_current_policy)
     python_expl = exploitability.nash_conv(game, python_current_policy)
-    self.assertEqual(cpp_expl, python_expl)
+    self.assertAlmostEqual(cpp_expl, python_expl, places=10)
 
 
 class CorrDistTest(absltest.TestCase):

--- a/open_spiel/python/algorithms/cfr_test.py
+++ b/open_spiel/python/algorithms/cfr_test.py
@@ -262,7 +262,7 @@ class CFRTest(parameterized.TestCase, absltest.TestCase):
       # convert one to the other, so we use the exploitability as a proxy.
       cpp_expl = pyspiel.nash_conv(game, cpp_avg_policy)
       python_expl = exploitability.nash_conv(game, python_avg_policy)
-      self.assertEqual(cpp_expl, python_expl)
+      self.assertAlmostEqual(cpp_expl, python_expl, places=10)
     # Then we also check the CurrentPolicy, just to check it is giving the same
     # results too
     cpp_current_policy = cpp_solver.current_policy()

--- a/open_spiel/python/pytorch/dqn.py
+++ b/open_spiel/python/pytorch/dqn.py
@@ -318,8 +318,8 @@ class DQN(rl_agent.AbstractAgent):
     rewards = torch.Tensor([t.reward for t in transitions])
     next_info_states = torch.Tensor([t.next_info_state for t in transitions])
     are_final_steps = torch.Tensor([t.is_final_step for t in transitions])
-    legal_actions_mask = torch.Tensor(
-        np.array([t.legal_actions_mask for t in transitions]))
+    legal_actions_mask = torch.BoolTensor(
+        np.array([t.legal_actions_mask for t in transitions], dtype=bool))
 
     self._q_values = self._q_network(info_states)
     self._target_q_values = self._target_q_network(next_info_states).detach()

--- a/open_spiel/python/pytorch/dqn.py
+++ b/open_spiel/python/pytorch/dqn.py
@@ -318,15 +318,15 @@ class DQN(rl_agent.AbstractAgent):
     rewards = torch.Tensor([t.reward for t in transitions])
     next_info_states = torch.Tensor([t.next_info_state for t in transitions])
     are_final_steps = torch.Tensor([t.is_final_step for t in transitions])
-    legal_actions_mask = torch.BoolTensor(
-        np.array([t.legal_actions_mask for t in transitions], dtype=bool))
+    legal_actions_mask = torch.Tensor(
+        np.array([t.legal_actions_mask for t in transitions]))
 
     self._q_values = self._q_network(info_states)
     self._target_q_values = self._target_q_network(next_info_states).detach()
 
     illegal_actions_mask = 1 - legal_actions_mask
     legal_target_q_values = self._target_q_values.masked_fill(
-        illegal_actions_mask, ILLEGAL_ACTION_LOGITS_PENALTY)
+        illegal_actions_mask.bool(), ILLEGAL_ACTION_LOGITS_PENALTY)
     max_next_q = torch.max(legal_target_q_values, dim=1)[0]
 
     target = (

--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -46,23 +46,19 @@ verlt() {
 }
 
 #
-# Python extra deps that work across all supported versions
-#
-export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.13.1"
-
-
-#
 # Python-version dependent versions
 #
 
 echo "Set Python version: $PY_VER"
 if verlt $PY_VER 3.10; then
   echo "Python < 3.10 detected"
+  export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.13.1"
   export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.4.6 jaxlib==0.4.6 dm-haiku==0.0.10 optax==0.1.7 chex==0.1.7 rlax==0.1.5 distrax==0.1.3"
   export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.23.5 tensorflow==2.13.1 tensorflow-probability==0.19.0 tensorflow_datasets==4.9.2 keras==2.13.1"
   export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 networkx==2.4 matplotlib==3.5.2 mock==4.0.2 nashpy==0.0.19 scipy==1.10.1 testresources==2.0.1 cvxopt==1.3.1 cvxpy==1.2.0 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6 flax==0.5.3"
 else
   echo "Python >= 3.10 detected"
+  export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==2.1.0"
   export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.4.20 jaxlib==0.4.20 dm-haiku==0.0.10 optax==0.1.7 chex==0.1.84 rlax==0.1.6 distrax==0.1.4"
   export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.26.1 tensorflow==2.14.0 tensorflow-probability==0.22.1 tensorflow_datasets==4.9.2 keras==2.14.0"
   export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 networkx==3.2 matplotlib==3.5.2 mock==4.0.2 nashpy==0.0.19 scipy==1.11.3 testresources==2.0.1 cvxopt==1.3.1 cvxpy==1.4.1 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6 flax==0.5.3"

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -63,7 +63,7 @@ fi
 
 if [[ "$MODE" = "full" ]]; then
   if [[ "$OS" = "Linux" ]]; then
-    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   elif [[ "$OS" = "Darwn" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
   else

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -67,7 +67,7 @@ if [[ "$MODE" = "full" ]]; then
   elif [[ "$OS" = "Darwn" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
   else
-    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp312-cp312-macosx_13_6_arm64.whl
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp311-cp311-macosx_13_6_arm64.whl
   fi
 fi
 

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -65,7 +65,7 @@ if [[ "$MODE" = "full" ]]; then
   if [[ "$OS" = "Linux" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   else
-    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_universal2.whl
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
   fi
 fi
 

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -64,7 +64,7 @@ fi
 if [[ "$MODE" = "full" ]]; then
   if [[ "$OS" = "Linux" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  elif [[ "$OS" = "Darwn" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
+  elif [[ "$OS" = "Darwin" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
   else
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp311-cp311-macosx_11_0_arm64.whl

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -67,7 +67,7 @@ if [[ "$MODE" = "full" ]]; then
   elif [[ "$OS" = "Darwn" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
   else
-    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp311-cp311-macosx_13_6_arm64.whl
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp311-cp311-macosx_11_0_arm64.whl
   fi
 fi
 
@@ -79,7 +79,7 @@ rm -rf build && mkdir build && cd build
 cmake -DPython3_EXECUTABLE=${PYBIN} $PROJDIR/open_spiel
 
 NPROC="nproc"
-if [[ "$OS" == "darwin"* ]]; then
+if [[ "$OS" == "darwin"* || "$OS" == "Darwin"* ]]; then
   NPROC="sysctl -n hw.physicalcpu"
 fi
 

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -67,7 +67,7 @@ if [[ "$MODE" = "full" ]]; then
   elif [[ "$OS" = "Darwn" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
   else
-    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp311-cp311-macosx_13_6_arm64.whl
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp312-cp312-macosx_13_6_arm64.whl
   fi
 fi
 

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -64,8 +64,10 @@ fi
 if [[ "$MODE" = "full" ]]; then
   if [[ "$OS" = "Linux" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  else
+  elif [[ "$OS" = "Darwn" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
+  else
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp311-cp311-macosx_13_6_arm64.whl
   fi
 fi
 


### PR DESCRIPTION
First approach (cross-compiling) didn't work.  So I posted on cibuildwheel: https://github.com/pypa/cibuildwheel/issues/1662.

- Added a new runner (macos-13-xlarge) that is now in beta for the Apple Silicon builds.
- Patched wheels.yml and test_wheel.sh
- Increase pytorch version to 2.1.0
- Fixed a few tests (cfr_test.py, cfr_br_test.py, pytorch dqn.py)