### PR TITLE
Add board class in TTT

### DIFF
--- a/open_spiel/games/phantom_ttt/phantom_ttt.h
+++ b/open_spiel/games/phantom_ttt/phantom_ttt.h
@@ -15,7 +15,6 @@
 #ifndef OPEN_SPIEL_GAMES_PHANTOM_TTT_H_
 #define OPEN_SPIEL_GAMES_PHANTOM_TTT_H_
 
-#include <array>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -106,8 +105,8 @@ class PhantomTTTState : public State {
 
   // TODO(author2): Use the base class history_ instead.
   std::vector<std::pair<int, Action>> action_sequence_;
-  std::array<tic_tac_toe::CellState, tic_tac_toe::kNumCells> x_view_;
-  std::array<tic_tac_toe::CellState, tic_tac_toe::kNumCells> o_view_;
+  tic_tac_toe::GridBoard x_view_;
+  tic_tac_toe::GridBoard o_view_;
 };
 
 // Game object.

--- a/open_spiel/games/tic_tac_toe/tic_tac_toe.cc
+++ b/open_spiel/games/tic_tac_toe/tic_tac_toe.cc
@@ -79,8 +79,7 @@ std::string StateToString(CellState state) {
   }
 }
 
-bool BoardHasLine(const std::array<CellState, kNumCells>& board,
-                  const Player player) {
+bool BoardHasLine(const GridBoard& board, const Player player) {
   CellState c = PlayerToState(player);
   return (board[0] == c && board[1] == c && board[2] == c) ||
          (board[3] == c && board[4] == c && board[5] == c) ||

--- a/open_spiel/games/tic_tac_toe/tic_tac_toe.cc
+++ b/open_spiel/games/tic_tac_toe/tic_tac_toe.cc
@@ -79,27 +79,48 @@ std::string StateToString(CellState state) {
   }
 }
 
+GridBoard::GridBoard() {
+  // All cells on the board start empty
+  std::fill(begin(board_), end(board_), CellState::kEmpty);
+}
+
+const CellState& GridBoard::At(size_t index) const { return board_.at(index); }
+
+CellState& GridBoard::At(size_t index) {
+  return const_cast<CellState &>(std::as_const(*this).At(index));
+}
+
+const CellState& GridBoard::At(size_t row, size_t col) const {
+  return board_.at(row * kNumCols + col);
+}
+
+CellState& GridBoard::At(size_t row, size_t col) {
+  return const_cast<CellState &>(std::as_const(*this).At(row, col));
+}
+
 bool BoardHasLine(const GridBoard& board, const Player player) {
   CellState c = PlayerToState(player);
-  return (board[0] == c && board[1] == c && board[2] == c) ||
-         (board[3] == c && board[4] == c && board[5] == c) ||
-         (board[6] == c && board[7] == c && board[8] == c) ||
-         (board[0] == c && board[3] == c && board[6] == c) ||
-         (board[1] == c && board[4] == c && board[7] == c) ||
-         (board[2] == c && board[5] == c && board[8] == c) ||
-         (board[0] == c && board[4] == c && board[8] == c) ||
-         (board[2] == c && board[4] == c && board[6] == c);
+  return (board.At(0) == c && board.At(1) == c && board.At(2) == c) ||
+         (board.At(3) == c && board.At(4) == c && board.At(5) == c) ||
+         (board.At(6) == c && board.At(7) == c && board.At(8) == c) ||
+         (board.At(0) == c && board.At(3) == c && board.At(6) == c) ||
+         (board.At(1) == c && board.At(4) == c && board.At(7) == c) ||
+         (board.At(2) == c && board.At(5) == c && board.At(8) == c) ||
+         (board.At(0) == c && board.At(4) == c && board.At(8) == c) ||
+         (board.At(2) == c && board.At(4) == c && board.At(6) == c);
 }
 
 std::vector<CellState> TicTacToeState::Board() const {
-  std::vector<CellState> board(board_.begin(), board_.end());
+  std::vector<CellState> board;
+  for (int cell = 0; cell < kNumCells; ++cell) {
+    board.push_back(board_.At(cell));
+  }
   return board;
 }
 
-
 void TicTacToeState::DoApplyAction(Action move) {
-  SPIEL_CHECK_EQ(board_[move], CellState::kEmpty);
-  board_[move] = PlayerToState(CurrentPlayer());
+  SPIEL_CHECK_EQ(board_.At(move), CellState::kEmpty);
+  board_.At(move) = PlayerToState(CurrentPlayer());
   if (HasLine(current_player_)) {
     outcome_ = current_player_;
   }
@@ -112,7 +133,7 @@ std::vector<Action> TicTacToeState::LegalActions() const {
   // Can move in any empty cell.
   std::vector<Action> moves;
   for (int cell = 0; cell < kNumCells; ++cell) {
-    if (board_[cell] == CellState::kEmpty) {
+    if (board_.At(cell) == CellState::kEmpty) {
       moves.push_back(cell);
     }
   }
@@ -130,9 +151,7 @@ bool TicTacToeState::HasLine(Player player) const {
 
 bool TicTacToeState::IsFull() const { return num_moves_ == kNumCells; }
 
-TicTacToeState::TicTacToeState(std::shared_ptr<const Game> game) : State(game) {
-  std::fill(begin(board_), end(board_), CellState::kEmpty);
-}
+TicTacToeState::TicTacToeState(std::shared_ptr<const Game> game) : State(game) {}
 
 std::string TicTacToeState::ToString() const {
   std::string str;
@@ -181,12 +200,12 @@ void TicTacToeState::ObservationTensor(Player player,
   // Treat `values` as a 2-d tensor.
   TensorView<2> view(values, {kCellStates, kNumCells}, true);
   for (int cell = 0; cell < kNumCells; ++cell) {
-    view[{static_cast<int>(board_[cell]), cell}] = 1.0;
+    view[{static_cast<int>(board_.At(cell)), cell}] = 1.0;
   }
 }
 
 void TicTacToeState::UndoAction(Player player, Action move) {
-  board_[move] = CellState::kEmpty;
+  board_.At(move) = CellState::kEmpty;
   current_player_ = player;
   outcome_ = kInvalidPlayer;
   num_moves_ -= 1;

--- a/open_spiel/games/tic_tac_toe/tic_tac_toe.h
+++ b/open_spiel/games/tic_tac_toe/tic_tac_toe.h
@@ -48,6 +48,9 @@ enum class CellState {
   kCross,   // X
 };
 
+// The game board is composed of a grid of cells
+typedef std::array<CellState, kNumCells> GridBoard;
+
 // State of an in-play game.
 class TicTacToeState : public State {
  public:
@@ -82,7 +85,7 @@ class TicTacToeState : public State {
   void SetCurrentPlayer(Player player) { current_player_ = player; }
 
  protected:
-  std::array<CellState, kNumCells> board_;
+  GridBoard board_;
   void DoApplyAction(Action move) override;
 
  private:
@@ -116,8 +119,7 @@ CellState PlayerToState(Player player);
 std::string StateToString(CellState state);
 
 // Does this player have a line?
-bool BoardHasLine(const std::array<CellState, kNumCells>& board,
-                  const Player player);
+bool BoardHasLine(const GridBoard& board, const Player player);
 
 inline std::ostream& operator<<(std::ostream& stream, const CellState& state) {
   return stream << StateToString(state);

--- a/open_spiel/games/tic_tac_toe/tic_tac_toe.h
+++ b/open_spiel/games/tic_tac_toe/tic_tac_toe.h
@@ -49,7 +49,23 @@ enum class CellState {
 };
 
 // The game board is composed of a grid of cells
-typedef std::array<CellState, kNumCells> GridBoard;
+class GridBoard {
+ public:
+  // Constructs an empty board
+  GridBoard();
+
+  // Get the contents of the board at a given index
+  const CellState& At(size_t index) const;
+  CellState& At(size_t index);
+
+  // Get the contents of the board at a given 2D position
+  const CellState& At(size_t row, size_t col) const;
+  CellState& At(size_t row, size_t col);
+
+ private:
+  // The underlying container - i.e., the actual board
+  std::array<CellState, kNumCells> board_;
+};
 
 // State of an in-play game.
 class TicTacToeState : public State {
@@ -74,9 +90,9 @@ class TicTacToeState : public State {
   void UndoAction(Player player, Action move) override;
   std::vector<Action> LegalActions() const override;
   std::vector<CellState> Board() const;
-  CellState BoardAt(int cell) const { return board_[cell]; }
+  CellState BoardAt(int cell) const { return board_.At(cell); }
   CellState BoardAt(int row, int column) const {
-    return board_[row * kNumCols + column];
+    return board_.At(row, column);
   }
   Player outcome() const { return outcome_; }
   void ChangePlayer() { current_player_ = current_player_ == 0 ? 1 : 0; }

--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
@@ -78,9 +78,9 @@ void UltimateTTTState::DoApplyAction(Action move) {
     if (local_states_[current_state_]->IsTerminal()) {
       Player local_outcome = local_state(current_state_)->outcome();
       if (local_outcome < 0) {
-        meta_board_[current_state_] = ttt::CellState::kEmpty;
+        meta_board_.At(current_state_) = ttt::CellState::kEmpty;
       } else {
-        meta_board_[current_state_] = ttt::PlayerToState(local_outcome);
+        meta_board_.At(current_state_) = ttt::PlayerToState(local_outcome);
       }
     }
     // Set the next potential local state.
@@ -137,7 +137,6 @@ UltimateTTTState::UltimateTTTState(std::shared_ptr<const Game> game)
       ttt_game_(
           static_cast<const UltimateTTTGame*>(game.get())->TicTacToeGame()),
       current_state_(-1) {
-  std::fill(meta_board_.begin(), meta_board_.end(), ttt::CellState::kEmpty);
   for (int i = 0; i < ttt::kNumCells; ++i) {
     local_states_[i] = ttt_game_->NewInitialState();
   }
@@ -220,9 +219,9 @@ UltimateTTTState::UltimateTTTState(const UltimateTTTState& other)
       current_player_(other.current_player_),
       outcome_(other.outcome_),
       ttt_game_(other.ttt_game_),
+      meta_board_(other.meta_board_),
       current_state_(other.current_state_) {
   for (int i = 0; i < ttt::kNumCells; ++i) {
-    meta_board_[i] = other.meta_board_[i];
     local_states_[i] = other.local_states_[i]->Clone();
   }
 }

--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.h
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.h
@@ -72,7 +72,7 @@ class UltimateTTTState : public State {
   // The tic-tac-toe subgames, arranged in the same order as moves.
   const tic_tac_toe::TicTacToeGame* ttt_game_;
   std::array<std::unique_ptr<State>, tic_tac_toe::kNumCells> local_states_;
-  std::array<tic_tac_toe::CellState, tic_tac_toe::kNumCells> meta_board_;
+  tic_tac_toe::GridBoard meta_board_;
   int current_state_;
 };
 


### PR DESCRIPTION
Add a class for the board in TTT. This helps encapsulate behavior, and drafts a class that could be later reused in other games. In the future it will be expanded with other functions, once more cleanup is merged.