### PR TITLE
wheels.yml: Enable large runners for arm64 builds for new version

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,12 +59,12 @@ jobs:
         # Disabling now that the OpenSpiel 1.4 wheels are on PyPI because these xlarge machines are
         # quite costly... we don't want to run these on every PR.
         # TODO(author5): Set this to macos-13 once these runners are no longer in beta
-        #- os: macos-13-xlarge
-        #  OS_TYPE: "Darwin"
-        #  CI_PYBIN: python3.11
-        #  OS_PYTHON_VERSION: 3.11
-        #  CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
-        #  CIBW_BUILD: cp39-macosx_arm64 cp310-macosx_arm64 cp311-macosx_arm64 cp312-macosx_arm64
+        - os: macos-13-xlarge
+          OS_TYPE: "Darwin"
+          CI_PYBIN: python3.11
+          OS_PYTHON_VERSION: 3.11
+          CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON' OPEN_SPIEL_BUILD_WITH_ROSHAMBO='ON'"
+          CIBW_BUILD: cp39-macosx_arm64 cp310-macosx_arm64 cp311-macosx_arm64 cp312-macosx_arm64
     env:
       OPEN_SPIEL_BUILDING_WHEEL: ON
       OPEN_SPIEL_BUILD_WITH_ACPC: ON


### PR DESCRIPTION
Mostly for OpenSpiel 1.6.1 release wheels.