### PR TITLE
Fix Clang++ 15.0 compiler issue with spiel_utils

### DIFF
--- a/open_spiel/spiel_utils.h
+++ b/open_spiel/spiel_utils.h
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <random>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
This PR fixes one of the issues reported in #1293.
The compiler fails when building the Dockerfile.base. Specifically, the issue occurs when the compiler Clang++ 15.0.0 is used (Note: no other compilers were tested, so it's unclear if the issue happens with other compilers or settings).

The error looks as the following
```
3.450 In file included from /repo/open_spiel/spiel_utils.cc:15:
3.452 /repo/open_spiel/../open_spiel/spiel_utils.h:51:59: error: no template named 'unique_ptr' in namespace 'std'
3.452 std::ostream& operator<<(std::ostream& stream, const std::unique_ptr<T>& v);
3.452                                                      ~~~~~^
3.463 /repo/open_spiel/../open_spiel/spiel_utils.h:88:59: error: no template named 'unique_ptr' in namespace 'std'
3.463 std::ostream& operator<<(std::ostream& stream, const std::unique_ptr<T>& v) {
```
and it can be fixed by explicitly importing the library memory in spiel_utils.h.