### PR TITLE
OpenSpiel 1.5 Preparation: Remove support for Python 3.8

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,28 +41,12 @@ jobs:
           BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
-        # Standard or older platforms with older Python versions.
-        - os: macos-11
-          OS_PYTHON_VERSION: "3.8"
-          TRAVIS_USE_NOX: 0
-          DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
-          OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
-          OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         # Older Python version on Ubuntu 20.04
         - os: ubuntu-20.04
           OS_PYTHON_VERSION: "3.9"
           DEFAULT_OPTIONAL_DEPENDENCY: "ON"
           TRAVIS_USE_NOX: 0
           BUILD_SHARED_LIB: "ON"
-          OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
-          OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
-        # One older platform with oldest Python version on that platform.
-        - os: ubuntu-20.04
-          OS_PYTHON_VERSION: "3.8"
-          TRAVIS_USE_NOX: 0
-          DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,13 +33,13 @@ jobs:
           CI_PYBIN: python3
           OS_PYTHON_VERSION: 3.10
           CIBW_ENVIRONMENT: "CXX=$(which g++) OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
-          CIBW_BUILD: cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
+          CIBW_BUILD: cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
         - os: macOS-12
           OS_TYPE: "Darwin"
           CI_PYBIN: python3.9
           OS_PYTHON_VERSION: 3.9
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
-          CIBW_BUILD: cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64 cp312-macosx_x86_64
+          CIBW_BUILD: cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64 cp312-macosx_x86_64
         # Setting to the new M1 runners to build the _arm64 wheels
         # https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
         # Disabling now that the OpenSpiel 1.4 wheels are on PyPI because these xlarge machines are

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ else:
 
 setuptools.setup(
     name="open_spiel",
-    version="1.4",
+    version="1.5",
     license="Apache 2.0",
     author="The OpenSpiel authors",
     author_email="open_spiel@google.com",
@@ -138,7 +138,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/deepmind/open_spiel",
     install_requires=_get_requirements(req_file),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     ext_modules=[CMakeExtension("pyspiel", sourcedir="open_spiel")],
     cmdclass={"build_ext": BuildExt},
     zip_safe=False,


### PR DESCRIPTION
Remove support for Python 3.8.

EOL is October, so this is slightly premature... but it has been causing problems with CI and wheels tests for a while now. Also it does not support the new style for annotations which has caused issues several times with interoperability with internal code. At this point it has become a bit difficult to maintain, so users who need Python 3.8 support should install OpenSpiel 1.4.

Also: update OpenSpiel version to 1.5 in setup.py in preparation of release.