### PR TITLE
Fix RCFR test and example to work with Keras 3

### DIFF
--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -311,8 +311,7 @@ if (OPEN_SPIEL_ENABLE_TENSORFLOW)
       algorithms/nfsp_test.py
       algorithms/policy_gradient_test.py
       algorithms/psro_v2/strategy_selectors_test.py
-      # Broken in Python 3.12. Must port to Keras 3. https://github.com/google-deepmind/open_spiel/issues/1207.
-      # algorithms/rcfr_test.py
+      algorithms/rcfr_test.py
   )
   if (OPEN_SPIEL_ENABLE_PYTHON_MISC)
     set(PYTHON_TESTS ${PYTHON_TESTS}

--- a/open_spiel/python/algorithms/rcfr_test.py
+++ b/open_spiel/python/algorithms/rcfr_test.py
@@ -37,7 +37,7 @@ def _new_model():
   return rcfr.DeepRcfrModel(
       _GAME,
       num_hidden_layers=1,
-      num_hidden_units=13,
+      num_hidden_units=26,
       num_hidden_factors=1,
       use_skip_connections=True)
 
@@ -476,12 +476,16 @@ class RcfrTest(parameterized.TestCase, tf.test.TestCase):
       data = data.batch(12)
       data = data.repeat(num_epochs)
 
-      optimizer = tf.keras.optimizers.Adam(lr=0.005, amsgrad=True)
+      optimizer = tf.keras.optimizers.Adam(learning_rate=0.005, amsgrad=True)
 
+      model = models[regret_player]
       for x, y in data:
-        optimizer.minimize(
-            lambda: tf.losses.huber_loss(y, models[regret_player](x)),  # pylint: disable=cell-var-from-loop
-            models[regret_player].trainable_variables)
+        with tf.GradientTape() as tape:
+          loss = tf.losses.huber_loss(y, model(x))
+        optimizer.apply_gradients(
+          zip(
+            tape.gradient(loss, model.trainable_variables),
+            model.trainable_variables))
 
       regret_player = reach_weights_player
 
@@ -504,12 +508,15 @@ class RcfrTest(parameterized.TestCase, tf.test.TestCase):
       data = data.batch(12)
       data = data.repeat(num_epochs)
 
-      optimizer = tf.keras.optimizers.Adam(lr=0.005, amsgrad=True)
+      optimizer = tf.keras.optimizers.Adam(learning_rate=0.005, amsgrad=True)
 
       for x, y in data:
-        optimizer.minimize(
-            lambda: tf.losses.huber_loss(y, model(x)),  # pylint: disable=cell-var-from-loop
-            model.trainable_variables)
+        with tf.GradientTape() as tape:
+          loss = tf.losses.huber_loss(y, model(x))
+        optimizer.apply_gradients(
+          zip(
+            tape.gradient(loss, model.trainable_variables),
+            model.trainable_variables))
 
     average_policy = patient.average_policy()
     self.assertGreater(pyspiel.nash_conv(_GAME, average_policy), 0.91)
@@ -565,12 +572,15 @@ class RcfrTest(parameterized.TestCase, tf.test.TestCase):
       data = data.batch(12)
       data = data.repeat(num_epochs)
 
-      optimizer = tf.keras.optimizers.Adam(lr=0.005, amsgrad=True)
+      optimizer = tf.keras.optimizers.Adam(learning_rate=0.005, amsgrad=True)
 
       for x, y in data:
-        optimizer.minimize(
-            lambda: tf.losses.huber_loss(y, model(x)),  # pylint: disable=cell-var-from-loop
-            model.trainable_variables)
+        with tf.GradientTape() as tape:
+          loss = tf.losses.huber_loss(y, model(x))
+        optimizer.apply_gradients(
+          zip(
+            tape.gradient(loss, model.trainable_variables),
+            model.trainable_variables))
 
     average_policy = patient.average_policy()
     self.assertGreater(pyspiel.nash_conv(_GAME, average_policy), 0.91)

--- a/open_spiel/python/algorithms/rcfr_test.py
+++ b/open_spiel/python/algorithms/rcfr_test.py
@@ -37,8 +37,7 @@ def _new_model():
   return rcfr.DeepRcfrModel(
       _GAME,
       num_hidden_layers=1,
-      num_hidden_units=26,
-      num_hidden_factors=1,
+      num_hidden_units=13,
       use_skip_connections=True)
 
 


### PR DESCRIPTION
Fixes #1207 by replacing `lr` with `learning_rate` and replacing calls to `minimize`, which is no longer present in `tf.keras.optimizers.Adam`. The `test_rcfr_functions` was flaky so I also increased the size of the model to get the test to pass.

With this patch, `python open_spiel/python/algorithms/rcfr_test.py` should now pass and `python open_spiel/python/examples/rcfr_example.py` runs without error.