### PR TITLE
Fix some build errors with MSVC and update the windows.md

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -42,7 +42,7 @@ dependencies (commands adapted from open_spiel/scripts/install.sh)
 cd C:\Users\MyUser
 git clone https://github.com/deepmind/open_spiel.git
 cd open_spiel
-git clone -b smart_holder --single-branch --depth 1 https://github.com/pybind/pybind11.git pybind11
+git clone --single-branch --depth 1 https://github.com/pybind/pybind11.git pybind11
 git clone -b 20211102.0 --single-branch --depth 1 https://github.com/abseil/abseil-cpp.git open_spiel\abseil-cpp
 git clone -b 'master' https://github.com/pybind/pybind11_abseil.git open_spiel\pybind11_abseil
 cd open_spiel\pybind11_abseil

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -70,7 +70,9 @@ if(APPLE)
   set (CMAKE_FIND_FRAMEWORK LAST)
 elseif(WIN32)
   # Setup for MSVC 2022.
-  # No changes needed. In particular: do not use -Wno-everything.
+  if(MSVC)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /utf-8 /bigobj /DWIN32 /D_WINDOWS /GR /EHsc")
+  endif()
 else()
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-everything")
 endif()

--- a/open_spiel/games/bargaining/bargaining_instances1000.cc
+++ b/open_spiel/games/bargaining/bargaining_instances1000.cc
@@ -913,7 +913,9 @@ constexpr const char* kDefaultInstances1000 =
 1,3,1 5,1,2 5,1,2
 1,4,1 2,1,4 6,1,0
 1,1,4 7,3,0 2,4,1
-1,1,3 4,0,2 9,1,0
+1,1,3 4,0,2 9,1,0)"
+// MSVC can't handle string longer than 16,384 bytes
+R"(
 2,4,1 1,0,8 1,1,4
 1,4,1 3,1,3 6,1,0
 1,1,5 2,3,1 10,0,0

--- a/open_spiel/games/chess/chess960_starting_positions.cc
+++ b/open_spiel/games/chess/chess960_starting_positions.cc
@@ -307,7 +307,9 @@ nbbrknqr/pppppppp/8/8/8/8/PPPPPPPP/NBBRKNQR w KQkq - 0 1
 nbbrkrqn/pppppppp/8/8/8/8/PPPPPPPP/NBBRKRQN w KQkq - 0 1
 rbbnnkqr/pppppppp/8/8/8/8/PPPPPPPP/RBBNNKQR w KQkq - 0 1
 rbbnknqr/pppppppp/8/8/8/8/PPPPPPPP/RBBNKNQR w KQkq - 0 1
-rbbnkrqn/pppppppp/8/8/8/8/PPPPPPPP/RBBNKRQN w KQkq - 0 1
+rbbnkrqn/pppppppp/8/8/8/8/PPPPPPPP/RBBNKRQN w KQkq - 0 1)"
+// MSVC can't handle string longer than 16,384 bytes
+R"(
 rbbknnqr/pppppppp/8/8/8/8/PPPPPPPP/RBBKNNQR w KQkq - 0 1
 rbbknrqn/pppppppp/8/8/8/8/PPPPPPPP/RBBKNRQN w KQkq - 0 1
 rbbkrnqn/pppppppp/8/8/8/8/PPPPPPPP/RBBKRNQN w KQkq - 0 1
@@ -594,7 +596,9 @@ rkqbbrnn/pppppppp/8/8/8/8/PPPPPPPP/RKQBBRNN w KQkq - 0 1
 nnrbbqkr/pppppppp/8/8/8/8/PPPPPPPP/NNRBBQKR w KQkq - 0 1
 nrnbbqkr/pppppppp/8/8/8/8/PPPPPPPP/NRNBBQKR w KQkq - 0 1
 nrkbbqnr/pppppppp/8/8/8/8/PPPPPPPP/NRKBBQNR w KQkq - 0 1
-nrkbbqrn/pppppppp/8/8/8/8/PPPPPPPP/NRKBBQRN w KQkq - 0 1
+nrkbbqrn/pppppppp/8/8/8/8/PPPPPPPP/NRKBBQRN w KQkq - 0 1)"
+// MSVC can't handle string longer than 16,384 bytes
+R"(
 rnnbbqkr/pppppppp/8/8/8/8/PPPPPPPP/RNNBBQKR w KQkq - 0 1
 rnkbbqnr/pppppppp/8/8/8/8/PPPPPPPP/RNKBBQNR w KQkq - 0 1
 rnkbbqrn/pppppppp/8/8/8/8/PPPPPPPP/RNKBBQRN w KQkq - 0 1
@@ -881,7 +885,9 @@ rqnkrbbn/pppppppp/8/8/8/8/PPPPPPPP/RQNKRBBN w KQkq - 0 1
 rqknnbbr/pppppppp/8/8/8/8/PPPPPPPP/RQKNNBBR w KQkq - 0 1
 rqknrbbn/pppppppp/8/8/8/8/PPPPPPPP/RQKNRBBN w KQkq - 0 1
 rqkrnbbn/pppppppp/8/8/8/8/PPPPPPPP/RQKRNBBN w KQkq - 0 1
-nnqrkbbr/pppppppp/8/8/8/8/PPPPPPPP/NNQRKBBR w KQkq - 0 1
+nnqrkbbr/pppppppp/8/8/8/8/PPPPPPPP/NNQRKBBR w KQkq - 0 1)"
+// MSVC can't handle string longer than 16,384 bytes
+R"(
 nrqnkbbr/pppppppp/8/8/8/8/PPPPPPPP/NRQNKBBR w KQkq - 0 1
 nrqknbbr/pppppppp/8/8/8/8/PPPPPPPP/NRQKNBBR w KQkq - 0 1
 nrqkrbbn/pppppppp/8/8/8/8/PPPPPPPP/NRQKRBBN w KQkq - 0 1

--- a/open_spiel/games/hive/hive.cc
+++ b/open_spiel/games/hive/hive.cc
@@ -413,7 +413,7 @@ Move HiveState::ActionToMove(Action action) const {
     to = HiveTile::kNoneTile;
   }
 
-  return Move{from, to, static_cast<Direction>(direction)};
+  return Move{HiveTile(from), HiveTile(to), static_cast<Direction>(direction)};
 }
 
 Action HiveState::MoveToAction(Move move) const {

--- a/open_spiel/games/hive/hive_board.cc
+++ b/open_spiel/games/hive/hive_board.cc
@@ -735,7 +735,7 @@ bool HiveBoard::IsConnected(HivePosition pos, HivePosition to_ignore) const {
 }
 
 bool HiveBoard::IsCovered(HivePosition pos) const {
-  return std::find_if(
+  return std::any_of(
       covered_tiles_.begin(), covered_tiles_.end(),
       [this, pos](HiveTile tile) { return GetPositionOf(tile) == pos; });
 }


### PR DESCRIPTION
- In **windows.md** remove the `-b smart_holder` parameters since this branch of `pybind11` no more exists
- In **open_spiel/CMakeLists.txt** add the build flags which are required for MSVC and already listed in **windows.md**
- In **open_spiel/games/bargaining/bargaining_instances1000.cc** and **chess/chess960_starting_positions.cc** :
    - Splits raw strings since they are loo long for MSVC
- In **open_spiel/games/hive/hive.cc** fix this error :
    - `error C2397: conversion from 'int64_t' to 'open_spiel::hive::HiveTile' requires a narrowing conversion`
- In **HiveBoard::IsCovered**, replace `find_if` by `any_of` since `find_if` returns an iterator and `IsCovered` expect a `bool`.