### PR TITLE
Fix python_liars_poker: players param not propagated to num_players()

### DIFF
--- a/open_spiel/python/games/liars_poker.py
+++ b/open_spiel/python/games/liars_poker.py
@@ -49,33 +49,31 @@ _GAME_TYPE = pyspiel.GameType(
         "num_digits": _NUM_DIGITS,
     },
 )
-_GAME_INFO = pyspiel.GameInfo(
-    # Num actions = total number of cards * number of digits + action enum
-    num_distinct_actions=_HAND_LENGTH * _NUM_DIGITS * _MIN_NUM_PLAYERS
-    + BID_ACTION_OFFSET,
-    max_chance_outcomes=_HAND_LENGTH * _NUM_DIGITS,
-    num_players=_MIN_NUM_PLAYERS,
-    min_utility=-(
-        _MIN_NUM_PLAYERS - 1
-    ),  # Reward from being challenged and losing.
-    max_utility=_MIN_NUM_PLAYERS
-    - 1,  # Reward for being challenged and winning.
-    utility_sum=0.0,
-    # Number of possible rounds: hand_length * num_digits * num_players
-    # Total moves per round: num_players for non-rebid, num_players-1 for rebid
-    # Max game length: number of possible rounds * total moves per round
-    max_game_length=_HAND_LENGTH * _NUM_DIGITS * _MIN_NUM_PLAYERS**2,
-)
-
-
 class LiarsPoker(pyspiel.Game):
   """A Python version of Liar's poker."""
 
   def __init__(self, params=None):
-    super().__init__(_GAME_TYPE, _GAME_INFO, params or dict())
-    game_parameters = self.get_parameters()
-    self.hand_length = game_parameters.get("hand_length", _HAND_LENGTH)
-    self.num_digits = game_parameters.get("num_digits", _NUM_DIGITS)
+    params = params or {}
+    num_players = params.get("players", _MIN_NUM_PLAYERS)
+    hand_length = params.get("hand_length", _HAND_LENGTH)
+    num_digits = params.get("num_digits", _NUM_DIGITS)
+    game_info = pyspiel.GameInfo(
+        # Num actions = total number of cards * number of digits + action enum
+        num_distinct_actions=hand_length * num_digits * num_players
+        + BID_ACTION_OFFSET,
+        max_chance_outcomes=hand_length * num_digits,
+        num_players=num_players,
+        min_utility=-(num_players - 1),  # Being challenged and losing.
+        max_utility=num_players - 1,  # Being challenged and winning.
+        utility_sum=0.0,
+        # Number of possible rounds: hand_length * num_digits * num_players
+        # Total moves per round: num_players for non-rebid, num_players-1 for
+        # rebid. Max game length: possible rounds * total moves per round.
+        max_game_length=hand_length * num_digits * num_players**2,
+    )
+    super().__init__(_GAME_TYPE, game_info, params)
+    self.hand_length = hand_length
+    self.num_digits = num_digits
     self.deck = _FULL_DECK[: self.num_digits]
 
   def new_initial_state(self):


### PR DESCRIPTION
Follow-up to #1571, per @lanctot's go-ahead there.

`python_liars_poker`'s `GameInfo` was built once at module import time using the *default* player count (`_MIN_NUM_PLAYERS`), and that same object was reused for every instance regardless of the `players` param actually passed in. So:

```python
pyspiel.load_game("python_liars_poker", {"players": 4}).num_players()  # returns 2, not 4
```

`num_distinct_actions`, `min_utility`/`max_utility`, and `max_game_length` were all similarly stuck at their 2-player values too, since they're derived from `num_players` in the same formulas.

Fix: build `GameInfo` inside `__init__` from the actual merged params (mirroring how other parameterized games in this file set, e.g. `pig.cc`, handle it), instead of a shared module-level constant.

**Testing:**
- `pyspiel.load_game("python_liars_poker", {"players": n}).num_players() == n` for n in 2-6.
- `pyspiel.random_sim_test` passes for players in 2-6, with serialization.
- Existing `liars_poker_test.py` suite passes unchanged (10/10).