### PR TITLE
Updates to CI workflow scripts

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: 1.8
     - name: Ad-hoc fix

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,7 +34,7 @@ jobs:
           BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
-        - os: macos-14
+        - os: macos-13
           OS_PYTHON_VERSION: "3.11"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,6 +34,15 @@ jobs:
           BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
+        - os: macos-14
+          OS_PYTHON_VERSION: "3.11"
+          TRAVIS_USE_NOX: 0
+          DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
+          BUILD_SHARED_LIB: "OFF"
+          OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
+          OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
+        # Standard or older platforms with older Python versions.
+        # Older Python version on Ubuntu 20.04
         - os: macos-12
           OS_PYTHON_VERSION: "3.9"
           TRAVIS_USE_NOX: 0
@@ -41,15 +50,6 @@ jobs:
           BUILD_SHARED_LIB: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
-        # Standard or older platforms with older Python versions.
-        - os: macos-11
-          OS_PYTHON_VERSION: "3.8"
-          TRAVIS_USE_NOX: 0
-          DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-          BUILD_SHARED_LIB: "OFF"
-          OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
-          OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
-        # Older Python version on Ubuntu 20.04
         - os: ubuntu-20.04
           OS_PYTHON_VERSION: "3.9"
           DEFAULT_OPTIONAL_DEPENDENCY: "ON"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -81,7 +81,7 @@ jobs:
       OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL:  ${{ matrix.OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: julia-actions/setup-julia@v1
       with:
         version: 1.8

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,6 +116,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.runs-on }}
           path: |
             dist/*.tar.gz
             ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,7 +68,7 @@ jobs:
       CIBW_ENVIRONMENT: ${{ matrix.CIBW_ENVIRONMENT }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install
         run: |
@@ -114,7 +114,7 @@ jobs:
       - name: Install bdist_wheel and full tests
         run: ./open_spiel/scripts/test_wheel.sh full `pwd` ${CI_PYBIN}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             dist/*.tar.gz

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,7 +116,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ matrix.runs-on }}
+          name: artifact-${{ matrix.os }}
           path: |
             dist/*.tar.gz
             ./wheelhouse/*.whl

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -306,9 +306,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
       cargo install bindgen-cli
     fi
   fi
-
-  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  ${PYBIN} get-pip.py
+  # brew install virtualenv   # May be the required way to do this as of Python 3.12?
   ${PYBIN} -m pip install virtualenv
 else
   echo "The OS '$OSTYPE' is not supported (Only Linux and MacOS is). " \

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -306,6 +306,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
       cargo install bindgen-cli
     fi
   fi
+  # Removed getting pip via git-pip.py. See #1200.
   # brew install virtualenv   # May be the required way to do this as of Python 3.12?
   ${PYBIN} -m pip install virtualenv
 else


### PR DESCRIPTION
- Github Actions migrate to node.js 20: upgrade version of checkout and upload-artifact to v4
- Remove (macos-11, Python3.8), add (macos-13, Python3.11)
