### PR TITLE
Added a test for `sequence_form_lp` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ build*/
 cmake-build-*/
 dist/
 pyspiel.egg-info/
+open_spiel.egg-info/
+
 
 # Swift build directory
 .build


### PR DESCRIPTION
Added a test for `sequence_form_lp` to check the right way of computing the `explotablity` of the solution.
Should I run local tests and if so, how? I didn't find that in the documentation.