### PR TITLE
Fix DQN bug (wrong target Q-value for illegal actions)

### DIFF
--- a/open_spiel/python/pytorch/dqn.py
+++ b/open_spiel/python/pytorch/dqn.py
@@ -30,7 +30,7 @@ Transition = collections.namedtuple(
     "Transition",
     "info_state action reward next_info_state is_final_step legal_actions_mask")
 
-ILLEGAL_ACTION_LOGITS_PENALTY = sys.float_info.min
+ILLEGAL_ACTION_LOGITS_PENALTY = torch.finfo(torch.float).min
 
 
 class SonnetLinear(nn.Module):


### PR DESCRIPTION
Came across a bug in the Pytorch DQN implementation in `open_spiel/python/pytorch/dqn.py`. 

TLDR: I replaced `sys.float_info.min` with `torch.finfo(torch.float).min` which is the minimum value of a float32.

This code computes the max Q-target, setting illegal actions' Q-values to a large negative value so that they cannot be considered in the max:

```python
illegal_actions_mask = 1 - legal_actions_mask
legal_target_q_values = self._target_q_values.masked_fill(
    illegal_actions_mask.bool(), ILLEGAL_ACTION_LOGITS_PENALTY
)
max_next_q = torch.max(legal_target_q_values, dim=1)[0]
```

However `ILLEGAL_ACTION_LOGITS_PENALTY` is set to `sys.float_info.min` which (surprisingly) is a positive number very close to 0 (see https://docs.python.org/3/library/sys.html#sys.float_info.min). 

```bash
Python 3.8.19
>>> import sys
>>> sys.float_info.min
2.2250738585072014e-308
>>> import torch
>>> torch.finfo(torch.float).min
-3.4028234663852886e+38
>>> torch.finfo(torch.float32).min
-3.4028234663852886e+38
```

The Tensorflow DQN implementation in `open_spiel/python/algorithms/dqn.py` is correct though: `ILLEGAL_ACTION_LOGITS_PENALTY = -1e9`

I ran a DQN best response against a Phantom Tic-Tac-Toe PPO policy and got a pretty significant difference of 0.1 in exploitability (consistant across several seeds):

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/5e35de7d-8122-451f-979d-6483b2d85795">

blue: tensorflow DQN, orange: torch DQN before fix, green: torch DQN after fix

