### PR TITLE
Update Deep CFR implementations to implement Policy

### DIFF
--- a/open_spiel/python/algorithms/deep_cfr.py
+++ b/open_spiel/python/algorithms/deep_cfr.py
@@ -360,7 +360,7 @@ class DeepCFRSolver(policy.Policy):
 
     return advantages, matched_regrets
 
-  def action_probabilities(self, state):
+  def action_probabilities(self, state, player_id=None):
     """Returns action probabilities dict for a single batch."""
     cur_player = state.current_player()
     legal_actions = state.legal_actions(cur_player)

--- a/open_spiel/python/algorithms/deep_cfr_tf2.py
+++ b/open_spiel/python/algorithms/deep_cfr_tf2.py
@@ -631,7 +631,7 @@ class DeepCFRSolver(policy.Policy):
         info_state, legal_actions_mask, player)
     return advantages.numpy(), matched_regrets.numpy()
 
-  def action_probabilities(self, state):
+  def action_probabilities(self, state, player_id=None):
     """Returns action probabilities dict for a single batch."""
     cur_player = state.current_player()
     legal_actions = state.legal_actions(cur_player)

--- a/open_spiel/python/jax/deep_cfr.py
+++ b/open_spiel/python/jax/deep_cfr.py
@@ -480,7 +480,7 @@ class DeepCFRSolver(policy.Policy):
         info_state, legal_actions_mask, self._params_adv_network[player])
     return advantages, matched_regrets
 
-  def action_probabilities(self, state):
+  def action_probabilities(self, state, player_id=None):
     """Returns action probabilities dict for a single batch."""
     cur_player = state.current_player()
     legal_actions = state.legal_actions(cur_player)

--- a/open_spiel/python/pytorch/deep_cfr.py
+++ b/open_spiel/python/pytorch/deep_cfr.py
@@ -416,7 +416,7 @@ class DeepCFRSolver(policy.Policy):
       matched_regrets[max(legal_actions, key=lambda a: raw_advantages[a])] = 1
     return advantages, matched_regrets
 
-  def action_probabilities(self, state):
+  def action_probabilities(self, state, player_id=None):
     """Computes action probabilities for the current player in state.
 
     Args:


### PR DESCRIPTION
The `player_id` argument is not need, but still needs to be present in order to implement `Policy`. For example without it PolicyBot breaks as it passes three arguments (self, the game state and the player id).