### PR TITLE
Fixed bug in Ultimate Tic Tac Toe termination conditions

### DIFF
--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
@@ -59,7 +59,7 @@ RegisterSingleTensorObserver single_tensor(kGameType.short_name);
 }  // namespace
 
 bool UltimateTTTState::AllLocalStatesTerminal() const {
-  return std::any_of(
+  return std::all_of(
       local_states_.begin(), local_states_.end(),
       [](const std::unique_ptr<State>& state) { return state->IsTerminal(); });
 }


### PR DESCRIPTION
Fixed bug in Ultimate Tic Tac Toe implementation that caused games to end when any small board was terminal instead of when *all* small boards are terminal