### PR TITLE
Fix DeepCFR advantage network learning

### DIFF
--- a/open_spiel/python/pytorch/deep_cfr.py
+++ b/open_spiel/python/pytorch/deep_cfr.py
@@ -562,7 +562,7 @@ class DeepCFRSolver(policy.Policy):
         samples = self._advantage_memories[player].experience
 
       # Ensure some samples have been gathered.
-      if len(samples.info_state == 0):
+      if len(samples.info_state) == 0:
         return None
 
       self._optimizer_advantages[player].zero_grad()


### PR DESCRIPTION
Fix a comparison bug in `_learn_advantage_network` that prevented the network from ever being trained.

Instead of checking whether `info_state` is empty, it compares each element of the array against zero (producing a boolean array), and then checks the length of that boolean array. Since this boolean array always has the same number of elements as the original, the condition is true (except when the original is empty) and the function returns early without training the advantage network.