### PR TITLE
Fix MaxGameLength of TTT variants

### DIFF
--- a/open_spiel/games/phantom_ttt/phantom_ttt.h
+++ b/open_spiel/games/phantom_ttt/phantom_ttt.h
@@ -118,7 +118,7 @@ class PhantomTTTGame : public Game {
   // These will depend on the obstype parameter.
   std::vector<int> InformationStateTensorShape() const override;
   std::vector<int> ObservationTensorShape() const override;
-  int MaxGameLength() const override { return tic_tac_toe::kNumCells * 2 - 1; }
+  int MaxGameLength() const override { return game_->MaxGameLength() * 2 - 1; }
 
   ObservationType obs_type() const { return obs_type_; }
 

--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.h
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.h
@@ -93,7 +93,7 @@ class UltimateTTTGame : public Game {
             tic_tac_toe::kNumRows, tic_tac_toe::kNumCols};
   }
   int MaxGameLength() const override {
-    return tic_tac_toe::kNumCells * kNumSubgames;
+    return ttt_game_->MaxGameLength() * kNumSubgames;
   }
 
   const tic_tac_toe::TicTacToeGame* TicTacToeGame() const {


### PR DESCRIPTION
The max game length of a TTT variant depends on the max length of its underlying TTT game. Encapsulate this instead of re-implementing TicTacToe::MaxGameLenth in the variants'::MaxGameLenth.