### PR TITLE
Preparation for OpenSpiel 1.5: Add warnings to algorithms with known issues.

### DIFF
--- a/open_spiel/python/algorithms/alpha_zero/model.py
+++ b/open_spiel/python/algorithms/alpha_zero/model.py
@@ -21,7 +21,13 @@ from typing import Sequence
 
 import numpy as np
 import tensorflow.compat.v1 as tf
+import warnings
 
+warnings.warn(
+    "Python AlphaZero has known issues when using Keras 3 and may be "
+    "removed in a future version unless fixed. See OpenSpiel github "
+    "issue #1206 for details."
+)
 
 def cascade(x, fns):
   for fn in fns:

--- a/open_spiel/python/algorithms/deep_cfr_tf2.py
+++ b/open_spiel/python/algorithms/deep_cfr_tf2.py
@@ -34,9 +34,16 @@ import os
 import random
 import numpy as np
 import tensorflow as tf
+import warnings
 
 from open_spiel.python import policy
 import pyspiel
+
+warnings.warn(
+    "Deep CFR TF2 has known issues when using Keras 3 and may be removed "
+    "in a future version unless fixed. See OpenSpiel github issue #1208 "
+    "for details."
+)
 
 
 # The size of the shuffle buffer used to reshuffle part of the data each

--- a/open_spiel/python/algorithms/rcfr.py
+++ b/open_spiel/python/algorithms/rcfr.py
@@ -44,6 +44,7 @@ import warnings
 # Temporarily disable TF2 behavior while the code is not updated.
 tf.disable_v2_behavior()
 
+
 warnings.warn(
     "RCFR has known issues when using Keras 3 and may be removed in a "
     "future version unless fixed. See OpenSpiel github issue #1207 for "

--- a/open_spiel/python/algorithms/rcfr.py
+++ b/open_spiel/python/algorithms/rcfr.py
@@ -39,9 +39,16 @@ Martin Zinkevich, Michael Johanson, Michael Bowling, and Carmelo Piccione.
 
 import numpy as np
 import tensorflow.compat.v1 as tf
+import warnings
 
 # Temporarily disable TF2 behavior while the code is not updated.
 tf.disable_v2_behavior()
+
+warnings.warn(
+    "RCFR has known issues when using Keras 3 and may be removed in a "
+    "future version unless fixed. See OpenSpiel github issue #1207 for "
+    "details."
+)
 
 
 def tensor_to_matrix(tensor):


### PR DESCRIPTION
Issues with Keras 3:
- Python AlphaZero (#1206)
- RCFR (#1207)
- Deep CFR TF2 (#1208)