### PR TITLE
[BUG FIX] fixed load method for dqn in pytorch

### DIFF
--- a/open_spiel/python/pytorch/dqn.py
+++ b/open_spiel/python/pytorch/dqn.py
@@ -428,7 +428,7 @@ class DQN(rl_agent.AbstractAgent):
         relative or absolute but the filename should be included. For example:
         optimizer.pt or /path/to/optimizer.pt
     """
-    torch.load(self._q_network, data_path)
-    torch.load(self._target_q_network, data_path)
+    self._q_network = torch.load(data_path)
+    self._target_q_network = torch.load(data_path)
     if optimizer_data_path is not None:
-      torch.load(self._optimizer, optimizer_data_path)
+      self._optimizer = torch.load(optimizer_data_path)


### PR DESCRIPTION
**Problem**

the past implementation of this function did not follow the syntax indicated by `torch.load()` [docs](https://pytorch.org/docs/stable/generated/torch.load.html), but rather seemed to imitate what is required by `torch.save()` [docs](https://pytorch.org/docs/stable/generated/torch.save.html).

This resulted in the following error: 
```
  File "../train/dqn_pytorch/block_dominoes_deep_cfr.py", line 77, in main
    agents[i].load(FLAGS.checkpoint_dir + f'{i}.pt')
  File "../.venv/lib/python3.10/site-packages/open_spiel/python/pytorch/dqn.py", line 431, in load
    torch.load(self._q_network, data_path)
  File "../.venv/lib/python3.10/site-packages/torch/serialization.py", line 997, in load
    with _open_file_like(f, 'rb') as opened_file:
  File "../.venv/lib/python3.10/site-packages/torch/serialization.py", line 449, in _open_file_like
    return _open_buffer_reader(name_or_buffer)
  File "../.venv/lib/python3.10/site-packages/torch/serialization.py", line 434, in __init__
    _check_seekable(buffer)
  File "../.venv/lib/python3.10/site-packages/torch/serialization.py", line 543, in _check_seekable
    raise_err_msg(["seek", "tell"], e)
  File "../.venv/lib/python3.10/site-packages/torch/serialization.py", line 536, in raise_err_msg
    raise type(e)(msg)
AttributeError: 'MLP' object has no attribute 'seek'. You can only torch.load from a file that is seekable. Please pre-load the data into a buffer like io.BytesIO and try to load from it instead.
```

**Solution**

use correct function calls when loading `.pt` objects, e. g. 
```
self._q_network = torch.load(data_path)
```
instead of 
```
torch.load(self._q_network, data_path)
```