### PR TITLE
Update Python trampoline classes

### DIFF
--- a/open_spiel/python/pybind11/pybind11.h
+++ b/open_spiel/python/pybind11/pybind11.h
@@ -60,13 +60,16 @@ class MCTSBot;
 class ISMCTSBot;
 }  // namespace algorithms
 
+namespace {
+namespace py = ::pybind11;
+}  // namespace
 }  // namespace open_spiel
 
 namespace open_spiel {
 // Trampoline helper class to allow implementing Bots in Python. See
 // https://pybind11.readthedocs.io/en/stable/advanced/classes.html#overriding-virtual-functions-in-python
 template <class BotBase = Bot>
-class PyBot : public BotBase {
+class PyBot : public BotBase, public py::trampoline_self_life_support {
  public:
   // We need the bot constructor
   using BotBase::BotBase;

--- a/open_spiel/python/pybind11/python_games.h
+++ b/open_spiel/python/pybind11/python_games.h
@@ -34,7 +34,7 @@ namespace open_spiel {
 namespace py = ::pybind11;
 
 // Trampoline for using Python-defined games from C++.
-class PyGame : public Game {
+class PyGame : public Game, public py::trampoline_self_life_support {
  public:
   PyGame(GameType game_type, GameInfo game_info,
          GameParameters game_parameters);


### PR DESCRIPTION
They must inherit from py::trampoline_self_life_support when using smart holder classes