### PR TITLE
Convert quoridor movement action IDs to relative

### DIFF
--- a/open_spiel/games/quoridor/quoridor.h
+++ b/open_spiel/games/quoridor/quoridor.h
@@ -85,6 +85,7 @@ struct Move {
 
   Move operator+(const Offset& o) const { return Move(x + o.x, y + o.y, size); }
   Move operator-(const Offset& o) const { return Move(x - o.x, y - o.y, size); }
+  Offset operator-(const Move& o) const { return Offset(x - o.x, y - o.y); }
 };
 
 // State of an in-play game.
@@ -155,6 +156,7 @@ class QuoridorState : public State {
   const int board_size_;
   const int board_diameter_;
   const bool ansi_color_output_;
+  const Move base_for_relative_;
 };
 
 // Game object.


### PR DESCRIPTION
The original implementation of Quoridor used absolute position numbering for pawn moves, so moving to b3 was always the same action ID, regardless of where the pawn was. This commit changes to using relative action IDs, so moving directly north is always the same action ID, regardless of what square that is moving to.