### PR TITLE
Fix issue with Python importlib_metadata requirements when building Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -21,6 +21,8 @@ COPY . .
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
 RUN ./install.sh
 RUN pip3 install --upgrade setuptools testresources
+# Line below is a workaround for the issue https://github.com/google-deepmind/open_spiel/issues/1293
+RUN pip install importlib_metadata --force-reinstall
 RUN pip3 install --upgrade -r requirements.txt
 RUN pip3 install --upgrade cmake
 


### PR DESCRIPTION
This PR fixes the following issue https://github.com/google-deepmind/open_spiel/issues/1293.
In particular, when building the docker, the following error is thrown
`AttributeError: module 'importlib_metadata' has no attribute 'EntryPoints'`
This solution was suggested in this this [Stackoverflow post](https://stackoverflow.com/questions/64494526/jupiter-notebook-run-error-attributeerror-module-importlib-metadata-has-no-a).