### PR TITLE
Fix build_and_run_tests.sh command error.

### DIFF
--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -34,7 +34,6 @@
 #include "pybind11/include/pybind11/detail/common.h"
 #include "pybind11/include/pybind11/pybind11.h"
 #include "pybind11/include/pybind11/pytypes.h"
-#include "pybind11/include/pybind11/smart_holder.h"
 
 // Optional headers.
 #if OPEN_SPIEL_BUILD_WITH_ROSHAMBO

--- a/open_spiel/python/pybind11/games_backgammon.cc
+++ b/open_spiel/python/pybind11/games_backgammon.cc
@@ -24,8 +24,6 @@ using open_spiel::State;
 using open_spiel::backgammon::BackgammonState;
 using open_spiel::backgammon::CheckerMove;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(BackgammonState);
-
 void open_spiel::init_pyspiel_games_backgammon(py::module& m) {
   py::class_<CheckerMove>(m, "CheckerMove")
       .def_readwrite("pos", &CheckerMove::pos)

--- a/open_spiel/python/pybind11/games_bargaining.cc
+++ b/open_spiel/python/pybind11/games_bargaining.cc
@@ -26,9 +26,6 @@ using open_spiel::bargaining::BargainingState;
 using open_spiel::bargaining::Instance;
 using open_spiel::bargaining::Offer;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(BargainingGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(BargainingState);
-
 void open_spiel::init_pyspiel_games_bargaining(py::module& m) {
   py::class_<Instance>(m, "Instance")
       .def(py::init<>())

--- a/open_spiel/python/pybind11/games_bridge.cc
+++ b/open_spiel/python/pybind11/games_bridge.cc
@@ -20,9 +20,6 @@
 #include "open_spiel/python/pybind11/pybind11.h"
 #include "open_spiel/spiel.h"
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::bridge::BridgeGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::bridge::BridgeState);
-
 namespace open_spiel {
 
 namespace py = ::pybind11;

--- a/open_spiel/python/pybind11/games_chess.cc
+++ b/open_spiel/python/pybind11/games_chess.cc
@@ -24,7 +24,6 @@
 #include "open_spiel/spiel.h"
 #include "pybind11/include/pybind11/cast.h"
 #include "pybind11/include/pybind11/pybind11.h"
-#include "pybind11/include/pybind11/smart_holder.h"
 
 namespace py = ::pybind11;
 using open_spiel::Game;
@@ -37,10 +36,6 @@ using open_spiel::chess::Square;
 using open_spiel::chess::Piece;
 using open_spiel::chess::PieceType;
 using open_spiel::chess::Move;
-
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ChessGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ChessState);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ChessBoard);
 
 void open_spiel::init_pyspiel_games_chess(py::module& m) {
   py::module_ chess = m.def_submodule("chess");

--- a/open_spiel/python/pybind11/games_colored_trails.cc
+++ b/open_spiel/python/pybind11/games_colored_trails.cc
@@ -32,9 +32,6 @@ using open_spiel::colored_trails::kDefaultNumColors;
 using open_spiel::colored_trails::kNumChipsLowerBound;
 using open_spiel::colored_trails::kNumChipsUpperBound;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ColoredTrailsGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ColoredTrailsState);
-
 void open_spiel::init_pyspiel_games_colored_trails(py::module& m) {
   m.attr("NUM_COLORS") = py::int_(kDefaultNumColors);
   m.attr("NUM_CHIPS_LOWER_BOUND") = py::int_(kNumChipsLowerBound);

--- a/open_spiel/python/pybind11/games_dots_and_boxes.cc
+++ b/open_spiel/python/pybind11/games_dots_and_boxes.cc
@@ -20,7 +20,6 @@
 
 #include "open_spiel/games/dots_and_boxes/dots_and_boxes.h"
 #include "open_spiel/spiel.h"
-#include "pybind11/include/pybind11/smart_holder.h"
 #include "pybind11/include/pybind11/pybind11.h"
 
 
@@ -28,8 +27,6 @@ namespace py = ::pybind11;
 using open_spiel::Game;
 using open_spiel::State;
 using open_spiel::dots_and_boxes::DotsAndBoxesState;
-
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(DotsAndBoxesState);
 
 void open_spiel::init_pyspiel_games_dots_and_boxes(py::module& m) {
   py::classh<DotsAndBoxesState, State>(m, "DotsAndBoxesState")

--- a/open_spiel/python/pybind11/games_euchre.cc
+++ b/open_spiel/python/pybind11/games_euchre.cc
@@ -25,9 +25,6 @@
 #include "pybind11/include/pybind11/detail/common.h"
 #include "pybind11_abseil/absl_casters.h"
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::euchre::EuchreGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::euchre::EuchreState);
-
 namespace open_spiel {
 
 namespace py = ::pybind11;

--- a/open_spiel/python/pybind11/games_gin_rummy.cc
+++ b/open_spiel/python/pybind11/games_gin_rummy.cc
@@ -27,9 +27,6 @@
 #include "pybind11/include/pybind11/detail/common.h"
 #include "pybind11_abseil/absl_casters.h"
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::gin_rummy::GinRummyGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::gin_rummy::GinRummyState);
-
 namespace open_spiel {
 
 namespace py = ::pybind11;

--- a/open_spiel/python/pybind11/games_leduc_poker.cc
+++ b/open_spiel/python/pybind11/games_leduc_poker.cc
@@ -24,8 +24,6 @@ using open_spiel::State;
 using open_spiel::leduc_poker::LeducState;
 using open_spiel::leduc_poker::ActionType;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(LeducState);
-
 void open_spiel::init_pyspiel_games_leduc_poker(py::module& m) {
   py::module_ leduc_poker = m.def_submodule("leduc_poker");
 

--- a/open_spiel/python/pybind11/games_negotiation.cc
+++ b/open_spiel/python/pybind11/games_negotiation.cc
@@ -23,8 +23,6 @@ using open_spiel::Game;
 using open_spiel::State;
 using open_spiel::negotiation::NegotiationState;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(NegotiationState);
-
 void open_spiel::init_pyspiel_games_negotiation(py::module& m) {
   py::classh<NegotiationState, State>(m, "NegotiationState")
       .def("item_pool",

--- a/open_spiel/python/pybind11/games_spades.cc
+++ b/open_spiel/python/pybind11/games_spades.cc
@@ -24,9 +24,6 @@
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::spades::SpadesGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::spades::SpadesState);
-
 namespace open_spiel {
 
 namespace py = ::pybind11;

--- a/open_spiel/python/pybind11/games_tarok.cc
+++ b/open_spiel/python/pybind11/games_tarok.cc
@@ -15,8 +15,6 @@
 #include "open_spiel/games/tarok/tarok.h"
 #include "open_spiel/python/pybind11/pybind11.h"
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::tarok::TarokState);
-
 namespace open_spiel {
 
 namespace py = ::pybind11;

--- a/open_spiel/python/pybind11/games_tiny_bridge.cc
+++ b/open_spiel/python/pybind11/games_tiny_bridge.cc
@@ -24,9 +24,6 @@ using open_spiel::State;
 using open_spiel::tiny_bridge::TinyBridgeAuctionState;
 using open_spiel::tiny_bridge::TinyBridgePlayState;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(TinyBridgePlayState);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(TinyBridgeAuctionState);
-
 void open_spiel::init_pyspiel_games_tiny_bridge(py::module& m) {
   py::classh<TinyBridgePlayState, State>(m, "TinyBridgePlayState")
       // Pickle support

--- a/open_spiel/python/pybind11/games_trade_comm.cc
+++ b/open_spiel/python/pybind11/games_trade_comm.cc
@@ -23,7 +23,6 @@ using open_spiel::Game;
 using open_spiel::State;
 using open_spiel::trade_comm::TradeCommState;
 
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(TradeCommState);
 void open_spiel::init_pyspiel_games_trade_comm(py::module& m) {
   py::classh<TradeCommState, State>(m, "TradeCommState")
       // Pickle support

--- a/open_spiel/python/pybind11/pybind11.h
+++ b/open_spiel/python/pybind11/pybind11.h
@@ -37,10 +37,6 @@
 #include "pybind11/include/pybind11/smart_holder.h"  // IWYU pragma: keep
 #include "pybind11/include/pybind11/stl.h"  // IWYU pragma: keep
 
-// Runtime errors happen if we're inconsistent about whether or not a type has
-// PYBIND11_SMART_HOLDER_TYPE_CASTERS applied to it or not. So we do it mostly
-// in one place to help with consistency.
-
 namespace open_spiel {
 
 class Policy;
@@ -66,20 +62,6 @@ class ISMCTSBot;
 }  // namespace algorithms
 
 }  // namespace open_spiel
-
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::State);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::Game);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::Policy);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::TabularPolicy);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::PartialTabularPolicy);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::UniformPolicy);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::PreferredActionPolicy);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::NormalFormGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::matrix_game::MatrixGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::tensor_game::TensorGame);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::Bot);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::algorithms::MCTSBot);
-PYBIND11_SMART_HOLDER_TYPE_CASTERS(open_spiel::algorithms::ISMCTSBot);
 
 namespace open_spiel {
 // Trampoline helper class to allow implementing Bots in Python. See

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -119,7 +119,7 @@ function cached_clone() {
 
 DIR="./pybind11"
 if [[ ! -d ${DIR} ]]; then
-  cached_clone -b smart_holder --single-branch --depth 1 https://github.com/pybind/pybind11.git ${DIR}
+  cached_clone -b master --single-branch --depth 1 https://github.com/pybind/pybind11.git ${DIR}
 fi
 
 # The official https://github.com/dds-bridge/dds.git seems to not accept PR,


### PR DESCRIPTION
First, kudos to the OpenSpiel team for maintaining such an impressive and valuable framework for reinforcement learning and game theory research!

This PR addresses an issue with the `pybind11` dependency in OpenSpiel, stemming from the `smart_holder` branch being archived and renamed to `archive/smart_holder` in the `pybind11` repository (see: https://github.com/pybind/pybind11/tree/archive/smart_holder). The original build process attempted to clone the now-deprecated `smart_holder` branch, causing errors.

### Changes Made
1. **Updated `pybind11` Branch**: Modified the `cached_clone` command in `./open_spiel/scripts/build_and_run_tests.sh` to use the `master` branch of `pybind11` instead of `smart_holder` or `archive/smart_holder`. The `smart_holder` features are now fully integrated into `master`, making this the appropriate target.
2. **Removed Deprecated Code**: As per the `pybind11` migration guidelines, removed the obsolete `#include <pybind11/smart_holder.h>` and the following deprecated macros from the codebase:
   - `PYBIND11_SMART_HOLDER_TYPE_CASTERS`
   These are no longer needed with the latest `pybind11`.

### Result
These changes resolve the build errors encountered when running `./open_spiel/scripts/build_and_run_tests.sh`, ensuring compatibility with the current `pybind11` `master` branch.

Please review and let me know if additional adjustments are needed!