### PR TITLE
Add GameParameter type to open_spiel/python/__init__.py

### DIFF
--- a/open_spiel/__init__.py
+++ b/open_spiel/__init__.py
@@ -14,4 +14,4 @@
 
 # The existence of this file allows us to have PYTHONPATH pointing to
 # the parent of this directory and then use:
-#    from open_spiel.python import rl_environment
+# from open_spiel.python import rl_environment

--- a/open_spiel/python/__init__.py
+++ b/open_spiel/python/__init__.py
@@ -12,3 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict, Union
+GameParameter = Union[int, float, str, bool, Dict[str, 'GameParameter']]


### PR DESCRIPTION
Helps provide a type for pytype hints (which was causing some issues in SpielViz)

c.f. https://github.com/google-deepmind/open_spiel/issues/1224