### PR TITLE
Make action IDs relative to pawn position

### DIFF
--- a/open_spiel/games/quoridor/quoridor.cc
+++ b/open_spiel/games/quoridor/quoridor.cc
@@ -207,7 +207,7 @@ Move QuoridorState::ActionToMove(Action action_id) const {
 std::vector<Action> QuoridorState::LegalActions() const {
   std::vector<Action> moves;
   if (IsTerminal()) return moves;
-  int max_moves = 5;  // Max pawn moves, including jumps.
+  int max_moves = 6;  // Max pawn moves, including jumps.
   if (wall_count_[current_player_] > 0) {
     max_moves += 2 * (board_size_ - 1) * (board_size_ - 1);  // Max wall moves.
   }

--- a/open_spiel/games/quoridor/quoridor.h
+++ b/open_spiel/games/quoridor/quoridor.h
@@ -29,6 +29,10 @@
 //   "wall_count"        int     How many walls per side (default = size^2/8)
 //   "ansi_color_output" bool    Whether to color the output for a terminal.
 //   "players"           int     Number of players (default = 2)
+//   "relative_moves"    bool    Whether move action IDs should be relative to the
+//                                 current pawn position or absolute based on target cell.
+//                                 The default is false/absolute as that was what was originally
+//                                 coded, though relative is probably better for learning.
 
 namespace open_spiel {
 namespace quoridor {
@@ -85,13 +89,14 @@ struct Move {
 
   Move operator+(const Offset& o) const { return Move(x + o.x, y + o.y, size); }
   Move operator-(const Offset& o) const { return Move(x - o.x, y - o.y, size); }
+  Offset operator-(const Move& o) const { return Offset(x - o.x, y - o.y); }
 };
 
 // State of an in-play game.
 class QuoridorState : public State {
  public:
   QuoridorState(std::shared_ptr<const Game> game, int board_size,
-                int wall_count, bool ansi_color_output = false);
+                int wall_count, bool ansi_color_output = false, bool relative_moves = false);
 
   QuoridorState(const QuoridorState&) = default;
   void InitializePlayer(QuoridorPlayer);
@@ -155,6 +160,8 @@ class QuoridorState : public State {
   const int board_size_;
   const int board_diameter_;
   const bool ansi_color_output_;
+  const bool relative_moves_;
+  const Move base_for_relative_;
 };
 
 // Game object.
@@ -165,7 +172,7 @@ class QuoridorGame : public Game {
   int NumDistinctActions() const override { return Diameter() * Diameter(); }
   std::unique_ptr<State> NewInitialState() const override {
     return std::unique_ptr<State>(new QuoridorState(
-        shared_from_this(), board_size_, wall_count_, ansi_color_output_));
+        shared_from_this(), board_size_, wall_count_, ansi_color_output_, relative_moves_));
   }
   int NumPlayers() const override { return num_players_; }
   int NumCellStates() const { return num_players_ + 1; }
@@ -188,6 +195,7 @@ class QuoridorGame : public Game {
   const int wall_count_;
   const bool ansi_color_output_ = false;
   const int num_players_;
+  const bool relative_moves_ = false;
 };
 
 }  // namespace quoridor

--- a/open_spiel/games/quoridor/quoridor_test.cc
+++ b/open_spiel/games/quoridor/quoridor_test.cc
@@ -41,6 +41,10 @@ void BasicQuoridorTests() {
 
   testing::RandomSimTest(*LoadGame("quoridor(board_size=9,wall_count=5)"), 3);
 
+  testing::RandomSimTest(
+      *LoadGame("quoridor(board_size=9,wall_count=5)"),
+      3);
+
   // Ansi colors!
   testing::RandomSimTest(
       *LoadGame("quoridor", {{"board_size", GameParameter(9)},


### PR DESCRIPTION
The original implementation of Quoridor mapped action IDs to absolute board positions.
This meant that moving north had a different ID for every pawn position. This commit
adds the option to make the action IDs be consistent for the same move relative to
pawn position.

This commit fixes #1158.