### PR TITLE
[BUG FIX} fixed small positional argument bug

### DIFF
--- a/open_spiel/python/jax/dqn.py
+++ b/open_spiel/python/jax/dqn.py
@@ -280,7 +280,7 @@ class DQN(rl_agent.AbstractAgent):
         (1 - legal_actions_mask) * ILLEGAL_ACTION_LOGITS_PENALTY,
         axis=-1)
     max_next_q = jax.numpy.where(
-        1 - are_final_steps, x=max_next_q, y=jnp.zeros_like(max_next_q))
+        1 - are_final_steps, max_next_q, jnp.zeros_like(max_next_q))
     target = (
         rewards + (1 - are_final_steps) * self._discount_factor * max_next_q)
     target = jax.lax.stop_gradient(target)


### PR DESCRIPTION
problem: Jax implementation of DQN wouldn't work for buffer size >= 1000 (min buffer size for learning) because of small bug in line 282.
```bash
open_spiel/open_spiel/python/jax/dqn.py", line 282, in _loss max_next_q = jax.numpy.where( TypeError: where() got some positional-only arguments passed as keyword arguments: 'x, y' (.venv) brunozorrilla:.../GitHub/open_spiel$
```

Solution:  get rid keyword of arguments:

```python
    max_next_q = jax.numpy.where(
        1 - are_final_steps, max_next_q, jnp.zeros_like(max_next_q))
```