### PR TITLE
Add player turn information to Breakthrough's serialization and deserialization function

### DIFF
--- a/open_spiel/games/breakthrough/breakthrough.cc
+++ b/open_spiel/games/breakthrough/breakthrough.cc
@@ -391,11 +391,14 @@ int BreakthroughGame::NumDistinctActions() const {
 
 std::string BreakthroughState::Serialize() const {
   std::string str = "";
+  // Serialize the board state.
   for (int r = 0; r < rows_; r++) {
     for (int c = 0; c < cols_; c++) {
       absl::StrAppend(&str, CellToString(board(r, c)));
     }
   }
+  // Append current player information.
+  absl::StrAppend(&str, std::to_string(cur_player_));
   return str;
 }
 
@@ -403,7 +406,7 @@ std::unique_ptr<State> BreakthroughGame::DeserializeState(
     const std::string& str) const {
   std::unique_ptr<State> state = NewInitialState();
 
-  if (str.length() != rows_ * cols_) {
+  if (str.length() != rows_ * cols_ + 1) {
     SpielFatalError("Incorrect number of characters in string.");
     return std::unique_ptr<State>();
   }
@@ -434,6 +437,8 @@ std::unique_ptr<State> BreakthroughGame::DeserializeState(
     }
   }
 
+  # -'0' to get the int value.
+  bstate->cur_player_ = str.at(i) - '0';
   return state;
 }
 

--- a/open_spiel/games/breakthrough/breakthrough.cc
+++ b/open_spiel/games/breakthrough/breakthrough.cc
@@ -437,8 +437,8 @@ std::unique_ptr<State> BreakthroughGame::DeserializeState(
     }
   }
 
-  # -'0' to get the int value.
-  bstate->cur_player_ = str.at(i) - '0';
+  // -'0' to get the int value.
+  bstate->Set_cur_player(str.at(i) - '0');
   return state;
 }
 

--- a/open_spiel/games/breakthrough/breakthrough.h
+++ b/open_spiel/games/breakthrough/breakthrough.h
@@ -66,6 +66,7 @@ class BreakthroughState : public State {
   bool InBounds(int r, int c) const;
   void SetBoard(int r, int c, CellState cs) { board_[r * cols_ + c] = cs; }
   void SetPieces(int idx, int value) { pieces_[idx] = value; }
+  void Set_cur_player(int player) { cur_player_ = player; }
   CellState board(int row, int col) const { return board_[row * cols_ + col]; }
   int pieces(int idx) const { return pieces_[idx]; }
   int rows() const { return rows_; }


### PR DESCRIPTION
Fix the bug in the original Breakthrough's serialization and deserialization function that misses the player turn information.