### PR TITLE
Normalize the received GTP responses to lowercase

### DIFF
--- a/open_spiel/python/bots/gtp.py
+++ b/open_spiel/python/bots/gtp.py
@@ -96,7 +96,7 @@ class GTPBot(pyspiel.Bot):
           continue  # Ignore leading newlines, possibly left from prev response.
       response += line
     if response.startswith("="):
-      return response[1:].strip()
+      return response[1:].strip().lower()
     else:
       raise CommandError(response[1:].strip())
 


### PR DESCRIPTION
Some programs return uppercase responses (`PASS`, `G5`, etc). For maximum compatibility normalize the responses to lowercase.