### PR TITLE
Fix for issue #1266

### DIFF
--- a/open_spiel/python/algorithms/efr.py
+++ b/open_spiel/python/algorithms/efr.py
@@ -808,7 +808,7 @@ def return_cs_partial_sequence(num_actions, history, prior_legal_actions):
     information set.
   """
   prior_actions_in_memory = history
-  external_memory_weights = [None]
+  external_memory_weights = []
 
   for i in range(len(history)):
     possible_memory_weight = np.zeros(len(history))
@@ -851,7 +851,7 @@ def return_cs_partial_sequence_orginal(
     information set.
   """
   prior_actions_in_memory = history
-  external_memory_weights = [None]
+  external_memory_weights = []
 
   for i in range(len(history)):
     possible_memory_weight = np.zeros(len(history))
@@ -891,7 +891,7 @@ def return_twice_informed_partial_sequence(
     all TIPS deviations that are realizable at theinformation set.
   """
   prior_actions_in_memory = history
-  memory_weights = [None]
+  memory_weights = []
 
   for i in range(len(history)):
     possible_memory_weight = np.zeros(len(history))


### PR DESCRIPTION
I removed an initial None element for a few of the prior_actions_weight arrays. They had no purpose within the code and must have been an artifact from a previous version. I have tested it locally with the newest version of Numpy and it passes the failing test fine.

I am also getting the following deprecation warning with the newer version (which I will also take a look at).

open_spiel/open_spiel/python/algorithms/efr.py:280: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)

#1266
