### PR TITLE
Change --game to --game_string

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ Similar examples using the Python API (run from one above `build`):
 
 ```bash
 # Similar to the C++ example:
-python3 open_spiel/python/examples/example.py --game=breakthrough
+python3 open_spiel/python/examples/example.py --game_string=breakthrough
 
 # Play a game against a random or MCTS bot:
 python3 open_spiel/python/examples/mcts.py --game=tic_tac_toe --player1=human --player2=random

--- a/docs/install.md
+++ b/docs/install.md
@@ -221,7 +221,7 @@ Once the proper Python paths are set, from the main directory (one above
 
 ```bash
 # Similar to the C++ example:
-python3 open_spiel/python/examples/example.py --game=breakthrough
+python3 open_spiel/python/examples/example.py --game_string=breakthrough
 
 # Play a game against a random or MCTS bot:
 python3 open_spiel/python/examples/mcts.py --game=tic_tac_toe --player1=human --player2=random


### PR DESCRIPTION
It seems the `--game` flag is deprecated in favor of `--game_string`. This updates the Installation documentation.

![Screenshot 2024-03-13 at 1 50 02 AM](https://github.com/google-deepmind/open_spiel/assets/982382/7b7e4cff-dd9b-4e7d-90dc-5f39cf79e8ea)

Related: https://github.com/google-deepmind/open_spiel/pull/1161.