### PR TITLE
Add teacher-student policy distillation colab for AlphaZero on Tic-Tac-Toe

### DIFF
--- a/open_spiel/colabs/alpha_zero_policy_distillation.ipynb
+++ b/open_spiel/colabs/alpha_zero_policy_distillation.ipynb
@@ -1,0 +1,1295 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "# @title ##### License { display-mode: \"form\" }\n",
+    "# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Policy Distillation from AlphaZero\n",
+    "\n",
+    "* This Colab trains an AlphaZero agent on Tic-Tac-Toe, distills it into a smaller network, and measures remaining playing strength."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: open_spiel>=2.0.1 in /opt/anaconda3/lib/python3.12/site-packages (2.0.1)\n",
+      "Requirement already satisfied: absl-py>=0.10.0 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (2.5.0)\n",
+      "Requirement already satisfied: attrs>=19.3.0 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (23.1.0)\n",
+      "Requirement already satisfied: numpy>=1.21.5 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (2.5.1)\n",
+      "Requirement already satisfied: scipy>=1.10.1 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (1.18.0)\n",
+      "Requirement already satisfied: ml-collections>=0.1.1 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (1.1.0)\n",
+      "Requirement already satisfied: PyYAML in /opt/anaconda3/lib/python3.12/site-packages (from ml-collections>=0.1.1->open_spiel>=2.0.1) (6.0.1)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "Requirement already satisfied: flax in /opt/anaconda3/lib/python3.12/site-packages (0.12.8)\n",
+      "Requirement already satisfied: optax in /opt/anaconda3/lib/python3.12/site-packages (0.2.8)\n",
+      "Requirement already satisfied: orbax-checkpoint in /opt/anaconda3/lib/python3.12/site-packages (0.12.1)\n",
+      "Requirement already satisfied: chex in /opt/anaconda3/lib/python3.12/site-packages (0.1.92)\n",
+      "Requirement already satisfied: matplotlib in /opt/anaconda3/lib/python3.12/site-packages (3.11.1)\n",
+      "Requirement already satisfied: jax[cpu] in /opt/anaconda3/lib/python3.12/site-packages (0.11.0)\n",
+      "Requirement already satisfied: jaxlib<=0.11.0,>=0.11.0 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (0.11.0)\n",
+      "Requirement already satisfied: ml_dtypes>=0.5.0 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (0.5.4)\n",
+      "Requirement already satisfied: numpy>=2.1 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (2.5.1)\n",
+      "Requirement already satisfied: opt_einsum in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (3.4.0)\n",
+      "Requirement already satisfied: scipy>=1.15 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (1.18.0)\n",
+      "Requirement already satisfied: msgpack in /opt/anaconda3/lib/python3.12/site-packages (from flax) (1.1.2)\n",
+      "Requirement already satisfied: tensorstore in /opt/anaconda3/lib/python3.12/site-packages (from flax) (0.1.84)\n",
+      "Requirement already satisfied: rich>=11.1 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (13.3.5)\n",
+      "Requirement already satisfied: typing_extensions>=4.2 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (4.16.0)\n",
+      "Requirement already satisfied: PyYAML>=5.4.1 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (6.0.1)\n",
+      "Requirement already satisfied: treescope>=0.1.7 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (0.1.10)\n",
+      "Requirement already satisfied: absl-py>=0.7.1 in /opt/anaconda3/lib/python3.12/site-packages (from optax) (2.5.0)\n",
+      "Requirement already satisfied: etils[epath,epy] in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (1.14.0)\n",
+      "Requirement already satisfied: prometheus-client>=0.20.0 in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (0.26.0)\n",
+      "Requirement already satisfied: aiofiles in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (25.1.0)\n",
+      "Requirement already satisfied: protobuf in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (3.20.3)\n",
+      "Requirement already satisfied: humanize in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (4.16.0)\n",
+      "Requirement already satisfied: simplejson>=3.16.0 in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (4.1.1)\n",
+      "Requirement already satisfied: psutil in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (5.9.0)\n",
+      "Requirement already satisfied: uvloop in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (0.22.1)\n",
+      "Requirement already satisfied: toolz>=1.0.0 in /opt/anaconda3/lib/python3.12/site-packages (from chex) (1.1.0)\n",
+      "Requirement already satisfied: contourpy>=1.0.1 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (1.3.3)\n",
+      "Requirement already satisfied: cycler>=0.10 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (0.11.0)\n",
+      "Requirement already satisfied: fonttools>=4.28.2 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (4.51.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.3.1 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (1.4.4)\n",
+      "Requirement already satisfied: packaging>=20.0 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (23.2)\n",
+      "Requirement already satisfied: pillow>=9 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (10.3.0)\n",
+      "Requirement already satisfied: pyparsing>=3 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (3.0.9)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (2.9.0.post0)\n",
+      "Requirement already satisfied: six>=1.5 in /opt/anaconda3/lib/python3.12/site-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n",
+      "Requirement already satisfied: markdown-it-py<3.0.0,>=2.2.0 in /opt/anaconda3/lib/python3.12/site-packages (from rich>=11.1->flax) (2.2.0)\n",
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /opt/anaconda3/lib/python3.12/site-packages (from rich>=11.1->flax) (2.15.1)\n",
+      "Requirement already satisfied: fsspec in /opt/anaconda3/lib/python3.12/site-packages (from etils[epath,epy]->orbax-checkpoint) (2024.3.1)\n",
+      "Requirement already satisfied: zipp in /opt/anaconda3/lib/python3.12/site-packages (from etils[epath,epy]->orbax-checkpoint) (3.17.0)\n",
+      "Requirement already satisfied: mdurl~=0.1 in /opt/anaconda3/lib/python3.12/site-packages (from markdown-it-py<3.0.0,>=2.2.0->rich>=11.1->flax) (0.1.0)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --upgrade \"open_spiel>=2.0.1\"\n",
+    "%pip install --upgrade \"jax[cpu]\" flax optax orbax-checkpoint chex matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jax 0.11.0\n",
+      "backend: cpu\n",
+      "devices: [CpuDevice(id=0)]\n",
+      "pyspiel games available: 126\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
+      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "import collections\n",
+    "import os\n",
+    "import tempfile\n",
+    "import time\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from flax import nnx\n",
+    "\n",
+    "import pyspiel\n",
+    "from open_spiel.python.algorithms import mcts\n",
+    "from open_spiel.python.algorithms import minimax\n",
+    "from open_spiel.python.algorithms.alpha_zero import alpha_zero as az\n",
+    "from open_spiel.python.algorithms.alpha_zero import evaluator as evaluator_lib\n",
+    "from open_spiel.python.algorithms.alpha_zero import model_nnx as model_lib\n",
+    "from open_spiel.python.algorithms.alpha_zero import utils as az_utils\n",
+    "\n",
+    "# Accelerator selection. Set USE_ACCELERATOR = False to pin everything to CPU.\n",
+    "# NOTE: self-play always runs on CPU regardless of this setting - az.alpha_zero()\n",
+    "# forks worker processes and an accelerator cannot be shared across forks.\n",
+    "USE_ACCELERATOR = True\n",
+    "if not USE_ACCELERATOR:\n",
+    "  jax.config.update(\"jax_platforms\", \"cpu\")\n",
+    "\n",
+    "print(\"jax\", jax.__version__)\n",
+    "print(\"backend:\", jax.default_backend())\n",
+    "print(\"devices:\", jax.devices())\n",
+    "print(\"pyspiel games available:\", len(pyspiel.registered_names()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tic_tac_toe: observation shape [3, 3, 3], 9 distinct actions\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Hyperparameters and environment setup.\n",
+    "SEED = 42\n",
+    "GAME_NAME = \"tic_tac_toe\"\n",
+    "\n",
+    "# Teacher parameters (AlphaZero)\n",
+    "TEACHER_WIDTH, TEACHER_DEPTH = 256, 4\n",
+    "TEACHER_TRAIN_STEPS = 20\n",
+    "TEACHER_ACTORS = 4\n",
+    "UCT_C = 1.41\n",
+    "SELFPLAY_SIMULATIONS = 40     # MCTS sims/move during self-play training.\n",
+    "EVAL_SIMULATIONS = 200        # MCTS sims/move when evaluating teacher+MCTS.\n",
+    "                              # 40 is on a cliff edge here: equally-converged\n",
+    "                              # teachers score 0 or 5+ losses vs minimax at 40,\n",
+    "                              # but both are perfect at 200.\n",
+    "\n",
+    "# Student parameters (distilled model)\n",
+    "STUDENT_WIDTH, STUDENT_DEPTH = 32, 1\n",
+    "DISTILL_EPOCHS = 300\n",
+    "DISTILL_BATCH_SIZE = 128\n",
+    "DISTILL_LEARNING_RATE = 1e-2\n",
+    "\n",
+    "# Evaluation parameters\n",
+    "N_GAMES = 100\n",
+    "\n",
+    "game = pyspiel.load_game(GAME_NAME)\n",
+    "OBS_SHAPE = game.observation_tensor_shape()\n",
+    "NUM_ACTIONS = game.num_distinct_actions()\n",
+    "print(f\"{GAME_NAME}: observation shape {OBS_SHAPE}, {NUM_ACTIONS} distinct actions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train the AlphaZero Teacher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting game tic_tac_toe\n",
+      "Writing logs and checkpoints to: /var/folders/_6/m1f08ld958917y_vty9_8yvm0000gn/T/az_teacher_12uqm1rq\n",
+      "Model type: mlp(width=256, depth=4)\n",
+      "learner started\n",
+      "[2026-07-25 23:53:54.993] Initializing model\n",
+      "actor-0 started\n",
+      "actor-3 started\n",
+      "actor-2 started\n",
+      "actor-1 started\n",
+      "evaluator-0 started\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
+      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
+      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
+      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
+      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
+      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
+      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
+      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
+      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
+      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2026-07-25 23:53:57.386] Model type: mlp(256, 4)\n",
+      "[2026-07-25 23:53:57.399] Model size: 338698 variables\n",
+      "[2026-07-25 23:53:57.545] Initial checkpoint: 0\n",
+      "[2026-07-25 23:53:57.551] Collecting trajectories\n",
+      "[2026-07-25 23:54:20.095] Step: 1\n",
+      "[2026-07-25 23:54:20.097] Collected  2049 states from 258 games, 24.8 states/s. 6.2 states/(s*actor), game length: 7.9\n",
+      "[2026-07-25 23:54:20.098] Buffer size: 2049. States seen: 2049\n",
+      "[2026-07-25 23:54:21.652] Losses(total: 1.897, policy: 1.547, value: 0.201, l2: 0.149)\n",
+      "[2026-07-25 23:54:21.654] Checkpoint saved: -1\n",
+      "[2026-07-25 23:54:21.794]\n",
+      "[2026-07-25 23:54:21.794] Collecting trajectories\n",
+      "[2026-07-25 23:54:40.630] Step: 2\n",
+      "[2026-07-25 23:54:40.631] Collected  2052 states from 271 games, 99.9 states/s. 25.0 states/(s*actor), game length: 7.6\n",
+      "[2026-07-25 23:54:40.632] Buffer size: 4101. States seen: 4101\n",
+      "[2026-07-25 23:54:40.915] Losses(total: 1.750, policy: 1.488, value: 0.127, l2: 0.136)\n",
+      "[2026-07-25 23:54:40.916] Checkpoint saved: -1\n",
+      "[2026-07-25 23:54:40.929]\n",
+      "[2026-07-25 23:54:40.931] Collecting trajectories\n",
+      "[2026-07-25 23:55:00.407] Step: 3\n",
+      "[2026-07-25 23:55:00.408] Collected  2052 states from 265 games, 103.8 states/s. 25.9 states/(s*actor), game length: 7.7\n",
+      "[2026-07-25 23:55:00.409] Buffer size: 6153. States seen: 6153\n",
+      "[2026-07-25 23:55:00.806] Losses(total: 1.631, policy: 1.402, value: 0.105, l2: 0.124)\n",
+      "[2026-07-25 23:55:00.807] Checkpoint saved: -1\n",
+      "[2026-07-25 23:55:00.828]\n",
+      "[2026-07-25 23:55:00.829] Collecting trajectories\n",
+      "[2026-07-25 23:55:19.535] Step: 4\n",
+      "[2026-07-25 23:55:19.536] Collected  2053 states from 250 games, 107.3 states/s. 26.8 states/(s*actor), game length: 8.2\n",
+      "[2026-07-25 23:55:19.537] Buffer size: 8192. States seen: 8206\n",
+      "[2026-07-25 23:55:20.008] Losses(total: 1.536, policy: 1.326, value: 0.093, l2: 0.117)\n",
+      "[2026-07-25 23:55:20.010] Checkpoint saved: -1\n",
+      "[2026-07-25 23:55:20.030]\n",
+      "[2026-07-25 23:55:20.031] Collecting trajectories\n",
+      "[2026-07-25 23:55:38.515] Step: 5\n",
+      "[2026-07-25 23:55:38.516] Collected  2048 states from 240 games, 107.9 states/s. 27.0 states/(s*actor), game length: 8.5\n",
+      "[2026-07-25 23:55:38.517] Buffer size: 8192. States seen: 10254\n",
+      "[2026-07-25 23:55:39.120] Losses(total: 1.356, policy: 1.184, value: 0.060, l2: 0.111)\n",
+      "[2026-07-25 23:55:39.122] Checkpoint saved: -1\n",
+      "[2026-07-25 23:55:39.142]\n",
+      "[2026-07-25 23:55:39.142] Collecting trajectories\n",
+      "[2026-07-25 23:55:57.529] Step: 6\n",
+      "[2026-07-25 23:55:57.530] Collected  2055 states from 241 games, 108.1 states/s. 27.0 states/(s*actor), game length: 8.5\n",
+      "[2026-07-25 23:55:57.531] Buffer size: 8192. States seen: 12309\n",
+      "[2026-07-25 23:55:58.004] Losses(total: 1.233, policy: 1.086, value: 0.041, l2: 0.106)\n",
+      "[2026-07-25 23:55:58.005] Checkpoint saved: -1\n",
+      "[2026-07-25 23:55:58.015]\n",
+      "[2026-07-25 23:55:58.016] Collecting trajectories\n",
+      "[2026-07-25 23:56:16.478] Step: 7\n",
+      "[2026-07-25 23:56:16.479] Collected  2054 states from 236 games, 108.4 states/s. 27.1 states/(s*actor), game length: 8.7\n",
+      "[2026-07-25 23:56:16.481] Buffer size: 8192. States seen: 14363\n",
+      "[2026-07-25 23:56:16.988] Losses(total: 1.107, policy: 0.977, value: 0.028, l2: 0.102)\n",
+      "[2026-07-25 23:56:16.989] Checkpoint saved: -1\n",
+      "[2026-07-25 23:56:17.015]\n",
+      "[2026-07-25 23:56:17.016] Collecting trajectories\n",
+      "[2026-07-25 23:56:36.226] Step: 8\n",
+      "[2026-07-25 23:56:36.227] Collected  2053 states from 240 games, 104.0 states/s. 26.0 states/(s*actor), game length: 8.6\n",
+      "[2026-07-25 23:56:36.230] Buffer size: 8192. States seen: 16416\n",
+      "[2026-07-25 23:56:36.768] Losses(total: 1.073, policy: 0.951, value: 0.024, l2: 0.097)\n",
+      "[2026-07-25 23:56:36.769] Checkpoint saved: -1\n",
+      "[2026-07-25 23:56:36.780]\n",
+      "[2026-07-25 23:56:36.780] Collecting trajectories\n",
+      "[2026-07-25 23:56:56.230] Step: 9\n",
+      "[2026-07-25 23:56:56.232] Collected  2050 states from 242 games, 102.5 states/s. 25.6 states/(s*actor), game length: 8.5\n",
+      "[2026-07-25 23:56:56.235] Buffer size: 8192. States seen: 18466\n",
+      "[2026-07-25 23:56:56.734] Losses(total: 1.047, policy: 0.933, value: 0.021, l2: 0.093)\n",
+      "[2026-07-25 23:56:56.735] Checkpoint saved: -1\n",
+      "[2026-07-25 23:56:56.746]\n",
+      "[2026-07-25 23:56:56.747] Collecting trajectories\n",
+      "[2026-07-25 23:57:16.211] Step: 10\n",
+      "[2026-07-25 23:57:16.212] Collected  2049 states from 238 games, 102.6 states/s. 25.6 states/(s*actor), game length: 8.6\n",
+      "[2026-07-25 23:57:16.214] Buffer size: 8192. States seen: 20515\n",
+      "[2026-07-25 23:57:16.715] Losses(total: 1.037, policy: 0.928, value: 0.020, l2: 0.089)\n",
+      "[2026-07-25 23:57:16.716] Checkpoint saved: -1\n",
+      "[2026-07-25 23:57:16.739]\n",
+      "[2026-07-25 23:57:16.740] Collecting trajectories\n",
+      "[2026-07-25 23:57:35.522] Step: 11\n",
+      "[2026-07-25 23:57:35.523] Collected  2053 states from 237 games, 106.3 states/s. 26.6 states/(s*actor), game length: 8.7\n",
+      "[2026-07-25 23:57:35.525] Buffer size: 8192. States seen: 22568\n",
+      "[2026-07-25 23:57:36.054] Losses(total: 1.054, policy: 0.946, value: 0.023, l2: 0.085)\n",
+      "[2026-07-25 23:57:36.056] Checkpoint saved: -1\n",
+      "[2026-07-25 23:57:36.067]\n",
+      "[2026-07-25 23:57:36.068] Collecting trajectories\n",
+      "[2026-07-25 23:57:55.496] Step: 12\n",
+      "[2026-07-25 23:57:55.497] Collected  2053 states from 238 games, 102.8 states/s. 25.7 states/(s*actor), game length: 8.6\n",
+      "[2026-07-25 23:57:55.498] Buffer size: 8192. States seen: 24621\n",
+      "[2026-07-25 23:57:56.010] Losses(total: 1.041, policy: 0.940, value: 0.019, l2: 0.081)\n",
+      "[2026-07-25 23:57:56.011] Checkpoint saved: -1\n",
+      "[2026-07-25 23:57:56.030]\n",
+      "[2026-07-25 23:57:56.030] Collecting trajectories\n",
+      "[2026-07-25 23:58:14.932] Step: 13\n",
+      "[2026-07-25 23:58:14.933] Collected  2054 states from 236 games, 105.7 states/s. 26.4 states/(s*actor), game length: 8.7\n",
+      "[2026-07-25 23:58:14.935] Buffer size: 8192. States seen: 26675\n",
+      "[2026-07-25 23:58:15.440] Losses(total: 1.038, policy: 0.944, value: 0.016, l2: 0.078)\n",
+      "[2026-07-25 23:58:15.442] Checkpoint saved: -1\n",
+      "[2026-07-25 23:58:15.455]\n",
+      "[2026-07-25 23:58:15.456] Collecting trajectories\n",
+      "[2026-07-25 23:58:34.529] Step: 14\n",
+      "[2026-07-25 23:58:34.530] Collected  2048 states from 238 games, 104.5 states/s. 26.1 states/(s*actor), game length: 8.6\n",
+      "[2026-07-25 23:58:34.530] Buffer size: 8192. States seen: 28723\n",
+      "[2026-07-25 23:58:35.098] Losses(total: 1.033, policy: 0.942, value: 0.017, l2: 0.074)\n",
+      "[2026-07-25 23:58:35.099] Checkpoint saved: -1\n",
+      "[2026-07-25 23:58:35.127]\n",
+      "[2026-07-25 23:58:35.128] Collecting trajectories\n",
+      "[2026-07-25 23:58:54.499] Step: 15\n",
+      "[2026-07-25 23:58:54.500] Collected  2049 states from 240 games, 102.6 states/s. 25.7 states/(s*actor), game length: 8.5\n",
+      "[2026-07-25 23:58:54.501] Buffer size: 8192. States seen: 30772\n",
+      "[2026-07-25 23:58:54.978] Losses(total: 1.047, policy: 0.959, value: 0.017, l2: 0.071)\n",
+      "[2026-07-25 23:58:54.980] Checkpoint saved: -1\n",
+      "[2026-07-25 23:58:54.990]\n",
+      "[2026-07-25 23:58:54.991] Collecting trajectories\n",
+      "[2026-07-25 23:59:14.329] Step: 16\n",
+      "[2026-07-25 23:59:14.331] Collected  2052 states from 243 games, 103.5 states/s. 25.9 states/(s*actor), game length: 8.4\n",
+      "[2026-07-25 23:59:14.332] Buffer size: 8192. States seen: 32824\n",
+      "[2026-07-25 23:59:14.812] Losses(total: 1.041, policy: 0.955, value: 0.017, l2: 0.068)\n",
+      "[2026-07-25 23:59:14.813] Checkpoint saved: -1\n",
+      "[2026-07-25 23:59:14.836]\n",
+      "[2026-07-25 23:59:14.837] Collecting trajectories\n",
+      "[2026-07-25 23:59:34.330] Step: 17\n",
+      "[2026-07-25 23:59:34.331] Collected  2051 states from 240 games, 102.5 states/s. 25.6 states/(s*actor), game length: 8.5\n",
+      "[2026-07-25 23:59:34.332] Buffer size: 8192. States seen: 34875\n",
+      "[2026-07-25 23:59:34.845] Losses(total: 1.050, policy: 0.967, value: 0.018, l2: 0.066)\n",
+      "[2026-07-25 23:59:34.848] Checkpoint saved: -1\n",
+      "[2026-07-25 23:59:34.869]\n",
+      "[2026-07-25 23:59:34.874] Collecting trajectories\n",
+      "[2026-07-25 23:59:53.996] Step: 18\n",
+      "[2026-07-25 23:59:53.997] Collected  2051 states from 239 games, 104.3 states/s. 26.1 states/(s*actor), game length: 8.6\n",
+      "[2026-07-25 23:59:53.999] Buffer size: 8192. States seen: 36926\n",
+      "[2026-07-25 23:59:54.497] Losses(total: 1.047, policy: 0.965, value: 0.018, l2: 0.063)\n",
+      "[2026-07-25 23:59:54.500] Checkpoint saved: -1\n",
+      "[2026-07-25 23:59:54.520]\n",
+      "[2026-07-25 23:59:54.521] Collecting trajectories\n",
+      "[2026-07-26 00:00:13.926] Step: 19\n",
+      "[2026-07-26 00:00:13.927] Collected  2051 states from 237 games, 102.9 states/s. 25.7 states/(s*actor), game length: 8.7\n",
+      "[2026-07-26 00:00:13.928] Buffer size: 8192. States seen: 38977\n",
+      "[2026-07-26 00:00:14.406] Losses(total: 1.052, policy: 0.975, value: 0.016, l2: 0.061)\n",
+      "[2026-07-26 00:00:14.407] Checkpoint saved: -1\n",
+      "[2026-07-26 00:00:14.423]\n",
+      "[2026-07-26 00:00:14.423] Collecting trajectories\n",
+      "[2026-07-26 00:00:33.429] Step: 20\n",
+      "[2026-07-26 00:00:33.430] Collected  2056 states from 238 games, 105.4 states/s. 26.4 states/(s*actor), game length: 8.6\n",
+      "[2026-07-26 00:00:33.432] Buffer size: 8192. States seen: 41033\n",
+      "[2026-07-26 00:00:33.939] Losses(total: 1.044, policy: 0.970, value: 0.015, l2: 0.058)\n",
+      "[2026-07-26 00:00:33.940] Checkpoint saved: 20\n",
+      "[2026-07-26 00:00:33.951]\n",
+      "[2026-07-26 00:00:33.966] learner exiting\n",
+      "learner exiting\n",
+      "actor-2 exiting\n",
+      "actor-3 exiting\n",
+      "actor-0 exiting\n",
+      "actor-1 exiting\n",
+      "evaluator-0 exiting\n",
+      "\n",
+      "Teacher training finished in 6.7 minutes\n",
+      "checkpoints: ['checkpoint--1', 'checkpoint-0', 'checkpoint-20']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Train the teacher model using AlphaZero self-play.\n",
+    "teacher_dir = tempfile.mkdtemp(prefix=\"az_teacher_\")\n",
+    "\n",
+    "teacher_config = az.Config(\n",
+    "    game=GAME_NAME,\n",
+    "    path=teacher_dir,\n",
+    "    learning_rate=1e-3,\n",
+    "    weight_decay=1e-4,\n",
+    "    decouple_weight_decay=False,\n",
+    "    train_batch_size=2**7,\n",
+    "    replay_buffer_size=2**13,\n",
+    "    replay_buffer_reuse=4,\n",
+    "    max_steps=TEACHER_TRAIN_STEPS,\n",
+    "    checkpoint_freq=TEACHER_TRAIN_STEPS,\n",
+    "    actors=TEACHER_ACTORS,\n",
+    "    evaluators=1,\n",
+    "    evaluation_window=25,\n",
+    "    eval_levels=2,\n",
+    "    uct_c=UCT_C,\n",
+    "    max_simulations=SELFPLAY_SIMULATIONS,\n",
+    "    policy_alpha=1.0,\n",
+    "    policy_epsilon=0.25,\n",
+    "    temperature=1,\n",
+    "    temperature_drop=2,\n",
+    "    nn_model=\"mlp\",\n",
+    "    nn_width=TEACHER_WIDTH,\n",
+    "    nn_depth=TEACHER_DEPTH,\n",
+    "    observation_shape=None,\n",
+    "    output_size=None,\n",
+    "    verbose=False,\n",
+    "    quiet=True,\n",
+    "    nn_api_version=\"nnx\",\n",
+    ")\n",
+    "\n",
+    "# Pin self-play to CPU: the forked actor processes cannot share an accelerator.\n",
+    "_prev_platforms = os.environ.get(\"JAX_PLATFORMS\")\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "_t0 = time.time()\n",
+    "try:\n",
+    "  az.alpha_zero(teacher_config)\n",
+    "finally:\n",
+    "  if _prev_platforms is None:\n",
+    "    os.environ.pop(\"JAX_PLATFORMS\", None)\n",
+    "  else:\n",
+    "    os.environ[\"JAX_PLATFORMS\"] = _prev_platforms\n",
+    "print(f\"\\nTeacher training finished in {(time.time() - _t0) / 60:.1f} minutes\")\n",
+    "print(\"checkpoints:\", sorted(f for f in os.listdir(teacher_dir) if f.startswith(\"checkpoint\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reload the Teacher Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Teacher reloaded: 338,698 trainable parameters (mlp, width=256, depth=4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build_model(width, depth, path, learning_rate=1e-3, seed=SEED):\n",
+    "  \"\"\"Builds an AlphaZero Model (mlp torso) with the given capacity.\"\"\"\n",
+    "  return model_lib.Model.build_model(\n",
+    "      model_type=\"mlp\",\n",
+    "      input_shape=OBS_SHAPE,\n",
+    "      output_size=NUM_ACTIONS,\n",
+    "      nn_width=width,\n",
+    "      nn_depth=depth,\n",
+    "      weight_decay=1e-4,\n",
+    "      learning_rate=learning_rate,\n",
+    "      path=path,\n",
+    "      seed=seed,\n",
+    "  )\n",
+    "\n",
+    "\n",
+    "# Rebuild teacher architecture and load saved checkpoint.\n",
+    "teacher = build_model(TEACHER_WIDTH, TEACHER_DEPTH, teacher_dir)\n",
+    "teacher.load_checkpoint(TEACHER_TRAIN_STEPS)\n",
+    "\n",
+    "TEACHER_PARAMS = int(teacher.num_trainable_variables)\n",
+    "print(f\"Teacher reloaded: {TEACHER_PARAMS:,} trainable parameters \"\n",
+    "      f\"(mlp, width={TEACHER_WIDTH}, depth={TEACHER_DEPTH})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Batched Forward Pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Batched forward matches Model.inference() on 10 probe states.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def make_batched_forward(model):\n",
+    "  \"\"\"Returns a batched forward function matching Model.inference.\"\"\"\n",
+    "  net = nnx.merge(model._state.graphdef, model._state.params, model._state.batch_stats)  # pylint: disable=protected-access\n",
+    "  net.eval()\n",
+    "  graphdef, state = nnx.split(net)\n",
+    "\n",
+    "  @jax.jit\n",
+    "  def _forward(state, obs, mask):\n",
+    "    net = nnx.merge(graphdef, state)\n",
+    "    logits, values = jax.vmap(net)(obs)\n",
+    "    logits = jnp.where(mask, logits, jnp.finfo(jnp.float32).min)\n",
+    "    return values, jax.nn.softmax(logits)\n",
+    "\n",
+    "  return lambda obs, mask: _forward(\n",
+    "      state, jnp.asarray(obs, jnp.float32), jnp.asarray(mask, bool))\n",
+    "\n",
+    "\n",
+    "def state_features(state):\n",
+    "  \"\"\"Returns observation tensor and legal actions mask for a state.\"\"\"\n",
+    "  return (np.asarray(state.observation_tensor(), dtype=np.float32),\n",
+    "          np.asarray(state.legal_actions_mask(), dtype=bool))\n",
+    "\n",
+    "\n",
+    "# Verify that batched forward pass matches Model.inference().\n",
+    "_teacher_forward = make_batched_forward(teacher)\n",
+    "_probe = [game.new_initial_state()] + [game.new_initial_state().child(a)\n",
+    "                                       for a in game.new_initial_state().legal_actions()]\n",
+    "_obs = np.stack([state_features(s)[0] for s in _probe])\n",
+    "_mask = np.stack([state_features(s)[1] for s in _probe])\n",
+    "_vb, _pb = _teacher_forward(_obs, _mask)\n",
+    "for _i, _s in enumerate(_probe):\n",
+    "  _v, _p = teacher.inference(_obs[_i], _mask[_i])\n",
+    "  assert np.allclose(np.asarray(_p), np.asarray(_pb[_i]), atol=1e-5)\n",
+    "  assert np.allclose(np.asarray(_v), np.asarray(_vb[_i]), atol=1e-5)\n",
+    "print(f\"Batched forward matches Model.inference() on {len(_probe)} probe states.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluate the Teacher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exact minimax solver cache.\n",
+    "_minimax_cache = {}\n",
+    "\n",
+    "\n",
+    "def optimal_value(state, player):\n",
+    "  \"\"\"Returns game-theoretic value of state for player under optimal play.\"\"\"\n",
+    "  key = (str(state), player)\n",
+    "  if key not in _minimax_cache:\n",
+    "    if state.is_terminal():\n",
+    "      _minimax_cache[key] = state.returns()[player]\n",
+    "    else:\n",
+    "      _minimax_cache[key] = minimax.alpha_beta_search(\n",
+    "          game, state=state, maximizing_player_id=player)[0]\n",
+    "  return _minimax_cache[key]\n",
+    "\n",
+    "\n",
+    "def optimal_actions(state):\n",
+    "  \"\"\"Returns all value-preserving actions for current player.\"\"\"\n",
+    "  player = state.current_player()\n",
+    "  best = optimal_value(state, player)\n",
+    "  return [a for a in state.legal_actions()\n",
+    "          if optimal_value(state.child(a), player) == best]\n",
+    "\n",
+    "\n",
+    "# Agent wrappers.\n",
+    "def make_random_agent(seed):\n",
+    "  rng = np.random.default_rng(seed)\n",
+    "  return lambda s: int(rng.choice(s.legal_actions()))\n",
+    "\n",
+    "\n",
+    "def make_optimal_agent(seed):\n",
+    "  rng = np.random.default_rng(seed)\n",
+    "  return lambda s: int(rng.choice(optimal_actions(s)))\n",
+    "\n",
+    "\n",
+    "def make_raw_agent(forward_fn):\n",
+    "  \"\"\"Greedy policy head agent without MCTS search.\"\"\"\n",
+    "  def act(state):\n",
+    "    obs, mask = state_features(state)\n",
+    "    _, policy = forward_fn(obs[None], mask[None])\n",
+    "    return int(np.argmax(np.asarray(policy[0])))\n",
+    "  return act\n",
+    "\n",
+    "\n",
+    "def make_mcts_agent(model, seed, simulations=EVAL_SIMULATIONS):\n",
+    "  \"\"\"AlphaZero agent with MCTS search.\"\"\"\n",
+    "  bot = mcts.MCTSBot(\n",
+    "      game,\n",
+    "      uct_c=UCT_C,\n",
+    "      max_simulations=simulations,\n",
+    "      evaluator=evaluator_lib.AlphaZeroEvaluator(game, model),\n",
+    "      solve=True,\n",
+    "      random_state=np.random.RandomState(seed),\n",
+    "  )\n",
+    "  return lambda s: int(bot.step(s))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sanity - optimal vs optimal:   0W  20D   0L   (score 0.500)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def play_matches(agent_a, agent_b, n_games):\n",
+    "  \"\"\"Plays n_games alternating seats and returns (wins, draws, losses) for agent_a.\"\"\"\n",
+    "  wins = draws = losses = 0\n",
+    "  for g in range(n_games):\n",
+    "    seat_a = g % 2\n",
+    "    state = game.new_initial_state()\n",
+    "    while not state.is_terminal():\n",
+    "      actor = agent_a if state.current_player() == seat_a else agent_b\n",
+    "      state.apply_action(actor(state))\n",
+    "    reward = state.returns()[seat_a]\n",
+    "    wins += reward > 0\n",
+    "    draws += reward == 0\n",
+    "    losses += reward < 0\n",
+    "  return wins, draws, losses\n",
+    "\n",
+    "\n",
+    "def format_wdl(record, n_games):\n",
+    "  w, d, l = record\n",
+    "  return f\"{w:>3}W {d:>3}D {l:>3}L   (score {(w + 0.5 * d) / n_games:.3f})\"\n",
+    "\n",
+    "\n",
+    "# Verify game evaluation harness (optimal vs optimal must draw).\n",
+    "_check = play_matches(make_optimal_agent(0), make_optimal_agent(1), 20)\n",
+    "print(\"sanity - optimal vs optimal:\", format_wdl(_check, 20))\n",
+    "assert _check[0] == 0 and _check[2] == 0, \"perfect play must always draw\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  teacher-raw vs random    92W   8D   0L   (score 0.960)   [0.2s]\n",
+      "  teacher-raw vs minimax    0W  97D   3L   (score 0.485)   [0.1s]\n",
+      " teacher+MCTS vs random    90W  10D   0L   (score 0.950)   [11.1s]\n",
+      " teacher+MCTS vs minimax    0W 100D   0L   (score 0.500)   [4.3s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Evaluate teacher variants against random and minimax opponents.\n",
+    "random_agent = make_random_agent(SEED)\n",
+    "optimal_agent = make_optimal_agent(SEED)\n",
+    "teacher_raw_agent = make_raw_agent(_teacher_forward)\n",
+    "teacher_mcts_agent = make_mcts_agent(teacher, SEED)\n",
+    "\n",
+    "teacher_results = {}\n",
+    "for name, agent in [(\"teacher-raw\", teacher_raw_agent),\n",
+    "                    (\"teacher+MCTS\", teacher_mcts_agent)]:\n",
+    "  for opp_name, opp in [(\"random\", make_random_agent(SEED + 1)),\n",
+    "                        (\"minimax\", make_optimal_agent(SEED + 1))]:\n",
+    "    t0 = time.time()\n",
+    "    teacher_results[(name, opp_name)] = play_matches(agent, opp, N_GAMES)\n",
+    "    print(f\"{name:>13s} vs {opp_name:<8s} {format_wdl(teacher_results[(name, opp_name)], N_GAMES)}\"\n",
+    "          f\"   [{time.time() - t0:.1f}s]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Search provides additional playing strength over the raw network outputs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Enumerate State Space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reachable non-terminal positions: 4520\n"
+     ]
+    }
+   ],
+   "source": [
+    "def enumerate_non_terminal_states():\n",
+    "  \"\"\"BFS from initial state to return deduplicated reachable non-terminal states.\"\"\"\n",
+    "  root = game.new_initial_state()\n",
+    "  seen = {str(root): root}\n",
+    "  ordered = [root]\n",
+    "  queue = collections.deque([root])\n",
+    "  while queue:\n",
+    "    state = queue.popleft()\n",
+    "    for action in state.legal_actions():\n",
+    "      child = state.child(action)\n",
+    "      if child.is_terminal():\n",
+    "        continue\n",
+    "      key = str(child)\n",
+    "      if key not in seen:\n",
+    "        seen[key] = child\n",
+    "        ordered.append(child)\n",
+    "        queue.append(child)\n",
+    "  return ordered\n",
+    "\n",
+    "\n",
+    "all_states = enumerate_non_terminal_states()\n",
+    "NUM_STATES = len(all_states)\n",
+    "print(f\"Reachable non-terminal positions: {NUM_STATES}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symmetry-Aware Train/Validation Split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4520 positions -> 627 symmetry classes\n",
+      "class-size histogram: {1: 4, 2: 4, 4: 111, 8: 508}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute board symmetries for Tic-Tac-Toe.\n",
+    "_grid = np.arange(9).reshape(3, 3)\n",
+    "SYMMETRIES = []\n",
+    "for _k in range(4):\n",
+    "  _rot = np.rot90(_grid, _k)\n",
+    "  for _variant in (_rot, np.fliplr(_rot)):\n",
+    "    _perm = tuple(_variant.reshape(-1).tolist())\n",
+    "    if _perm not in SYMMETRIES:\n",
+    "      SYMMETRIES.append(_perm)\n",
+    "assert len(SYMMETRIES) == 8, len(SYMMETRIES)\n",
+    "\n",
+    "\n",
+    "def board_cells(state):\n",
+    "  \"\"\"Returns 9 board cells as a flat string.\"\"\"\n",
+    "  return \"\".join(str(state).split())\n",
+    "\n",
+    "\n",
+    "def canonical_form(state):\n",
+    "  \"\"\"Returns lexicographically smallest board over all 8 symmetries.\"\"\"\n",
+    "  cells = board_cells(state)\n",
+    "  return min(\"\".join(cells[perm[i]] for i in range(9)) for perm in SYMMETRIES)\n",
+    "\n",
+    "\n",
+    "symmetry_classes = collections.defaultdict(list)\n",
+    "for _idx, _state in enumerate(all_states):\n",
+    "  symmetry_classes[canonical_form(_state)].append(_idx)\n",
+    "\n",
+    "class_keys = sorted(symmetry_classes)\n",
+    "_sizes = collections.Counter(len(v) for v in symmetry_classes.values())\n",
+    "print(f\"{NUM_STATES} positions -> {len(class_keys)} symmetry classes\")\n",
+    "print(\"class-size histogram:\", dict(sorted(_sizes.items())))\n",
+    "assert sum(len(v) for v in symmetry_classes.values()) == NUM_STATES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train: 3628 positions from 502 classes\n",
+      "val:   892 positions from 125 classes\n",
+      "No symmetry class appears on both sides of the split.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Split symmetry classes into training and validation sets.\n",
+    "_rng = np.random.default_rng(SEED)\n",
+    "_shuffled = list(class_keys)\n",
+    "_rng.shuffle(_shuffled)\n",
+    "_n_val_classes = int(0.2 * len(_shuffled))\n",
+    "\n",
+    "val_indices = np.array(sorted(\n",
+    "    i for k in _shuffled[:_n_val_classes] for i in symmetry_classes[k]))\n",
+    "train_indices = np.array(sorted(\n",
+    "    i for k in _shuffled[_n_val_classes:] for i in symmetry_classes[k]))\n",
+    "\n",
+    "print(f\"train: {len(train_indices)} positions from {len(_shuffled) - _n_val_classes} classes\")\n",
+    "print(f\"val:   {len(val_indices)} positions from {_n_val_classes} classes\")\n",
+    "\n",
+    "# Verify symmetry classes do not leak between train and validation splits.\n",
+    "_train_forms = {canonical_form(all_states[i]) for i in train_indices}\n",
+    "_val_forms = {canonical_form(all_states[i]) for i in val_indices}\n",
+    "assert not (_train_forms & _val_forms), \"symmetry class present on both sides of the split\"\n",
+    "assert len(set(train_indices) & set(val_indices)) == 0\n",
+    "print(\"No symmetry class appears on both sides of the split.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Teacher Targets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Teacher targets for 4520 positions in 0.08s\n",
+      "policy targets: shape (4520, 9), rows sum to 1\n",
+      "value targets:  shape (4520,), range [-0.298, 1.000]\n",
+      "teacher policy entropy: 0.6432 (irreducible floor of the distillation cross-entropy)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute teacher target outputs for all states.\n",
+    "observations = np.stack([state_features(s)[0] for s in all_states])\n",
+    "legals_masks = np.stack([state_features(s)[1] for s in all_states])\n",
+    "\n",
+    "_t0 = time.time()\n",
+    "_values, _policies = _teacher_forward(observations, legals_masks)\n",
+    "teacher_values = np.asarray(_values)\n",
+    "teacher_policies = np.asarray(_policies)\n",
+    "print(f\"Teacher targets for {NUM_STATES} positions in {time.time() - _t0:.2f}s\")\n",
+    "\n",
+    "assert np.allclose(teacher_policies.sum(axis=1), 1.0, atol=1e-5)\n",
+    "assert np.all(teacher_policies[~legals_masks] < 1e-6)\n",
+    "print(f\"policy targets: shape {teacher_policies.shape}, rows sum to 1\")\n",
+    "print(f\"value targets:  shape {teacher_values.shape}, \"\n",
+    "      f\"range [{teacher_values.min():.3f}, {teacher_values.max():.3f}]\")\n",
+    "\n",
+    "teacher_policy_entropy = float(np.mean(-np.sum(\n",
+    "    teacher_policies * np.log(np.clip(teacher_policies, 1e-12, None)), axis=1)))\n",
+    "print(f\"teacher policy entropy: {teacher_policy_entropy:.4f} \"\n",
+    "      f\"(irreducible floor of the distillation cross-entropy)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Distill into Student Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Student: 3,338 parameters (mlp, width=32, depth=1)\n",
+      "Teacher: 338,698 parameters\n",
+      "Compression: 101.5x fewer parameters\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build student model.\n",
+    "student_dir = tempfile.mkdtemp(prefix=\"az_student_\")\n",
+    "student = build_model(STUDENT_WIDTH, STUDENT_DEPTH, student_dir,\n",
+    "                      learning_rate=DISTILL_LEARNING_RATE)\n",
+    "STUDENT_PARAMS = int(student.num_trainable_variables)\n",
+    "print(f\"Student: {STUDENT_PARAMS:,} parameters \"\n",
+    "      f\"(mlp, width={STUDENT_WIDTH}, depth={STUDENT_DEPTH})\")\n",
+    "print(f\"Teacher: {TEACHER_PARAMS:,} parameters\")\n",
+    "print(f\"Compression: {TEACHER_PARAMS / STUDENT_PARAMS:.1f}x fewer parameters\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch    0  train policy 1.0815 value 0.0609  |  val policy 1.0475 value 0.0580\n",
+      "epoch   50  train policy 0.6676 value 0.0059  |  val policy 0.7076 value 0.0080\n",
+      "epoch  100  train policy 0.6650 value 0.0050  |  val policy 0.7021 value 0.0083\n",
+      "epoch  150  train policy 0.6655 value 0.0049  |  val policy 0.6997 value 0.0081\n",
+      "epoch  200  train policy 0.6613 value 0.0047  |  val policy 0.6985 value 0.0098\n",
+      "epoch  250  train policy 0.6606 value 0.0044  |  val policy 0.6969 value 0.0064\n",
+      "epoch  299  train policy 0.6633 value 0.0045  |  val policy 0.6962 value 0.0071\n",
+      "\n",
+      "Distillation finished in 19.3s\n"
+     ]
+    }
+   ],
+   "source": [
+    "def evaluate_losses(forward_fn, indices):\n",
+    "  \"\"\"Computes policy cross-entropy and value loss against teacher targets.\"\"\"\n",
+    "  values, policies = forward_fn(observations[indices], legals_masks[indices])\n",
+    "  policies = np.asarray(policies)\n",
+    "  values = np.asarray(values)\n",
+    "  targets = teacher_policies[indices]\n",
+    "  policy_loss = float(np.mean(-np.sum(\n",
+    "      targets * np.log(np.clip(policies, 1e-12, None)), axis=1)))\n",
+    "  value_loss = float(np.mean(0.5 * (values - teacher_values[indices]) ** 2))\n",
+    "  return policy_loss, value_loss\n",
+    "\n",
+    "\n",
+    "# Train the student model on teacher targets.\n",
+    "rng = np.random.default_rng(SEED)\n",
+    "history = {\"train_policy\": [], \"train_value\": [], \"val_policy\": [], \"val_value\": []}\n",
+    "\n",
+    "_t0 = time.time()\n",
+    "for epoch in range(DISTILL_EPOCHS):\n",
+    "  order = rng.permutation(train_indices)\n",
+    "  epoch_policy, epoch_value, n_batches = 0.0, 0.0, 0\n",
+    "\n",
+    "  for start in range(0, len(order), DISTILL_BATCH_SIZE):\n",
+    "    batch_idx = order[start:start + DISTILL_BATCH_SIZE]\n",
+    "    batch = az_utils.TrainInput(\n",
+    "        observation=jnp.asarray(observations[batch_idx]),\n",
+    "        legals_mask=jnp.asarray(legals_masks[batch_idx]),\n",
+    "        policy=jnp.asarray(teacher_policies[batch_idx]),\n",
+    "        value=jnp.asarray(teacher_values[batch_idx]),\n",
+    "    )\n",
+    "    losses = student.update(batch)\n",
+    "    epoch_policy += float(losses.policy)\n",
+    "    epoch_value += float(losses.value)\n",
+    "    n_batches += 1\n",
+    "\n",
+    "  student_forward = make_batched_forward(student)\n",
+    "  val_policy, val_value = evaluate_losses(student_forward, val_indices)\n",
+    "  history[\"train_policy\"].append(epoch_policy / n_batches)\n",
+    "  history[\"train_value\"].append(epoch_value / n_batches)\n",
+    "  history[\"val_policy\"].append(val_policy)\n",
+    "  history[\"val_value\"].append(val_value)\n",
+    "\n",
+    "  if epoch % 50 == 0 or epoch == DISTILL_EPOCHS - 1:\n",
+    "    print(f\"epoch {epoch:>4d}  train policy {history['train_policy'][-1]:.4f} \"\n",
+    "          f\"value {history['train_value'][-1]:.4f}  |  \"\n",
+    "          f\"val policy {val_policy:.4f} value {val_value:.4f}\")\n",
+    "\n",
+    "print(f\"\\nDistillation finished in {time.time() - _t0:.1f}s\")\n",
+    "student_forward = make_batched_forward(student)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEIAAAGNCAYAAAAVRNS/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAA9lBJREFUeJzs3Xd8k9X+B/DPk9Gke7eMli17T5E9ZMhGRGQ4EBw/vO4rol4VB1wUxxURF6jABUQFroKIyt7IllE2dADdbTrTJM/5/fE0aUObkJa0aenn/Xrxojk553nOc5I2J9/nDEkIIUBEREREREREVAOoPF0BIiIiIiIiIqLKwkAIEREREREREdUYDIQQERERERERUY3BQAgRERERERER1RgMhBARERERERFRjcFACBERERERERHVGAyEEBEREREREVGNwUAIEREREREREdUYDIQQERERERERUY3BQAgREVEFePHFF6HX62+aVhVVRD1dbY+KaqPq0vZERERU8RgIISIiKhQVFQVJkmz/fHx80KFDByxYsACyLHu6euXyzjvv2F2TXq9H7dq10b9/f8ydOxeJiYluO9dTTz0FPz8/tx2vup3fEetrcPToUU9XhYiIiMBACBERkZ1u3bpBCAEhBC5cuIA+ffrg6aefxiuvvHLLx54/fz7y8/PdUMuyO3LkCIQQyMrKwl9//YVp06Zh5cqVaN68OX799dcKr6cnr70qnJ+IiIiqDgZCiIiIHKhduzY++ugjNGvWDJ9++inMZrOnq3TLtFotoqKiMHHiRBw4cABNmzbFfffdhytXrni6akRERESVgoEQIiIiJyRJQtOmTZGTk4O0tDQAwB9//IG+ffvCz88PPj4+6N69O9atW3fTYzlap+Lvv//G+PHjERkZCR8fH3Tq1AnLli2DEAIffPABJEnCiRMnSpRbsGABJEnC4cOHy3Vter0e//73v5Gbm4tPPvnEaT3Pnz+PCRMmoE6dOvDx8UGbNm0wZ84c5OXlAQCGDx+OhQsXIicnx24qTnx8vNNrd8X8+fPtjhkYGIi+ffti06ZNtjzlPb8rr+W0adMQFhaGrKwsPPzwwwgMDERQUBAeeughZGdnl+uabiSEwMcff4xWrVpBr9cjNDQUY8eOxenTp+3y/fbbb+jduzdCQkIQHByMnj17Ys2aNWXOQ0REVJMxEEJEROSEEAJnz56Fj48PQkJCsG7dOgwZMgSNGzfGqVOncOHCBfTo0QNjxozB4sWLy3z8Xbt2oWvXrsjKysKmTZuQlJSEr7/+Gn/88QcuXbqEqVOnwtvbG5999lmJsp9//jnat2+Pjh07lvv6evXqBb1ej+3btzvMI4TA4MGDkZKSgm3btiEtLQ2rV69GXl4efvnlFwDA+vXrMWPGDPj6+tqmFgkhEBUVVe66Wb344ou241ksFhw/fhxt2rTByJEjcezYsXKfvyyvpRACTz31FCZMmID4+HisXLkSa9aswcsvv3zL1wcAM2bMwMyZM/HUU0/h6tWr2LlzJ1JSUnDnnXciJiYGAHDixAmMHDkSPXr0QExMDOLj4zF//nysXLnSttaLK3mIiIhqOgZCiIiIHLh+/TpeeOEFnDlzBv/3f/8HjUaDF154AS1atMDXX3+NevXqoXbt2pg/fz769OmDmTNnwmg0lukc//d//4e6devi559/Rvv27eHn54cOHTpg6dKlaNSoEYKDgzFhwgQsX77cbvTBtm3bcOrUKTz66KO3dI0ajQa1atXC1atXHeaJjY3FxYsX8eCDD6Jp06bQ6/Vo0aIF3n77bYwfP/6Wzl9WKpUK9evXx4IFCxAREYFvv/223Mcqy2uZlpaG0aNHY8iQIfD398fQoUMxZcoULF68+JYX0j1z5gw+//xzPPXUU3jyyScREhKCli1bYu3atbBYLHjttdcAALt374bJZMJzzz2HiIgI+Pr64s4778QPP/yAyMhIl/MQERHVdAyEEBERFbN//37btIqGDRti8+bN+PDDDzFv3jxcvnwZFy9exJgxYyBJkl25cePGITU1tUw7g8TFxeHvv//GfffdB61W6zDfjBkzkJWVhWXLltnSPvvsM+j1ekyaNKnM13gjIUSJ6ymudu3aiIiIwFtvvYXly5cjOTn5ls9ZFtnZ2Zg1axaaN28OvV5vN+3l/Pnz5TpmWV9LSZIwdOhQu3ytW7dGfn6+0yCSK7Zu3QohBMaOHWuXHhoair59+2Lz5s0AgLZt2wIAHnroIfz555+2aUnFuZKHiIiopmMghIiIqJjiu8bk5eXh2LFjeO6556BSqZCamgoAqFWrVoly1rSUlBSXz5WUlAQAqFu3rtN8nTp1QteuXbFo0SIAykiVdevWYcyYMQgODnb5fKUxm81ITExEnTp1HObx8vLC77//jmbNmmHatGmIiIhA69atMWfOnErZiWXChAn48ssv8d577+Hq1auwWCwQQqB58+YwmUzlOmZZX8vg4OASa4wEBAQAADIyMspVB1frkpGRAYvFgu7du2PlypVISkrCoEGDbGul/Pjjj7b8ruQhIiKq6RgIISIiclFISAgAlLrWgjUtLCzM5eOFh4cDABISEm6ad8aMGfj777+xa9cufPXVVzCZTLc8LQYAduzYgfz8fPTt29dpvnbt2mHDhg3IyMjAzp07cffdd+O1117Ds88+e8t1cCY1NRUbNmzAM888g5EjRyIkJAQqlQqyLN/STjdlfS2djZi5VTerS1BQENRqNQAlKHTo0CGkpKTgxx9/hE6nw3333We3wKsreYiIiGoyBkKIiIhc1LBhQzRs2BDr1q2DEMLuuZ9++gkhISFo3769y8erV68e2rRpgx9++OGmIxvuv/9+hIWFYcGCBfjqq6/QsGFD9O/fvzyXYZOfn49Zs2bBx8cHTz/9tEtl9Ho9evbsiY8++gh33XUXduzYYXvO19cXBQUFt1SnG1kDEDqdzi79xx9/LDHtoyznd/dreSusr+PatWvt0tPS0rBt2zYMGDCgRJmQkBCMHDkSP/30EwDYvQ5lyUNERFQTMRBCRERUBu+//z5OnDiBxx9/HHFxcbh+/TpeeuklbN26Ff/+979LfGG/mc8++wwJCQkYNWoUjh07hpycHBw9ehQPPfQQLl68aMun0+kwdepUrF69GnFxcXjkkUfKNUrBbDYjISEBK1euRNeuXXHu3DmsWbMG0dHRDsvs27cP48ePx+bNm5GcnIy8vDxs3LgRx48fR79+/Wz5WrduDZPJhI0bN8JisZS5bqUJCQlBjx49sHDhQvz111/IysrC//73P3z66ado0aKFXd6ynt/dr2V5NWvWDI899hg++eQTfPnll0hPT8fp06dx7733AgDeeustAMo2wi+99BIOHz6M7OxspKWl2bY9to7ocSUPERFRTcdACBERURnce++92LhxI2JiYtC8eXM0atQIO3bswI8//ojp06eX+Xg9e/bEvn374O3tjf79+yMiIgLTpk3DwIED0bBhQ7u8Tz75JFQqFVQqFR5++OEynadDhw6QJAm+vr7o1KkTvvzySzzwwAOIiYnB4MGDnZbt0qUL7r//frz33nto1aoVIiIi8NJLL+HVV1/FRx99ZMv3wAMP4JFHHsGUKVOg1WptC5requ+//x5du3bF4MGDERUVhaVLl+L777+Hl5eXXb6ynt/dr+XNWF+DG//t27cPixYtwpw5c/Dxxx+jVq1auOuuuxAYGIi9e/eiZcuWAIDp06cjMjISjz/+OGrVqoWmTZvi999/x9q1azFy5EiX8xAREdV0krhxPCgRERFVScnJyahbty4GDBiAjRs3ero6RERERNUSR4QQERFVE2vWrIHJZKqQ0QpERERENQVHhBAREVUDCQkJGDBgADQaDY4fPw6VivcyiIiIiMqDvSgiIqIqrn379mjYsCECAwPx/fffMwhCREREdAs4IoSIiIiIiIiIagzeUiIiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQIiIiIiIiIqoxGAghIiIiIiIiohqDgRAiIiIiIiIiqjEYCCEiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQIiIiIiIiIqoxGAghIiIiIiIiohqDgRAiIiIiIiIiqjEYCCEiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQIiIiIiIiIqoxGAghIiIiIiIiohqDgRAiIiIiIiIiqjEYCCEiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQqnG+/fZbSJKE8+fPO03zRD2qkh9++AEBAQFITU2tsHOcPHkSAwYMQEBAACRJwo8//lhh56Kqb/HixYiMjITBYPB0VYiIKsSQIUPQuXPnGnduV9x777249957PV0NchO9Xo9nn33W09W4ZXfffTcefvhhT1eDKgADIVQtDBkyBJIk2f7p9Xo0a9YMr732GnJzcz1dvduO0WjEzJkz8eyzzyI0NLTCzjNp0iQIIRAbGwshBMaNG4fhw4ejdevWFXbOmiIjIwOSJOHf//63p6visoceeggBAQF49913PV0VIqrhRo4cCZ1Oh5SUFId55syZA0mSsHXr1kqs2e1px44dWLduHWbPnl3iubNnz2L06NEICgqCn58f+vbti71797p03DfffNOu/1j83/Xr1919GXQbeuedd7B06VIcOnTI01UhN2MghKoNX19fCCEghMC1a9fw1FNPYc6cORg/fvwtH/vhhx+GEAJNmjRxQ02rv5UrVyI2Nhb/93//V2HnMBgMOHbsGEaMGIGgoKAKOw9VHxqNBo8//jgWLlzIUSFE5FHTp09HQUEBli9fXurzQggsWbIETZo0Qd++fSu3crehOXPmoG/fviVuhMTFxaFnz54wmUw4ceIE4uLi0LJlS/Tv3x8HDx50+fhZWVm2PqT1X61atdx9GXQb6tatGzp27FitbiyRaxgIoWopODgY//jHPzB69Ghs2LAB586d83SVbiuff/45Bg4cWKGdhOTkZACAt7d3hZ2Dqp+JEyciNzcXy5Yt83RViKgGu+eee1CnTh0sXry41Oe3bt2KCxcuYNq0aZAkqZJrd3u5dOkSfv/9d0yZMqXEc2+//Tays7OxbNkyREVFITg4GAsWLEDdunXxz3/+0wO1pZpo8uTJWLduHUcR3WYYCKFqrXnz5gCUOwYAcPz4cYwaNQohISHQ6/Vo06YNFi5cCCGE0+M4Wq8jISEBjz/+OOrVqwe9Xo+WLVvivffeg9FoxKZNmyBJElatWlXieFu3boUkSVi6dGmZr8mVa0hLS8OMGTNQv359eHt7o2nTpnj22WfthvC6kqc0ycnJ2L9/P/r371/iOVePebNreOKJJ2yjb5588klIkoSwsDC0bt0aGzZswMmTJ21DVzUazU3bbOfOnRg2bBhCQ0Ph5+eHnj17YsOGDbbnBw4ciM6dOyM2NhYjR45EQEAAhg8fDgDIzs7Giy++iAYNGsDLywt169bF448/XuKavvjiC7Rv3x7+/v6oVasWhg8fjv3795c5jyMWiwUffvgh2rRpA71ej+DgYNx77712Qb7r169DkiR8/PHH2LBhgy1vy5Yt8b///c+W7+jRowgODgYAzJo1y9aW1jmuxY+zdu1atG3bFl5eXrb38tGjRzFy5EgEBwdDr9ejbdu2WLRokV1958+fD0mSkJCQgKeffhphYWHw8/PD6NGjcenSJVu+DRs2OFz/5Y8//oAkSVixYoUtrU6dOmjevDl+/vlnl9qNiKgiqNVqPPLIIzhx4kSpf8cXL14MjUaDhx56CIAystT6t1alUiEsLAwjR47E8ePHb3quqKgoTJ48uUT6ww8/XOoNiT///BMDBw5EYGAgvL290aVLF7vPgLL67rvv0LFjR3h7eyMwMBCDBw8ucc179+7F4MGDER4eDn9/f3Tp0gXffPMNZFkuU57SrF+/HkKIUvsda9asQZ8+fRASEmJLU6vVGDlyJLZv3267qVIRjh07Bh8fH0yaNMku/a+//oJOp8Ojjz7qtLyr7fHBBx+gUaNG8Pb2Rrdu3bBnzx5MmzYNYWFhdvnK8j5x9f145513om/fvrhw4QKGDh0Kf39/TJgwAQBgMpkwd+5ctGzZEnq9HiEhIbj//vtx+fJlu2MkJiZi8uTJCAoKQlBQEB588MEyjep05Tznz5+HJEn4+uuvsXLlSrRq1QparRbr16/Hxx9/DEmSEBcXh5deegm1a9e2C04uWbIEHTp0gLe3N4KCgjB06FD89ddfdnXo3LkzBg4ciLNnz2LIkCHw8/Oza+v+/fvDbDZj48aNLl8XVQOCqBoYPHiw8PX1LZE+duxYAUCcPXtWHD9+XPj6+or+/fuLU6dOidTUVPHJJ58IjUYjnnvuOVuZb775RgAQ586dc5p2+fJlERkZKdq1aye2b98uDAaDOH36tHj55ZfFxo0bhSzL4o477hC9evUqUa9x48aJgIAAkZOT4/CaSjunq9cwfPhw0bRpU3Ho0CGRl5cnLl68KBYsWCDmzZtXpjylWbNmjQAgNm/eXOI5V47p6jWcO3dOABCLFi2yO8ewYcNEq1atnNaxuO+//16oVCrx4IMPitOnT4usrCyxZ88eMWzYMGE2m4UQQgwYMEC0atVK3HPPPWLnzp0iJSVFLF++XJhMJnHXXXeJ8PBwsX79epGZmSm2b98uGjZsKJo1ayYMBoMQQojly5cLlUolvv32W5GZmSlSU1PFxo0bxbhx42z1cCWPM/fdd58ICgoSS5cuFWlpaeLixYtizJgxIiwsTMTFxQkhhLh27ZoAIMaNGycee+wxcfnyZZGYmCgmTJggtFqtuHLliu146enpAoCYO3duiXNZjzNq1CjxyCOPiEuXLomTJ0+Kbdu2iSNHjggfHx9x9913i5iYGJGSkiI++ugjoVarxT//+U/bMd5//30BQDzwwAPiu+++ExkZGeLQoUOibdu2IioqSqSmpgohhLBYLKJhw4aiX79+JeoxevRoERQUJPLy8uzSH3roIeHr6yssFotLbUdEVBEuXrwoJEkS06dPt0tPS0sTer1ejBkzptRyBQUF4uTJk2LkyJEiMjJSJCcn254bPHiw6NSpk13+unXrikmTJpU4zkMPPSQiIyPt0pYuXSokSRLPPfecuHLlikhLSxMffvihUKvVYsWKFU6vp7Rzv/vuu0KSJPH222+LpKQkceHCBTFmzBjh5eUlduzYIYRQPjP8/f3F1KlTRXx8vMjNzRWHDx8Wjz76qDh8+LDLeRwZP368CA8PL5EeHx8vAIhnnnmmxHNffvmlACC2bNni9NhvvPGGACAiIiKERqMRtWrVEhMmTBCnT592Ws5qyZIlAoD49NNPhRBCpKSkiHr16ol27dqV+OwqztX2eP3114VarRYff/yxSE1NFadOnRL33HOPGDhwoAgNDbU7ZlneJ8U5ez9269ZNdOrUSQwZMkTs27dPJCUliRUrVgiLxSKGDRsmwsLCxKpVq0R6ero4d+6cGDp0qKhdu7ZITEwUQgiRl5cnWrVqJRo2bCh27NghMjMzxbp168QDDzwgdDpdqa9dca6ex9pnHD16tHjyySfFlStXxJEjR8SePXvERx99JACIiRMnisWLF4vU1FTxxRdfCCGEmD17tlCpVGLOnDkiKSlJnDt3TowcOVLodDqxZ88eWz06deokunTpIoYMGSIOHDggkpKSxMqVK+3q6ePjIx5++GGn10PVCwMhVC3cGAhJT08XCxcuFJIkiSFDhgghhBg5cqQICAgQ6enpdmVnzJghVCqVuHDhghDC9UDIhAkThK+vr7h69arDen3wwQcCgDhx4oQt7erVq0Kj0YjHH3/c6TWVdk5Xr8HPz8/uS2lpXMlTmo8//lgAEKdOnSrXMV29BncEQvLy8kR4eLjo3bu303wDBgwQAMTu3bvt0lesWCEAlOg87ty50y6IMG3aNBEdHe30HK7kcWTDhg0CgPjmm2/s0nNyckRkZKSYMWOGEKIogNGqVSshy7ItX1JSklCr1WL27Nm2NFcCIY0bNy4RbLjnnntEUFCQyMzMtEt//PHHhVqtFpcvXxZCFAVC3njjDbt8p06dEpIkiddff92WNm/ePAHAruMZHx8v1Gq17dqKe/nllwUAWweIiMhTBg4cKPz9/UV2drYt7ZNPPhEAxK+//uq0rPXv8Ndff21Lu5VASHZ2tggODhajRo0qkXfy5MkiKirK7rPhRjeeOzU1Vej1ejF+/Hi7fPn5+aJu3bqiW7duQggh1q9fLwCIQ4cOOTy2K3kcufPOO0Xbtm1LpB87dqzUzxkhhFi9erUAIFavXu302J9++qn49NNPxYULF4TBYBB//vmnaN26tfDz8xNHjhxxqX5Tp04VXl5eYu/evWLIkCEiMDBQnD9/3mkZV9ojNTVV6HQ68eijj9qlJyUlCR8fH7cFQqxKez9269ZNABBHjx61y/v9998LAOKHH36wS8/IyBBBQUFi5syZQgghvvjiCwFAbN261S7f559/7jCIVZ7zWPuMbdq0KXEMayBk1qxZdunJyclCp9OJiRMn2qXn5eWJWrVqiR49etjSOnXqVKI/f6MGDRqUelOHqi9OjaFqIycnxzbMLzIyEh9//DFmzpxpG3K/efNm9O/fv8TCm+PGjYMsy2Ve1f3XX39Fv379ULt2bYd5HnnkEXh7e+Ozzz6zpX311Vcwm803HTJZGlevoV27dli8eDE+/fRTXLlypdRjuZKnNBkZGQAAf3//ch3T3a+DM3/99ReSk5MxceLEm+YNDQ3FXXfdVaKukiRhzJgxduk9e/ZEZGQkNm/eDEC57ri4ODz55JM4cOAALBZLieO7kqd9+/Z2K9Zbh5/+8ssvUKlUGDt2rF1+Hx8fdO/eHdu3b7dLv+eee+yGfYaHhyMiIgIXL168aTsUN3z4cKhURR8DQghs2bIFAwcOREBAgF3ecePGwWKxYNu2bXbpI0eOtHvcokULNGvWDFu2bLGlPfroo9Dr9XbTa7744gtYLJZSf0+s57a+F4mIPGX69OnIysrC6tWrbWmLFy9GdHQ0Bg8ebEu7evUqHnvsMdSvXx9eXl6QJMk2RfHGabfltWvXLqSnp+O+++4r8dzAgQMRHx9fps+BPXv2ID8/v8Rnj06nw/Dhw3HgwAFkZWWhRYsW0Gq1eOqpp/DLL78gKyurxLFcyeNIRkZGqX0OK2drsNxsfZYZM2ZgxowZaNSoEfz9/TFgwAD8+uuvEELg5Zdfdql+CxcuRIsWLdCvXz/89ttv+Oabb9C4cWOnZVxpj927d8NoNJb4HA0PDy/RXymrsrwf69evj3bt2tml/fLLL/Dy8ipRt8DAQHTu3NnWL9m8eTP8/f1LLBg8evRol+rp6nmsbszn7Lldu3bBaDSWeH/r9XoMGzYMe/futdt5snHjxmjVqpXD4wcEBLBfcpthIISqjeK7xhiNRpw9exZz586Fr68vjEYjcnJySp1La0272doYxRmNRhgMBtStW9dpvuDgYDzwwANYtmwZsrOzYbFY8NVXX6FNmzbo0qVLma6vLNewatUq3HPPPXj11VfRoEEDNGzYEM8995zdNbqSpzTWAEZp8ztvdkx3vw43k5SUBAA3fZ0c5UlNTUVgYCD0en2J52rVqmWr65NPPom5c+fijz/+QLdu3RAcHIzRo0fbzaF2JY8j169fhyzLCAkJgUajgVqthkqlgkqlwrp165CammqXv7TgXHk+oG9sk9zcXOTn55fp9YuMjCyRNzIy0i5faGgoxo8fj++++w65ubkwm834+uuv0aFDB3To0KFEeet7z9ppIyLylNGjRyM8PNy2aOrBgwdx7NgxTJ061RZILigoQN++fbFr1y4sX74cqampkGUZBQUFkCQJJpOpXOcWN6xvZl2o8cEHHyzxWWFdA+rGzwtnrHkd/c0XQiAtLQ2NGjXC+vXrbTcOgoODceedd+Lrr7+21dGVPI4EBQWV2ucIDQ0FAKSnp5d4zvp5V3ztEFdFR0ejY8eO2LVrl0v59Xo9Jk2ahPz8fLRs2RKjRo26aRlX2sPa/o4+R111Y/uW9f1YWv/o+vXrKCgogI+Pj917TZIk/Pnnn7a6p6amllrXiIgIuxstjrh6Hmd1dfTczd7fsizbvbdu1pc0GAzsl9xmGAih24JOp4Ovry8SExNLPGdNu3HRqZsdz9/fHwkJCTfNO2PGDGRlZWH58uX4+eefER8fX67RIGW5hqioKCxbtgypqak4fPgwpk2bhi+//NIuAu9KntLUr18fAEpdGftmx3T363Az4eHhAODS66TVakukhYSEIDMzE/n5+SWeS0xMtNVVrVbj5Zdfxvnz5xEbG4uFCxfiwoUL6NOnj+3Oiit5jh49ard1n3Vx0rCwMOh0OluQwGKxQJZlyLIMIQSuXr1qVzd37VBwY5v4+PhAr9eX6fVzlNfagbWaMWMGMjMzsWLFCqxduxbXrl1z+Hty7do1+Pr6ljgGEVFl8/LywpQpU7B7927ExMTg66+/hkqlwtSpU2159u3bh3PnzuGdd95Br1694O/vD0mScOXKlZsGAQDl7ndpIwZu/Gyz/v1ds2ZNqZ8VQgh07drV5WuzBhEc/R2XJMmWZ9CgQdi9ezfS0tKwYcMG1K9fH9OnT8fChQttZVzJU5r69evj2rVrJdLr1q2LkJAQnDlzpsRzp0+fhiRJaNOmjcvXW15Hjx7F66+/jq5du+L06dN4++23XSp3s/awfsY5+8wtztX3SVnfj6X1j8LCwhAQEICCggK795r1fXb27FnbNVhvShWXlJR000Vyy3IeZ3V19NzN3t8qlcousOHs2LIsIykpydZHptsDAyF02+jfvz+2bNlS4q7CTz/9BJVKhX79+pXpeMOHD8fWrVtL/XAurmPHjujWrRsWLVqEzz77DF5eXqWu6u2Ksl6DRqNBhw4d8Oqrr2LKlCnYs2dPiSkZruQprkePHgCUu16OODvmrb4O1hE+rujWrRvCwsLsdh0piwEDBkAIUWK1/T179uD69esYMGBAiTLR0dGYMmUKFixYAKPRiAMHDpQrT3EjRoyA0WjEunXrynUdpfHx8YEkSS63JaAEWPr164c///wT2dnZds9ZX78bh7/+8ssvdo9jYmJw9uzZEm3XtWtXdO7c2fZ7otfrHU5pOnDgAHr06OHS3SQiooo2ffp0AMCCBQuwcuVKDBo0CPXq1SuRT6fT2T12dee4xo0b4+TJk3ZpKSkpJUYU9u7dGwEBAfj+++/LUn2HevToAb1ej7Vr19qlFxQUYP369ejatWuJKSsBAQEYPHgwVq1aheDgYOzYsaPEcV3JU1zPnj2RkpKC2NjYEs+NGTMG27dvR1pami3NYrHg559/Ru/evW03RMoiPj4ehw8ftvV3nMnIyMC9996LRo0aYcuWLXjxxRfx1ltv4Y8//nD5fI7a46677oJOpyvxOZqSkoI9e/aUOI6r7xOr8r4fAaVfYjAY8NtvvznN179/fxgMhhJTWFzdxcjV85RHz5494eXlVeL9bTQasWHDBnTv3h0+Pj4uHevEiRPIzc1Fr1693F5P8qBKXI+EqNwc7RpT3NGjR+12u0hLSxOffvqp0Gq14umnn7blK8+uMTt27BBZWVkiJibGtmtMcUuXLhUABIASi445Uto5XbmGjIwM0a9fP7F27VoRFxcn8vPzxYEDB0TDhg1ti4a6kseZO++8UwwePNguzdVjuvo6OFos9a233hJeXl7iyJEjLu0aUnzXmJiYGNuuMcOHD7fbNebGxemEUFZS79atm4iIiBAbNmwQBoNB7Ny5UzRq1Eg0adLEtmDoY489Jj744ANx6tQpkZeXJ+Li4sTkyZOFXq+3Lf7qSh5nxo8fL4KDg8VXX30lrl69KrKyssSRI0fEa6+9Jt566y0hRNEipx999FGJ8s2aNSuxgF7Tpk1Fv379RFpaml26s+McOnRI6PV6MWTIEHHmzBm7XX+ef/55Wz7rYqkTJ04Uy5YtExkZGeLw4cOiffv2om7duiIlJaXEsa2r71vLlSYhIUFIkmRboZ+IqCro2bOnkCRJABA//fST3XPZ2dmiTp06olu3buLcuXMiNTVVLFq0SIwfP16o1Wrxwgsv2PKWtljqzz//LACId999V2RkZIgTJ06IMWPGiLvvvrvUXWNUKpX4xz/+Ic6cOSNyc3PFuXPnxJIlS8Tw4cOdXkNp537rrbdsu2okJyeLixcvinvvvVdotVqxfft2IYQQ3333nXjyySfF3r17RUZGhsjMzBRff/21ACA+++wzl/M4Yt2d58YFw4UQ4sqVKyI0NFTcc889Ij4+XqSlpYknn3xS6HQ6sX//fru8r776qgAgdu7cKYQQwmw2i759+4qff/5ZxMfHi6ysLLFlyxbRrl074evr69LCrqNGjRJ+fn62xb5NJpPo1auXCA8PF/Hx8Q7Ludoer732mtBoNOKTTz4RaWlp4vTp02L48OGl7hrj6vukLO/Hbt26iT59+pSov8ViEcOHDxfh4eHiu+++E9euXRMGg0EcOnRIzJw5U7z//vtCCCFyc3NFixYtROPGjcWuXbuEwWAQP//8s5g4caLLu8a4ch5rn/Grr74qcQzrYqnXrl0r8dzrr78uVCqVmDdvnkhOTrbbFWnXrl22fJ06dRIDBgxwWM+PPvpIaDSaUs9B1RcDIVQtuBIIEUKII0eOiBEjRojAwEDh5eUlWrZsKf7zn//YraLuaiBECCHi4uLE1KlTRZ06dYROpxMtW7YU8+bNE/n5+Xb58vPzRVhYmAAgNm3a5NI1OTqnK9ewdetWMW7cOBEVFSW8vb1FkyZNxIsvvmj3hdeVPI58++23Qq1Wl/iD7+oxXbkGR4GQzMxMMWbMGBEYGCgACLVafdP6btu2TQwaNEgEBgYKf39/0bNnT7F+/Xrb844CIUIIYTAYxHPPPSfq1atn21pv2rRpdjuWxMbGipdeekm0bNlS6PV6Ubt2bTFmzBhx4MCBMuVxxmKxiEWLFokuXboIX19f4e/vLzp27CjmzJlj24q2rIGQbdu2ifbt2wsvLy8BQDz00EM3PY4QSjBk2LBhttevVatW4tNPP7V7/ayBkPj4ePHkk0+KkJAQ4evrK0aMGOFwNf3c3FwREhLicHtm63F9fX1FRkaG8wYjIqpE3333nW0b1oKCghLPHz16VPTr10/4+fmJ8PBw8eSTT4qcnByXAiFCKH/7oqKihE6nEz169BBHjhxxuBvIzp07xYgRI0RoaKjQ6XSiadOmYtq0aU53vHB27sWLF4v27dsLnU4n/P39xd133223y1pubq744osvxF133SUCAwNFUFCQ6Natm13gwpU8zgwZMkT079+/1OdOnz4tRowYIQICAoSPj4/o3bu33ZdYqxsDIUIIsWvXLjF+/HgRHR0ttFqtqFu3rpgyZYqIiYm5aZ2sO56tWrXKLv3q1asiMjJS9OjRQ5hMplLLutoesiyL9957T9SvX1/odDrRuXNnsXPnTvHoo4+WCIQI4fr7xNX3o6NAiBBKIOnjjz8WHTt2FD4+PiIwMFB07txZvP/++3af0deuXRMTJkwQAQEBIiAgQEycOFFkZGS4FAhx9TzlDYQIoWy13K5dO9v7e9CgQWLfvn12eW4WCOnUqZMYN27cTa+FqhdJCBcmLxKRU0II1K9fH5Ik4dKlS9V+SH9BQQFatGiBSZMm4a233vJ0dagKmj9/Pv75z38iOTnZ5XVfZFlGdHQ0dDodLly4UGKtE7PZjBYtWmDs2LGYN29eRVSbiIiqoJ07d6Jv3744duwYWrdu7enqeNy0adOwbt06ty4wT+Wzf/9+dO/eHX/99Rc6derk6eqQG1Xvb2tEVcSePXsQFxeHRx99tNoHQQBlcbh58+bh448/LtMK9ETO7Ny5E1evXsW0adNKXfB16dKlyMzMxKuvvuqB2hERkaf06tULY8aMweuvv+7pqhDZ+de//oUHH3yQQZDbEEeEEN0ig8GA++67D/v378f58+fduisKUVVV1hEhmZmZuPfee3H48GFcuHCBW9ARERE5wBEhRBWv+t+6JvKgyZMnIzg4GFeuXMHq1asZBCEqxYQJExASEoKEhASsXr2aQRAiIiIi8iiOCCEiIiIiIiKiGsPjI0J27dqFyZMno3Pnzjh06FCFlSEiIiIiIiIi8mgg5JVXXsHMmTPRoUMHHDp0CFlZWRVShoiIiIiIiIgI8PDUmKysLPj7+yM+Ph7R0dHYunUr+vbt6/YyN5JlGVevXoW/v3+pOxcQERFR2QghkJWVhTp16twWu2dVNPZFiIiI3KssfRFNJdWpVP7+/pVS5kZXr15FdHT0LR+HiIiI7MXFxSEqKsrT1ajy2BchIiKqGK70RTwaCKksRqMRRqPR9tg6CObKlSsICAhwyzlkWUZKSgrCwsJ4J6wUbB/H2DbOsX2cY/s4xrZxzt3tYzAYUL9+fbfcsKgJrO0UFxfn1r5IcnIywsPD+Z4vBdvHMbaNc2wf59g+jrFtnHN3+xgMBkRHR7vUF6kRgZC5c+di9uzZJdKNRiPy8/Pdcg5ZlmGxWJCfn883eSnYPo6xbZxj+zjH9nGMbeOcu9vHesOB0zxcY22ngIAAtwZC8vPzERAQwPd8Kdg+jrFtnGP7OMf2cYxt41xFtY8rfZEaEQiZNWsWnn/+edtja6QoPDzcrZ0PSZIY7XOA7eMY28Y5to9zbB/H2DbOubt99Hq9G2pFREREVPFqRCBEp9NBp9OVSFepVG6PPLn7mLcTto9jbBvn2D7OsX0cY9s45872YRsTERFRdVHley3vvPMOJkyY4OlqEBEREREREdFtwKMjQtavX48333wTJpMJAPD444/D398fjz32GB577DEAwOXLl3HixIkylSEiIs+zWCy2v9WeIMsyTCYT1whxoKzto9VqoVarK6FmRERE7sG+SNXmyb6IRwMh3bt3x+eff14ivU6dOraf//WvfyE7O7tMZYiIyHOEELh+/ToyMjI8Xg9ZlpGVlcUFPEtRnvYJCgpCrVq12J5ERFSlsS9SPXiyL+LRQEhoaChCQ0Od5qlfv36ZyxARkedYOx4RERHw8fHx2Ae/EAJmsxkajYadj1KUpX2EEMjNzUVSUhIAoHbt2pVRRSIionJhX6R68GRfpEYslkpERJXDYrHYOh6eDlqz8+FcWdvH29sbAJCUlISIiAhOkyEioiqJfZHqw5N9EU5UIiIit7HOw/Xx8fFwTagiWF9XT863JiIicoZ9kdubu/oiDIS4gSwL7DibjJ0XM2CyyJ6uDhGRx/Gux+2pur6uOTk5iI+Ph8VicXuZlJQUZGVl3WoVb5ksC2wv7IsUmNkXISKqrp9Z5Jy7XlcGQtxAAHj424P4588XkG00e7o6RETkYUajETExMWX64k3uZ7FYMGPGDISEhKBt27aoVasWVq1a5ZYy27dvR9u2bdG4cWM0bdoUkydPhsFgqKhLcckj7IsQEVEh9kWcYyDEDdQqCWqVEpky8S4MEVG1k5+fj5iYGMiye/6Gnz59Gi1atEB6erpbjkfl895772H16tU4evQo0tLS8O6772Ly5Mk4ceLELZU5cuQIBg8ejAkTJiA1NRXXrl3DiBEjcOHChcq4rFKpVBKsN8kssvBYPYiIqHzYF6lcDIS4iVZdGAixsPNBRFTdnDhxAi1atHDbHX29Xo9mzZpBo+Ga5J60aNEiTJs2DS1atAAAPPbYY2jUqBG+/PLLWyrz2muvoUuXLnjllVdsr/H999+PDh06VODV3JzWelOG03SJiKod9kUqFwMhbqJVK01ZwM4HEVG1YjKZcOXKFQDAuXPnEBMTg6tXryIvLw8xMTG27drOnz+P3NxcWCwWxMTEICYmBhcuXCh1sa6GDRti3bp18Pf3BwC7Y1ksFsTHx8Ns5vSFipSYmIi4uDh0797dLr1Hjx44ePBgucuYTCZs3rwZY8eOhcViQUJCQpVZPFZT2BfhiBAiouqFfZHKx/CQm3gVdj54F4aIqHpJSkrCCy+8AACYNGkSVCoVhg0bhjFjxqBXr1545ZVXsHDhQkRGRmLZsmVo1KgRRo8eDQAoKCjA1atX8dBDD+HTTz+FVqsFoAxH7dChA5KTkxEWFoZDhw6hV69eeO2117Bo0SJ4eXkhOzsb3377LcaOHeupS7+tpaSkAECJrRPDwsKwe/fucpdJSUmB0WjEtWvX0LBhQ5jNZqSmpuL+++/HZ599Bj8/v1KPbTQaYTQabY+td/xkWXbbMGjrNN0Cs8Vtx7ydyLIMIQTbphRsG+fYPs5Vtfax1sf6z9OsdXBWl8TExBJ9kXvuuQdjxoxB7969MWvWLHz22WeIjIzE0qVLS+2LPPjgg3Z9kVOnTqFjx45ISkpCWFgYDh48iN69e+PVV1/F559/buuLfPPNNx7ti7jSPjfmt77fbnzPleU9yECImxRNjakafwCIiKoKIQTyTJW/UJde49qgx7p16+LHH39Ely5dcODAAQQFBQEAdu3aBUAZqnrt2jXb3vUAEBMTY/s5Pj4eAwYMwKJFi/D00087Pde5c+cQHx8PvV6Pd955B9OnT8eIESNsnRZyH5Wq8AbFDXfJCgoKoFary13Gulr9smXLsHPnTjRp0gSXLl2ydVQXLFhQ6rHnzp2L2bNnl0hPTk5Gfn5+Ga7MMetVJSanwB95bjnm7USWZWRmZkIIYXutScG2cY7t41xVax+TyQRZlmE2m20jHjzZF7F+OXe220lkZCRWrVqF7t27Y/fu3ba+iDUI//fffyM2NtauL/L333/bfo6Pj8fgwYOxcOFCPPXUUwBgu3ZrO1gXTT179iwuXboEvV6POXPm4LHHHsPQoUM90hexjk4BXN8Nxmw2Q5ZlpKamlqhzWXZxYyDETbS2ESGejzoSEVUleSYLWr6+qdLPe3L2IHi5oT/2zjvv2HU8rEwmk23Y6t13340//vjjpoGQd999F3q9HgAwefJk/Otf/0JsbCwaN2586xUlO1FRUQCA69ev26Vfv37d9lx5yoSHh0Ov12PChAlo0qQJAGX48eTJk/HTTz85rM+sWbPw/PPP2x4bDAZER0cjPDwcAQEBZby60mkLg3+BQcGIiAhyyzFvJ7IsQ5IkhIeHV4kva1UJ28Y5to9zVa198vPzkZWVBY1GY1sfI7fAjHZvb6n0upycPQhateRSkMEacC9eb2vau+++a5viUpy1L5Kfn4+7774bW7ZswbPPPms7TvHjWY81Z84c2+jFBx98EG+++SauXr3q0b5IWYIwGo0GKpUKoaGhtj6V1Y2PnR7H5ZzklG2NEO4aQ0R0W2nUqJHd44KCAjzxxBP473//i9DQUAQEBCAtLc3hl+vi6tata/vZ2gkpy90Lcp2/vz86deqETZs2YcKECQCU1+7PP/+0C0hYR2RER0e7VEatVqNPnz4lVuFPS0tzGtDQ6XTQ6XQl0lUqldu+ONjWCBFSlfgyUhVJkuTWNr+dsG2cY/s4V5XaR6VSQZIk2z/A9dEGFcHVOhTPd2OZxo0b25V31he5seyNbVE8jzW4kp2d7ZE2EkKU+TWyXktp77eyvP8YCHET610YTo0hIrLnrVXj1FuDK/28eo3KNtzyVtw4jWLBggXYvn07zp8/j+joaADAG2+8gf/973+3fC5yrzfeeANjx45F+/bt0b17d3z44Yfw8vLCE088Ycsza9Ys7Nu3z7Y9ritl3njjDQwcOBDdunVDjx49sH//fnz33XdYtGhRpV9jcdZpuuYqMk+fiKiqYF+EbsRAiJtw+1wiotJJkgQfr8r/uCnLAmnWoZSu7P5x+vRpdO/e3dbxAIAtWyp/uC3d3IgRI/DDDz/gk08+wZdffok2bdpgx44ddouhRkREoF69emUq0717d2zcuBHz5s3DwoULUa9ePaxYscLjC9+qC++EmdkXISKyw74I3YiBEDfhrjFERNVX/fr1odfrsXz5cgwZMgSBgYEO83bv3h0vvPACfvrpJ0RFReGbb77B3r170bp160qsMblq9OjRtpX1SzNnzpwylwGA3r17o3fv3rdYO/fSqqwjQhgIISKqbtgXqVwMhLiJloEQIqJqy9/fH8uWLcNnn32Gr776CkOHDsWkSZPQrFmzEvNNp06ditTUVMyfPx8mkwm9evXCe++9h507d9ry6PV6NGvWzLZQmY+PT4ljaTQaNGvWrEwLexE5oykcnWrh1BgiomqHfZHKJYmqsLlyJTMYDAgMDERmZqbbVmqf/PU+7Dqfig/Ht8XYjtE3L1DDyLKMpKQkREREVIlFlKoSto1zbB/nqlr75Ofn49KlS2jYsKHHP1SFEDCbzdBoNB5dJK2qKk/7OHt9K+Kz9Xbm9vaymHHw34ORl58P87jv0K9dk1s/5m2mqv29rErYNs6xfZyrau3Dvkj14cm+CEeEuAm3zyUiIiKPUanR2XQQUANbTPmerg0REVGV5vmQ3W3CFgjh9rlERERU2SQJZii7Cshmo4crQ0REVLUxEOImXCyViIiIPMkiKQN9ZfPNdxwgIiKqyRgIcROthtvnEhERkeeYwUAIERGRKxgIcRPr1JgCjgghIiIiD5ALR4QIC6fGEBEROcNAiJtw+1wiIiLyJE6NISIicg13jXEHWUb3tHXQqJMhm7h1LhEREVU+i21ECAMhREREznBEiJsMj5uP2drvIBVke7oqREREVAMVBUIKPFwTIiKiqo2BEHdQqSAXblknuGUdEREReYBtjRBOjSEiInKKgRA3saiUzofFzLswREQ10alTp9CgQQOkp6eX+rg0V65cQYMGDXD9+nW3nptqJlmlVX7g1BgiohqJfRHXMRDiJrKkdD54F4aIqGYqKCjAlStXYLFYSn1cGpPJhCtXrsBsNrt8nr///hsNGjSAwWBweG6qmWROjSEiqtHYF3EdAyFuYr0Lw84HEREBQMuWLXHp0iWEhIS49bhGoxFXrlyBLBftUlZR56LqpSgQ4npnloiIbl/sizjGQIib2AIhnBpDRFStyLKMzp07Y8WKFXbp8fHxaNiwIY4ePYrk5GQ0aNAADRo0wB133IFBgwZh7dq1To97/vx59O3bF5mZmba0v//+G8OGDUOrVq1w77334u+//7Yrc7PzxMfHY+TIkQCAtm3bokGDBvjHP/5R6rnOnz+PSZMmoXnz5ujatSvmz59v12E5ePAg7rjjDmzfvh2jRo1C69atMXbsWJw/f77sjUhVgm1qjMy+CBFRdcK+SOX3Rbh9rptwXi4RkQNCAKbcyj+vxtulbCqVCl27dsWSJUswceJEW/rKlSshhEC7du0gyzK2bdsGQBn6uWfPHkyZMgU//fQTBg8eXOpxbxwimpGRgf79+2PEiBF45513cPr0aTz66KN2ZUJCQpyep1atWvjiiy8wcuRIrF+/HgEBAfD19UVCQoLduQwGA3r16oW+ffviv//9L2JjY/HEE08gPT0d7777LgAgPz8fV65cwdNPP40PPvgAkZGReO211zB27FgcO3YMkiS53NRUNYjC9crAESFERPbYFwHAvkhxDIS4ieDUGCKi0plygTl1Kv+8sxIAlc6lrJMmTULv3r1x9epV1Kmj1PW///0vJk2aBEmSoFar0aBBA1v+pk2b4uTJk1iyZInDzseNvvjiC/j5+eGrr76CWq1Ghw4dkJCQgJdeesmW52bn0Wg0qF27NgCgXr16CAoKAgAkJCTYnevzzz+HWq3G0qVLodVq0alTJ2RnZ+Oxxx7DzJkzERAQYFev7t27AwDmzJmDNm3a4Nq1a7Z2oOqjaEQIb8oQEdlhXwQA+yLFcWqMmwjbiBAGQoiIqpsePXqgfv36WLVqFQDg5MmTOHbsGCZPnmzLs3r1agwZMgQtWrRAgwYNsHjxYly+fNnlcxw9ehR33XUX1Gq1La13794l8t3qeYqfS6vV2tL69++P/Px8nDlzxi5vmzZtbD/XqlULgDIslqof64gQiX0RIqJqh30RRWX1RTgixE2EmoEQIqJSaX2AV65W/nk13kAZVi6fOHEili9fjueffx7Lly9Hx44d0aJFCwDAmjVr8Oijj+Ljjz9Gly5dEBAQgIULF+KPP/5w+fhGoxGBgYF2aXq93u6xO84DKENNfX197dJ0Op3tueKKd4ashBBlOh9VDUKy9kU4NYaIyA77IgDYFymOgRB3UbHzQURUKkkCvHxvns/dyvgBOnnyZLz77rs4deoUVq5ciWeeecb23G+//YaRI0fazaONj48v0/HvuOMObNmyxS7t+PHjdo9dOY+1s+Csg9C0aVNs3LjRLu3YsWO2etDtyXZThlNjiIjssS8CgH2R4jg1xk2E2gsAIHGldiKiaql58+bo2LEjZsyYgfj4eDzwwAO25+rWrYuDBw8iLS0NALBu3Tr88MMPZTr+tGnTcOTIEXzzzTcAlLm077zzjl0eV85jnS977tw5h+d67LHHEBMTg88++wxCCKSmpmLWrFkYN26cbcgp3X6s03RVDIQQEVVL7ItUHgZC3EXNXWOIiKq7yZMnY9u2bRgwYIDdh/Szzz6LunXrok6dOggODrZ9kJfFHXfcga+//hrPPfccgoKC0L59e9x77712eVw5T2RkJGbMmIHevXujfv36+Mc//lHiXI0aNcKKFSswZ84cBAUFoXbt2oiIiMCiRYvKVGeqZqy7xsgcnUpEVF2xL1I5JFEDJwIbDAYEBgYiMzPTbrXaW5H+1SgEJ2zDv3VP4+VZb7vlmLcTWZaRlJSEiIgIqFSMvxXHtnGO7eNcVWuf/Px8XLp0CQ0bNiwx57SyCSFgNpuh0Whc3n7NaDTi2rVrCAoKsq2CXlxmZiZMJhPCwsJgMBiQnZ1tuytSUFCAq1evol69elCpVCUeWxUUFCAjIwMREREwm82Ij49HdHS03fxYZ+exys/PR1JSEry9vREYGFjquYQQSExMhK+vL/z9/UuUj4uLQ+PGjW1lZFlGbGws6tSpAy8vrxLX7+z1rYjP1ttZRbRXzOLpaB63GuuDp2D4M5+65Zi3k6r297IqYds4x/Zxrqq1D/si7Iu48tnKNULcRFJzOCoRUXWn0+nstoy7UfEFxgICAuw+ZL28vOzK3vi4eHpERAQAQKPRlJrH2Xms9Ho96tWrZ3tc2nEkSXI4/NR6rcU7ZiqVyun1UxXHqTFERNUe+yKV0xfxfMjudsE1QoiIiMiTCm/KSIJTY4iIiJxhIMRNpMJACO/CEBERkUfYRoQwEEJEROQMAyFuImmsI0LY+SAiIqLKx2m6RERErmEgxE1UhYEQNTsfRERE5AnWqTG8KUNEROQUAyFuYh0RohIMhBAR1cANyWoEvq5VW1FfhIEQIiJ+Zt2e3PW6MhDiJqrCuzBaWGCR+UtHRDWTVqv8LczNzfVwTagiWF9X6+tMVUzhGiFq3pQhohqMfZHbm7v6Itw+101UWuUujBZmmCwy1Cr1TUoQEd1+1Go1goKCkJSUBADw8fGx2xKtMgkhYDabodFoPFaHqqws7SOEQG5uLpKSkhAUFAS1mp9xVRFHhBARsS9SnXiyL8JAiJtY1wixBkL0WnYSiahmsu4Vb+2AeIoQArIsQ6VSsfNRivK0T1BQkO31papHUivdOjUDIURUw7EvUj14si9SJQIhp0+fxpkzZ9CzZ0+EhYW5VObIkSNITExEq1atEB0dXcE1vDmVRgcA0MAMk4VTY4io5pIkCbVr10ZERARMJs8N0ZdlGampqQgNDYVKxZmgNypr+2i12mo5EiQxMRErVqxAYmIi2rRpg/vvvx8ajfPuz83K/PDDD9i9e7ddmdq1a2PmzJkVcg2usi3czkAIEdVw7ItUD57si3g0ELJ9+3a88cYbuHz5Mq5cuYKtW7eib9++TstkZWVh+PDhOH36NJo1a4ZDhw7hpZdewptvvlkpdXbEOhzVS7LAZJE9WhcioqpArVZ79IuzLMvQarXQ6/XsfJSiJrTPuXPn0KNHD3To0AFdu3bFG2+8gW+++QabNm1y+N50pczmzZuxb98+PPzww7Zyrt7IqUiSmoEQIqLi2Bep2jzZPh4NhCQnJ+ONN97AHXfc4fKojtdeew0JCQk4c+YMgoODsWXLFgwYMAB9+/a9aRClQqmLpsYUmBkIISIi8rSZM2eiefPm2LhxI1QqFaZPn44mTZpgxYoVmDJlyi2VadKkCZ599tlKuhLXqDTKwnFcI4SIiMg5j4alxo0bh379+rmcXwiB5cuX49FHH0VwcDAAoH///ujUqROWLVtWUdV0jW3XGDNHhBAREXmYyWTCr7/+iokTJ9ruMtWrVw99+/bFunXrbrnMhQsX8Morr2DevHnYs2dPRV6Ky6TCvoiGgRAiIiKnqsQaIa6Kj49HWloa2rVrZ5fevn17HDt2zGE5o9EIo9Foe2wwGAAoQ3Fk2T1BCyEpTamFGUaTxW3HvV3IsmxbDIfssW2cY/s4x/ZxjG3jnLvbp6q1c2xsLIxGIxo3bmyX3rhx4xLre5S1jCRJCAkJgV6vx8WLF/Hmm29i2rRpWLBggcP6VEZfxBoIUcNc5V6PqoB/Exxj2zjH9nGO7eMY28Y5T/ZFqlUgJDMzEwBso0GsQkNDkZGR4bDc3LlzMXv27BLpycnJyM/Pd0vddDl5CAbgBTMSU1IRrMpzy3FvF7IsIzMzE0IIzo+7AdvGObaPc2wfx9g2zrm7fbKystxQK/fJzc0FAPj7+9ulBwQE2J4rb5mXX34Z9evXtz2eMGEC+vfvj1GjRmHgwIGlHrsy+iI5ucpx1MLs8Z0SqiL+TXCMbeMc28c5to9jbBvnPNkXqVaBEC8vZR2OGzsw2dnZ0Ol0DsvNmjULzz//vO2xwWBAdHQ0wsPDERAQ4Ja6iURlkTQNLNAHBCIiIvgmJWoWWZYhSRLCw8P5R+AGbBvn2D7OsX0cY9s45+720ev1bqiV+1iDGTfeKElPTy8R6ChrmeJBEADo168foqOjsWvXLoeBkMroi+B6KABldGpERIR7jnkb4d8Ex9g2zrF9nGP7OMa2cc6TfZFqFQipV68e1Go14uLi7NLj4uLQsGFDh+V0Ol2pgRKVSuW2N6RcuH2uVjLDLINv9FJIkuTWNr+dsG2cY/s4x/ZxjG3jnDvbp6q1cb169eDn54eYmBgMGTLElh4TE4OWLVu6rYxVQUGB0y0aK6MvotYqHUANLFXu9agq+DfBMbaNc2wf59g+jrFtnPNUX6TKvxpHjx7Fli1bACgRnn79+uGnn36yPZ+eno7Nmzdj6NChnqqionBerhfMMFmEZ+tCRERUw6lUKtx777349ttvbVNPjh8/jt27d2P8+PG2fN9//z3mzZvnchmz2Yzt27fbnWvFihVITEzEoEGDKuPSHFJrrWuEWCAE+yJERESOeHRESGxsLA4fPozU1FQAwK5du5CRkYHmzZujefPmAIBPP/0U+/btw4kTJwAoc2x79eqF6dOno3v37vjiiy/QuHFjTJ061WPXAcBu+1zuGkNEROR5//73v9GnTx906dIFHTp0wK+//orJkydj1KhRtjx//PEH9u3bh5kzZ7pURpIkzJkzB7NmzUKrVq0QGxuLHTt24O2330afPn08cp1Wao3SF/GCGRZZQKOWPFofIiKiqsqjgZDz58/j22+/BQCMGjUKBw8exMGDBzFhwgRbIKRDhw7w9fW1lencuTMOHjyIL774Aps2bcKIESPw9NNPe35usqpo+9wCBkKIiIg8rlatWjh69Cg2btyIxMREPPbYY+jZs6ddngkTJqBv374ul1Gr1di0aRMOHz6MI0eOYOjQoVi8eDGioqIq67IcUmuVqTcamGGWBTRqD1eIiIioivJoIKR///7o37+/0zwzZswokdaqVSt88sknFVWt8lEXBUI4IoSIiKhq8Pb2xtixYx0+X9ripjcrAwAdO3ZEx44db7l+7qTWWPsiFphlTo0hIiJypMqvEVJtWKfGSBYGQoiIiKjSWafGaGGGmX0RIiIihxgIcZfiI0LMvAtDRERElUutVQIhGo4IISIicoqBEHcptlgq1wghIiKiyiYV9kU0kgyz2eLh2hAREVVdDIS4iy0QwqkxRERE5AGFo1MBwFRg9GBFiIiIqjYGQtxFraw768XFUomIiMgTigVCZLPJgxUhIiKq2hgIcZdiU2NMZgZCiIiIqJKpigIhFnO+BytCRERUtTEQ4i6FgRCVJGDiXRgiIiKqbCqN7UeziX0RIiIiRxgIcRd18bswBR6sCBEREdVIkgQT1AA4NYaIiMgZBkLcpXBECABYChgIISIiospnhjIqxGLiYqlERESOMBDiLnbzctn5ICIiospnDYTIFt6UISIicoSBEHeRJFisw1FN7HwQERFR5TMX9kUsXCOEiIjIIQZC3EguHBUic40QIiIi8gCLZB0RwtGpREREjjAQ4ka2zgenxhAREZEHWKfGCC6WSkRE5BADIW5kHRFiYeeDiIiIPKDopgz7IkRERI4wEOJGsqQEQgQXKCMiIiIPsEjW7XPZFyEiInKEgRA3EoUjQgSnxhAREZEH2KbGWDgihIiIyBEGQtzIGggB78IQERGRB8iSNRDCvggREZEjDIS4kVDxLgwRERF5jsU6TZc3ZYiIiBxiIMSNhJojQoiIiMhzrGuECIvZwzUhIiKquhgIcSPb1BiZgRAiIiKqfJwaQ0REdHMMhLiTdUQI78IQERGRB1inxoDTdImIiBxiIMSdCkeESLwLQ0RERB7A9cqIiIhujoEQN5IKR4RIMjsfREREVPlk2xoh7IsQERE5wkCIO1mnxjAQQkRERB4gSxydSkREdDMMhLiRdUSISjZBCOHh2hAREVFNIxdOjYHM9cqIiIgcYSDEjSS1FwBACzNMFgZCiIiIqHJxjRAiIqKbYyDEjSSNMiJECwsKLLKHa0NEREQ1TuHC7cLMqTFERESOMBDiRipN0YiQAjMDIURERFS5hEYPAJDMeR6uCRERUdXFQIg7Fd6F8ZJMDIQQERFRpbNofAEAGnOuh2tCRERUdTEQ4kaicI0QL44IISIiIg8QWh8AgMac4+GaEBERVV0MhLiTRgcA0KEABRaLhytDRERENY3QKiNCtBYGQoiIiBxhIMSNhNoaCDHByBEhREREVNm8rIEQrhFCRETkCAMhbmQNhHhJnBpDRERUFSxYsACNGzeGn58funfvjr1797q1zCuvvAKNRoMXXnjBndUuP50SCNHJXCOEiIjIEQZC3KlwjRAdChgIISIi8rBvvvkGM2fOxAcffIALFy7grrvuwqBBgxAXF+eWMn/++SfWrFmDRo0awVJFpsSqCkeE6BkIISIicoiBEDcStkCICQUWBkKIiIg86f3338fUqVMxevRoREZGYv78+QgICMCiRYtuuUxSUhKmTp2KZcuWwcfHp6IvxWUqnR8AQC84NYaIiMgRBkLcqPgaIRwRQkRE5Dnp6ek4ffo0+vXrZ0uTJAn9+vXDnj17bqmMEAIPPvggHn/8cXTp0qXiLqIc1HolEOIt8j1cEyIioqpL4+kK3E6EpmiNkGwGQoiIiDzm2rVrAICIiAi79PDwcBw8ePCWyrz//vvIycnByy+/7HJ9jEYjjEaj7bHBYAAAyLIMWXZPn0GWZdvUGG/kQbZYAElyy7FvB7IsQwjhtva+nbBtnGP7OMf2cYxt45y726csx2EgxJ2KrxHCqTFERERVjkqlghCi3GUOHTqE999/H3/99RfUarXLx5g7dy5mz55dIj05ORn5+e4ZvSHLMvJMSj3VEEi8egVCW3Wm7XiaLMvIzMyEEAIqFQdFF8e2cY7t4xzbxzG2jXPubp+srCyX8zIQ4kZ22+eaGAghIiLylFq1agFQAg3FJSUlITIystxl9u7di9TUVDRp0sT2vMViwfHjx/Hpp5/CaDSWGiCZNWsWnn/+edtjg8GA6OhohIeHIyAgoBxXWJIsy8jILYAsJKgkgVB/b6gCIm5esIaQZRmSJCE8PJxfSG7AtnGO7eMc28cxto1z7m4fvV7vcl4GQtzIuliqF8wwckQIERGRx4SEhKBp06bYvn07xo4dC0BZ22Pbtm2YNGlSucvMmDEDTzzxhF25zp07o0+fPvjggw8cjhLR6XTQ6XQl0lUqlVs7x946LXKhgx/yYcrPgndQbbcd+3YgSZLb2/x2wbZxju3jHNvHMbaNc+5sn7Icg6+GG9l2jZG4WCoREZGnvfDCC1i8eDE2bdqEzMxMvPbaa0hLS7MLZDz++ONo3769y2UkSYJGo7H7Vzzd03QaFXKg3BEryDV4uDZERERVk+c/sW8ntqkxBQyEEBERedhjjz2GjIwMPPLII0hKSkLr1q3x66+/okGDBrY8FosFZrO5TGWqMpUkIQfeADJQkOf6XGkiIqKahIEQN+L2uURERFXLSy+9hJdeesnh819++WWJxVNvVuZGhw4dglSFdmfJl5QRIWaOCCEiIioVAyFuZN0+VwczCiwWD9eGiIiIbsYdc5LLsntMZciTfAABmPIYCCEiIioN1whxp+JrhJgYCCEiIqLKZ5S8AQCykVNjiIiISsNAiBtZp8YAgGzK92BNiIiIqKbKV/sAAOT8HA/XhIiIqGpiIMSNrLvGAIBsZiCEiIiIKp9JpYwIEfkcEUJERFQajwdCNmzYgMGDB6N9+/aYMmUKLl686DR/fn4+5s2bh/79+6Njx474v//7PyQlJVVSbW9CpYWAsliaxWT0cGWIiIioJjJpfJUfChgIISIiKo1HAyG//vorRo8ejbvvvhsLFy5EXl4eevXqhfT0dIdlHnjgASxevBgvvPACFi1ahIyMDPTp0wf5+VVgBIYkwaJSRoUITo0hIiIiDzAVTo0RBZwaQ0REVBqPBkLefPNNTJw4ES+++CJ69OiBFStWIC8vD59//nmp+ePi4rBu3Tp8/PHHGDZsGLp164bvvvsOSUlJWLp0aSXXvnTWQAg4IoSIiIg8wKJVRoSoTAyEEBERlcZjgZDs7GwcPHgQQ4YMsaV5eXlh4MCB2Lp1a6llDAZlG7jQ0FBbmlarRUBAADZv3lyxFXaRbF0w1cIRIURERFT5LIVTY1QF2R6uCRERUdWk8dSJ4+PjIYRA7dq17dJr1aqFEydOlFqmadOmiI6OxkcffYTvvvsOOp0Oq1atwuXLl0scpzij0QijsWiEhjWgIssyZFl2w9UoxxJCQFYpgRBhMrrt2LcDW/uwTUpg2zjH9nGO7eMY28Y5d7cP27nqkAtHhKjNuR6uCRERUdXksUCIxWIBoIwCKU6n08FsNpdaRqvVYs2aNZg6dSrCwsLg7++PBg0a4J577kFKSorDc82dOxezZ88ukZ6cnOy2tUVkWUZmZiZ8JDUAwGLMqTqLuFYB1vYRQkCl8vgavVUK28Y5to9zbB/H2DbOubt9srK4MGeV4WUNhHBqDBERUWk8FgixTm+5MYCRkpJiN/XlRp07d8bx48eRmpqKvLw8REVFoU+fPoiOjnZYZtasWXj++edtjw0GA6KjoxEeHo6AgIBbvBKFLMuQJAkqrbJAmRYWREREuOXYtwNr+4SHh/MLyQ3YNs6xfZxj+zjGtnHO3e2j1+vdUCtyB9nLHwCgZSCEiIioVB4LhNSqVQtRUVHYt28fRo4caUvfu3cv7r777puWtwZLEhMTsXfvXnz22WcO8+p0Ouh0uhLpKpXKrZ1jSZIgNMp5VLKRHe8bSJLk9ja/XbBtnGP7OMf2cYxt45w724dtXHVIhSNCtBZOjSEiIiqNR3stjz/+OL7++mucO3cOALBkyRKcP38e06dPt+X517/+ZRcoWbZsGS5cuAAAyMjIwCOPPILmzZtjypQplVt5RzTKHTHJUuDhihAREVFNpNL5AQC8GAghIiIqldtGhFy+fBkRERHw8fFxuczLL7+M2NhYtG7dGoGBgTCbzfj222/Rtm1bW55r167h4sWLtsctWrTAyJEjkZWVhdTUVAwYMAC///57qSM+PEKtrHkiWbh9LhERkbuUp59RU6n0ytQYnZwLCAFIkodrREREVLWUa0TIoUOH8I9//MP2ePLkyWjYsCFq1aqFPXv2uHwcjUaDL7/8EsnJydi/fz8SExMxefJkuzzvvPMOfvnlF9vjzp074+TJk9i7dy+uXbuGn3/+GbVq1SrPZVQMrTIiRC0zEEJERFQe7upn1FTWQIgaMmB2z6LwREREt5NyBUJefPFF3H///QCAEydO4JdffsG+ffvwz3/+E7NmzSrz8QICAtCwYUNotdoSz9WqVQsNGzYskV63bl23LXTqTlLhGiFqTo0hIiIqF3f3M2oajbdf0YMCLphKRER0o3IFQg4ePIhOnToBAH7//XeMGTMG3bp1w3PPPYejR4+6s37VjqrYYqlERERUduxn3Bq9lxdyReGUYSO3NSYiIrpRuQIhfn5+uHz5MgBg/fr16N+/PwAgMzMTfn5+Tkre/iTb1JgCCCE8XBsiIqLqh/2MW+OtVSEHhdsZF2R7tjJERERVULkWSx03bhyGDRuG1q1b4+jRoxgxYgQAYNOmTRg6dKhbK1jdqLy8AQBeMMEsC2jVXKCMiIioLNjPuDU6jRrZQo9wKZNTY4iIiEpRrkDIhx9+iCZNmuDKlSuYPXs2goODAQAxMTF444033FrB6kZdOCJEBxOMZhlatUd3KCYiIqp22M+4Nd5eauRaR4QYOSKEiIjoRuUKhGi1WjzzzDN2aZcvX8abb75Z47e1U2uVObleMKHALANVZFdfIiKi6oL9jFuj16iQAWWEKgq4RggREdGNPLp97m3JbkSIxcOVISIiqn7Yz7g1PjoNcoTSHxFcLJWIiKiEKrF97m1FUxgIkUwwmmQPV4aIiKj6YT/j1gToNbapMaY8To0hIiK6Ubmmxjja1q5Vq1aYP3++WytY7WiKpsYYzQyEEBERlRX7GbfGT6dBTuHUGGNOJrw8XB8iIqKqhtvnuptaCYTorGuEEBERUZmwn3FrJEmCSa2spVKQa/BwbYiIiKoebp/rbpqiQAjXCCEiIio79jNunaz1AUyAOY9rhBAREd2I2+e6W/E1QjgihIiIqMzYz7h1stYPMAGWfAZCiIiIbuS27XMB4L333rvlClV7xUaE5HBECBERUZmxn+EGOj8gFxBGLpZKRER0o3IFQqzOnz+P06dPQwiBli1bokmTJu6qV/XFNUKIiIjcgv2M8pN0hWupFDAQQkREdKNyBUIyMzMxdepUrFmzBiqVst6qLMsYO3YslixZgsDAQLdWslrhrjFERES3hP2MW6fW+wMAJFOOh2tCRERU9ZRr15hnn30WFy5cwM6dO5Gfn4/8/Hzs3LkT58+fx3PPPefuOlYvxdcIMTEQQkREVFbsZ9w6jXeA8r+JI0KIiIhuVK4RIf/73/+we/dutGjRwpbWs2dPrFq1Cj179nRb5aoljRcA7hpDRERUXuxn3DovHyUQojVnA7s+Aur3AKK7erhWREREVUO5AiF5eXkICwsrkR4aGorc3NxbrlS1Zh0RggJOjSEiIioHd/YzCgoKsHnzZiQmJqJNmzbo1KmTW8qkpaVh9+7dyM7ORqtWrdC2bdsy1aui6QsDIcHmZODPN5XENzM9VyEiIqIqpFxTY7p3747XXnsNBQUFtjSj0YhXX30V3bt3d1vlqiUvXwCAD4wwmjgihIiIqKzc1c9ITk5Gp06d8Oyzz2LDhg0YOHAgnnjiiVsu85///AddunTBt99+i3Xr1qF3794YO3YsTCZT2S60Ann7cR0VIiIiR8o1IuSjjz7C4MGDsW7dOrRr1w4AcPToUahUKmzatMmtFax2dIVzciUZcgEXKCMiIiord/UzZs2aBQA4cuQIfHx8cOjQIXTp0gUjRozAsGHDyl2mRYsWOH36NLy8lOmw586dQ9OmTfHLL79g7Nix5b5ud/L2D/J0FYiIiKqsco0IadeuHc6dO4d//etfaNy4MZo0aYLXX38d586ds3VYaiytD2SolZ+NHIJKRERUVu7oZ8iyjNWrV+ORRx6Bj48PAKBTp0646667sGrVqlsqM2jQIFsQBAAiIiKgVqthsVSdkaB+/hwRQkRE5Ei5RoQAgL+/P5566il31uX2IEkwanzhbTZAZczydG2IiIiqpVvtZ8TFxSErKwstW7a0S2/ZsiUOHjx4y2Xi4uKwYcMGGAwG/PDDD5g0aRLGjBnjsD5GoxFGo9H22GAwAFCCL7LsnjXFZFmGEAKyLMPfW4d8oYVeKpquI1ssgCS55VzVUfH2IXtsG+fYPs6xfRxj2zjn7vYpy3FcDoTExMS4fNDmzZu7nPd2VKD2VwIhBQyEEBERucLd/QxroCEoKMguPTg42PbcrZTJysrC0aNHkZKSgoSEBPTp08dpfebOnYvZs2eXSE9OTkZ+fr7Tsq6SZRmZmZkQQqCgQIYK9h3CpOsJgNrLQenbX/H2UanKNSj6tsW2cY7t4xzbxzG2jXPubp+sLNe/f7scCCm+hd3NCCFczns7Mml9ASOgZiCEiIjIJe7uZ3h7ewMo2SkyGAy2aS+3UqZly5b4/PPPAQCXL19Gu3bt0KBBA4ejWGbNmoXnn3/e7pjR0dEIDw9HQEDATa/HFbIsQ5IkhIeHA5Cgkeyn6kQE+QLewW45V3VUvH34hcQe28Y5to9zbB/H2DbOubt99Hq9y3ldDoTExcWVqzI1kVnjDwDQmLI9XBMiIqLqwd39jPr168PLywuXLl2yS7906RKaNGnitjIA0KBBA3To0AH79+93GAjR6XTQ6XQl0lUqlVs7x5IkOTymypwP1PCOuLP2qenYNs6xfZxj+zjGtnHOne1TlmO4HAiJiooqV2VqIrOXHwBAY+KIECIiIle4u5+h1WoxZMgQrFq1CtOnT4ckSbh69Sq2bt2KL774wpZv+/btSExMxPjx410qYzabcfXqVdSrV892jPT0dJw8eRJ9+/Z16zW4nSnX0zUgIiKqEsq9WCo5ZtEqQ1y9zBwRQkRE5Cnz5s3DXXfdhVGjRuHOO+/E0qVL0a1bN0yePNmWZ9myZdi3bx/Gjx/vUhmLxYJhw4ahW7duaNmyJTIyMrBixQpERUXhmWee8ch1uqwgx9M1ICIiqhI4PqcCyDplaoyXmSNCiIiIPKV58+Y4fvw47rzzTiQmJuLFF1/En3/+CY2m6D5Q3759cf/997tcRqfT4dChQ+jfvz+uXbsGlUqFDz74AIcOHUJwcNVaf+PfYXPwm6ULCgpv0MCU59kKERERVREcEVIBZC+lw6Gz8M4LERGRJ0VFReGVV15x+Hzx0SGulvHy8sLEiRMxceJEt9SxoiRH9MQT8Q3wV+BshJsMgIn9EiIiIoAjQipG4YgQnYVTY4iIiMgz6oUoO93kyFoloYBrhBAREQEMhFQMfSAAwFvmnRciIiLyjHqhynbABouXksCpMURERAAYCKkQKm9lagwDIUREROQp9UJ8AQDppsIRIZwaQ0REBICBkAohFY4I8RHscBAREZFnWKfGpJsKl4Tj1BgiIiIADIRUCI23EgjxFexwEBERkWeE+XnBx0uNXMGpMURERMUxEFIB1D5BABgIISIiIs+RJAn1QnyQB72SwKkxREREABgIqRBaH2WNED/kAkJ4uDZERERUU0WH+CAXOuUBp8YQEREBYCCkQmgKR4R4SRaYjex0EBERkWfUD/FBnm1qDPskREREAAMhFULnEwBZSACAgpwMz1aGiIiIaqx6oT7Is44IYSCEiIgIAAMhFcJLq0E2vAEABbmZHq4NERER1VTK1JjCNUI4NYaIiAgAAyEVQq2SkAVlyzpzbrqHa0NEREQ1VVSQN6fGEBER3YCBkAqSXRgIsXBECBEREXlInSBv29QYs5G7xhAREQEMhFSYXKkwEJLHQAgRERF5hq9OA5XOFwBgzs/2cG2IiIiqBgZCKkiuSul0yHkGD9eEiIiIajJ/vwAAgMw1QoiIiAAwEFJhciQ/AIDI4xohRERE5Dn+AYHKD1wjhIiICAADIRUmV+0PAJDyMzxbESIiIqrRggODAABqBkKIiIgAMBBSYXLVyjBUBkKIiIjIk0KCgwAAGjkfEMKzlSEiIqoCGAipIPkaZUSIKp+LpRIREZHnRIQGAwDUkAFLgYdrQ0RE5HkaT1fAYrFgz549SExMRJs2bdCsWbOblsnJycH+/fuRnp6OevXqoUuXLpVQ07IxFgZC1AUMhBAREZHnRISGFD0oyAE0Os9VhoiIqArwaCAkPT0dgwcPxvXr19GqVSvs2rULjz/+OObPn++wzJYtW3DfffehQYMGaNCgAfbu3Ys6derg999/R0hIiMNyla1AqyxMpjYyEEJERESeUzfEH0ahgU4yw2TMgdan6vSXiIiIPMGjU2NeffVVGAwGnDx5Ehs3bsSmTZvw4Ycf4o8//nBY5sUXX8SgQYNw6NAh/PTTTzh9+jRiY2Px6aefVmLNb07ogwAAGo4IISIiIg8K9fVCPpRRIClp3M2OiIjIY4EQIQRWrlyJRx99FP7+yjSSu+66C127dsV///tfh+VMJhOio6NtjwMDAxEUFASz2VzhdS4LjY8yH9fLxEAIEREReY5KJaFApQfAQAgRERHgwakxcXFxyMjIQOvWre3S27Rpg8OHDzss95///AfTp0+HTqdD/fr18ccffyAyMhJPP/20wzJGoxFGo9H22GAwAABkWYYsy7d4JbAdSwhhO57GTxl2qjNnQ7aYAalmr0t7Y/tQEbaNc2wf59g+jrFtnHN3+7CdqzaTSg9YgJyswkCIEIAkebZSREREHuKxQEhmpjJSIjg42C49JCTE9lxp6tati3r16uGXX35Bo0aNcPjwYYwYMQJ+fn4Oy8ydOxezZ88ukZ6cnIz8/PxyXoE9WZaRmZkJIQRUKhXMkhYAoIKMxPhLEDp/t5ynurqxfagI28Y5to9zbB/H2DbOubt9srKy3FArqigpumjUyU2AOukksGIVkBkPPLYVUGs9XTUiIqJK57FAiLe3NwAgOzvbLj0rK8v23I1kWcY999yDgQMH4osvvrDlb9++Pby8vPDBBx+UWm7WrFl4/vnnbY8NBgOio6MRHh6OgIAAd1wOZFmGJEkIDw+HSqVCrUgT8oQXvKUChPtpgOAIt5ynurqxfagI28Y5to9zbB/H2DbOubt99Hq9G2pFFeVaQFu0zd2HenE/AzkxSmL6ZSDsDo/Wi4iIyBM8FgiJjo6GVqvFlStX7NKvXLmCRo0alVomISEBFy9exNixY21p/v7+GDRoELZv3+7wXDqdDjpdya3iVCqVWzvHkiTZjhns64VM+MIbBVAZMwF2wu3ah+yxbZxj+zjH9nGMbeOcO9uHbVy1ZYR2AK4DkdYgCACYcj1XISIiIg/yWK9Fp9NhwIABWL16tS0tOTkZW7ZswbBhw2xp+/btw/r16wEAkZGR0Gq1OHnypN2xTp48abeAalUQ5KNFpvBVHuRneLQuREREVLOZItvDLG7o9hmzS89MRER0m/PYiBAAmDdvHnr06IEHHngA3bt3x5IlS9C6dWs8/PDDtjxff/019u3bh+HDh8PLywuvvvoqXnvtNSQlJaFRo0b4/fffceDAAezYscNzF1KKQG8vpKEwEJKX4dG6EBERUc0WEBiE06Ie2kiXixILGAghIqKayaPjWNu2bYujR4+iYcOGOHbsGB5++GFs374dXl5etjzdu3fHiBEjbI/feOMNbNiwAQDw119/oX379jh79iy6du1a6fV3JtC7aESInMut6oiIiMhzQn29cEhuap9o5AK3RERUM3l0RAgANG7cGHPmzHH4/KOPPloirV+/fujXr19FVuuWBXprkQllJxtjdipKX/6ViIiIqOKF+nnhE0s3PKj5AyoIJZEjQoiIqIbiymYVxEujQq5KCYQUZKV5uDZERERUk4X4emG/aIGOxi8gtx6nJHJECBER1VAMhFSgAq2yNa8ph1NjiIiIyHNCfJRpxxnCDwXqwjXMuFgqERHVUAyEVCCTNhAAIOdyRAgREZEn/Pbbbxg2bBg6d+6MRx55BJcvX77lMgkJCZg1axb69OmDAQMG4I033kBmZmbFXICbaNQqBPloAQC5UuGEXU6NISKiGoqBkApk0QUBACRun0tERFTpfvvtN4wYMQK9evXCBx98gIyMDPTs2RMZGRnlLmOxWNC7d28EBQXh7bffxj//+U/88ssvuPvuu1FQUFA5F1ZOob7KqJBsURgI4dQYIiKqoTy+WOptzTsQyABUDIQQERFVujfeeAMTJkzAyy+/DAC48847UatWLXz++ee2tLKWUavVOHXqFHQ6na1MvXr10KpVKxw4cAA9e/as+Asrp1BfHS4k5yBLFNadI0KIiKiG4oiQCmTxqw0A8M5P9HBNiIiIapbs7Gz89ddfuOeee2xpOp0OAwcOxNatW2+pTPEgCABoNMp9JVmW3XkJbhfqp4wIybQU1p9rhBARUQ3FESEVyBIQBQDwMaUDBTmAl6+Ha0RERFQzJCQkQAiB2rVr26XXrl0bJ0+edFsZAHjzzTcRHR2Nrl27OsxjNBphNBptjw0GAwAleOKuAIosyxBCODxecOEaIakmJSAijFkQVTx44043a5+ajG3jHNvHObaPY2wb59zdPmU5DgMhFcjbPxQG4YMAKRfIiAMimnu6SkRERDWC2WwGAHh5edml63Q6mEwmt5WZO3cu1q5diz///BN6vd5hfebOnYvZs2eXSE9OTkZ+fr7jCykDWZaRmZkJIQRUqpKDfr0l5fqu5UgAAHNuBlKTktxy7urgZu1Tk7FtnGP7OMf2cYxt45y72ycry/W1rxgIqUBBPlokiDAESLFAJgMhRERElSU0NBQAkJqaapeempqKsLAwt5T56KOP8NZbb2HdunXo0aOH0/rMmjULzz//vO2xwWBAdHQ0wsPDERAQcPMLcoEsy5AkCeHh4aV2KKMj8gBcQ7pQRqhq5HxERES45dzVwc3apyZj2zjH9nGO7eMY28Y5d7ePsxsSN2IgpAIFeWsRL8LRArFAxhVPV4eIiKjGqFWrFurUqYP9+/djxIgRtvS9e/diwIABt1zmP//5D1555RWsXbsWgwcPvml9dDpdibVFAEClUrm1cyxJksNjRgX7AABis5XnJGMWpBrWMXfWPjUd28Y5to9zbB/H2DbOubN9ynIMvhoVKMjHC/Gi8A5SRqxnK0NERFTDPP744/j6669x8eJFAMDSpUtx9uxZTJs2zZbnjTfewJgxY8pUZsGCBXj55Zexdu1aDBkypJKu5tbVD1UCIRcylakxXCyViIhqKo4IqUDh/jr8aQuExHm2MkRERDXMK6+8gsuXL6N58+YICwtDbm4ulixZgvbt29vyJCQk4Ny5cy6XSU9PxzPPPAN/f3+8+OKLePHFF21l33rrLYwdO7ayLq/MokOUQEiiUQPoAZjzAIsZULM7SERENQs/+SpQuL8O8SIcACCnX+HwGyIiokqk0WiwZMkSfPDBB0hJSUG9evVKTE956623kJub63KZgIAAHD9+vNTz1a1bt2IuxE30WjVqB+qRmlls4deCbMA7yGN1IiIi8gQGQipQgF6DZJWyCJng1BgiIiKPCA4ORnBwcKnP1alTp0xl1Go1Wrdu7db6VaZ6IT64lpkPWdJAJcwMhBARUY3EQQoVSJIk5Pspd4fUucmAKc/DNSIiIqKazLpOiFGt7ByDrET2T4iIqMZhIKSC6f3DkC0Kt/HJjPdsZYiIiKhGqx+qBEDyJG8l4ev+wOJBgGwBfv8XcGajB2tHRERUORgIqWDhAXpcErWUBxe2eLYyREREVKPVK1wwNct6kwYArh8HTqwB9nwCbHrFQzUjIiKqPAyEVLAIfz2+t/RTHuz9VFmdnYiIiMgDrFNjMi32i8Yi5hfl/4w4QJYruVZERESVi4GQChbur8OPlt7IVgcCGbHA6Z89XSUiIiKqoeqHKFNjMsxe9k+c36z8L5uAnORKrhUREVHlYiCkgoX765APHTb7jVQSjn/v2QoRERFRjRXoo0W4vw5G3BAIKcgu+tnANc2IiOj2xkBIBYvwV4ae7hGtlITEUx6sDREREdV03RuFor503XGGzITKqwwREZEHMBBSwcILAyGH8woXTM2MBfINHqwRERER1WQ9moQiUMpxnMHAQAgREd3eGAipYBH+yqrsF3N0EP61lcTkGA/WiIiIiGqyuxqH4TXTVGQLPYwD3i6ZIZNTY4iI6PbGQEgFC/XzgiQBFlnAFNpMSUzi9BgiIiLyjOgQH8QE9UIb49fYEzYe0OjtM3BECBER3eYYCKlgWrUKIT7KgmRZAXcoiUmnPVgjIiIiqul6NA6DgAr7LqUDIY2VROvI1Us7gIXdgIPfeK6CREREFYiBkEoQGaDcabmuK+xocEQIEREReVD76CAAwImrmUCtNkpis6HK/7mpyjTeg0s8UzkiIqIKxkBIJWgY5gsAOCuilATuHENEREQe1KpOIADg5FUDxN2zgTFfAj2fs8+UfAawmD1QOyIioorFQEglaBSuBEKO5EcCkIDcFCAr0bOVIiIiohqraS0/aFQSMnJNSDAHAO3uBwKi7DNZjEDaRc9UkIiIqAIxEFIJrIGQM6kWIKypknj1iAdrRERERDWZTqPGHZH+AJRRIQAAVSndQk7nJSKi2xADIZWgUZgfAOBiSg4Q1VlJTDjowRoRERFRTdeqTgCAYoEQAOj+FOBXC2jQS3nMQAgREd2GGAipBA0LR4QkZxmRH9FOSYxnIISIiIg8xxoIOXU1syhx8LvACzFAs3uUx4knPVAzIiKiisVASCUI0GsR5qcDAMT5tFQSEw4DsuzBWhEREVFNZl0w9USCwf4JSQIiC/srHBFCRES3IQZCKol1nZBTlmhAoweMmUDaBQ/XioiIiGqqlnUCoJKA64Z8JBry7Z+MKAyEpF0C8g0lC7vq6EpgyRAgJ6X8xyAiInIzBkIqSePCQMiFVCNQu72SyOkxRERE5CF+Og2aFi6YeiQ2/YYnI4DgBgAE8PNT5RvFajED654AYvcCB5fccn2JiIjchYGQSmJdMPVsYjYQ3UVJjFnvwRoRERFRTdehXjAA4EhsRsknR38OqLTAqf8BBxeX/eCXdxT9LLHLSUREVQc/lSpJ+3pBAIADl9Mgt5usJMasB5LPeK5SREREVKN1KOyflBoIqd8d6P+q8nN5bt6c+Kno5/xSjk9EROQhDIRUkvbRQfD1UiMtpwAxljpA8+HKE7s+9mi9iIiIqObqWDgi5HhCBkyWUqa/3DFI+T/uL2Wqi6vMRuD0L0WPc1JvoZZ028pJBQ5+c2vr0BARlQMDIZVEq1aha8MQAMDu8ylAz+eVJ46vAuIPebBmREREVFM1CvNFgF6DfJOMmGtZJTOEtwB0gYApB4jbD5z62bWASNIpIL/Ytry5XCyVSrH7Y2D9s8Chbz1cESKqaRgIqUQ9moQBAHZfSAGiOgFt7gOEDKyZDvw0HfhpGrDnU8Bc4OGaEhERUU2gUkm2dULWH79aWoaitc3+Ow5YPQU49M3ND2y44VjcNYZKkxGr/J91zbP1IKIah4GQSmQNhOy/mIYCswwMfQ/wDVe20f17NfD3D8DvrwJb3/VwTYmIiKimmHJnfQDAkt2XcDE5u2SG6DuV/025yv/nfr/5Qa2BEN8I5f9cF6fGXN4NZCW6lpeqP+v7wsipMURUuRgIqUTNIv0R5ueFPJNF2abOJwQYvxRoPQ7o/xrQ8zkl4+7/AIsHASsfAEx5nq00ERER3dYGtIhA32bhMFkE5m6MKZmhXjf7x1f2ABaT84Na7/DXaqP870ogJOEw8O09wJppN89Lt4fcNOV/rhFCRJWMgZBKpFJJ6N7YOj2msENQ/y5g3GKg9z+BgW8CHaYAEMo83DO/Age+8lh9iYiI6PYnSRJmDW0BANh2JglZ+TcEOep2BvzrAIHRgHcwUJANJNxkfTPriJDabZX/C7IBU77zMtf/Vv5PPFXGK6Bqy7p2DEeEEFElYyCkkvVsEgqgcMHU0gx9TwmIdCm8G7LrQ+DLfsDS0YyWExERUYVoVssfDUJ9YLII7D5/w+gNLx/gqQPAk3uAhr2VtEs7ip4/8BWw/jlAthSlWQMhYc0AlVb5+WYLpqZfLsrnaESsEPaLsFL1JUSxqTGlLNRLRFSBGAipZHcVjgg5GpdR8o4LoHQ2ej4HDJkHhDUF8tKBq4eBi1uBVROBgtybn8RsBH55BvigBfBhS+D0ejdfBREREd1u+jZT1vPYfjap5JM6f0AfADTsozzeNlfpY1w/Afw2Czi4BLiyuyi/dWpMQB3AR7kJVGLB1GvHgOXjgJRzymNrIAQAMhNKr+S2fwPzGgCXdpZ8znAN+PWfwOa3gPiDTq+VqgCjAZALdyDizT4iqmQMhFSy6BAf1A/1gUUWOHApzXFGtQYY9iEQ2gTo+BDg5Qdc3gl82gXY/h5wcVtR3qTTwIYXgBNrlC3tdn+ibEOWdRUwJADfTwaOLFci71ePKIESqzMb2VkgIiIi9GkWDgDYdiYZQojSMzUdAmh9lF3vDAnKjndy4Y2dq0eK8llHhATULQqE3DgiZPt7wPk/gANfKo+LB0IM8aWf//JO5dyxe0s+d3CJcqydHygjaW+2jgl5VvF1Yzg1hogqGQMhHmDdPWZzTCl3XIpr2Av4xyFg5CfApB+UubmGeGVXmaWjgMPLlOGoX/QG/voa+PER4D9tgZ3zlfJD3wM6PQxAAOufB9Y+DnzZF/j5aeX5mA3AygnAdyOB7GTXLyAzHjCWsqo8Fbn+N5B+xdO1ICIiAJcuXcK+ffuQnp7u1jLx8fHYtm0bMjIy3FBLz+veKBQ6jQrXMvNx6IqD6w6sCzx3UrlZAwDJp4ueSzgMpJxX/i8o7CcE1AZ8rSNCin3xleWiESRJhcfIKPa5mekgEJIRV/h8XCnPxRb9XJDFLVmruuLvh9tpREjaReB/M+zfj+6SfkUJ9OVluP/YRDUMAyEecE/r2gCA9ceuIt9kuUnuQvXvAmYcUKbM3DFYSds4E/j1RcBSANTrrmzFa0gAzPlAg15A18eA4R8DjQcAFiNw/Hul3PFVwPnNynxeADDlAHs+Ue7EZF1XRo4AyuiSg98A/70PuHpUSYvdD/ynPbD8XiVfQW5RfkfMRkhb34U28biLLVTNpV5Q1nX5ZqjShkRE5BF5eXkYNWoU2rRpg+nTp6NOnTr46KOPbrnMgQMHMHr0aHTu3Bn9+vXD0aNHK/AqKo9eq8bQ1rUAAP9YeQRJWQ4WN/UJAdpPAnQB9ulX9ig3XL7qpzzWBQJevoCPcgPIbkRI4gll+i8AJMcoX4SLjxAoLRBiMSv9HEfPG26YTuMomFKcMVvpE8nyzfPWZLIF+HGqcmPNXYq/3ua822cEz96FykjsLe+4/9g7P1Cmfh1Z5v5jE9UwHg+ErF69Gj169ECTJk0wZswYnD592mn+Zs2aISoqqsS/V199tZJqfOu6Nw5FnUA9DPlmbD59k1EhxXn5AHc+AUxYAUS2VgIYAHDXP4BHNgLPngBGfaZMpRm9CJAk5d+I/wBe/kpe/zrK/8vHAtmJyurvALBnAfCfdsAHzYBPOwOx+4Alg4D1zwLnfgd+/ofSAfn1RWUIbNw+4I9/AfPqKyNSruxxXO8jyyHtnI+gTf+n3CESAvjjdeXfzYIo7mYxu7bOyq04uVZpI0OCsvsPERF5xJtvvokjR47gwoUL+Pvvv7F69Wo8//zz2Ldv3y2VOXPmDB566CHs33/7/Y2fPao1GoX74lpmPp5YdghGs4MbNlo90GJk4c8+yv85ScpIDKuAwj6Hb2EgpPgaIZeLrfGRk6ysh1ZcaSM+sq4BorA+pQU5rCNApMLubUYpx7jR5tlKn2jz7MK+UHvPjuiULSXXUilN/EHgz9mOF5V1t7j9wImfgIOL3Tca4cYtlW+XBVNTLyj/n/vd/TfErO/7tEtFaRe2KDcyiahMPBoIWbt2LSZNmoQpU6bgp59+gr+/P/r06YPkZMfTNLZu3Yp9+/bZ/i1YsAAJCQno2bNnJdb81qhVEsZ0rAsA+PGQCx/SJQ6gUYIbWl+g3QPAwLeUgIdWD3SYpEylCYouyh8UDTz6OzDuG2DqRkCtU9JDGgEP/QLU7QRAAJJa6TykngeWDFa2xtMHKee5fhxY9YDyv9WeBcpolOvHgW+HAWc3KelC2A9xPP+nUu3cZEh7FgCnfwF2/0f5d2ZjUT7DVWV9k+snyt4mNzIXAJd3KdOHUs4rabIMLB4IfNTSPeuimPJKv4N0al3Rz2d+vfXzVEey7FpHjkp3/W/g4zbcPpvoFn377beYNm0aIiMjAQAjRoxA27Zt8c0339xSmSlTpmDMmDFQq9UVewEeEOitxeKHuiBAr8Hh2Ay8utbJZ3KXqYDaSxkdEtK45PMBygjYohEhqcrnw6WdyvTc4qx9CKvSAh3F0zLj7W+mCFG0Lkl0t8I8LvSxrOuT7P4Y2PURkH4JOP3zzctVlLVPAPPvABJPOs/3+2vKzoI3tmNFKd6fSb/kOF9Z3BgIuV12A0q7qPyfl67cOHSnnMLvSNbRT+c3A8vGFE17JyKXaTx58rfffhsPPfQQnnjiCQDAkiVLULt2bSxatAivv/56qWXq1Klj9/itt95CdHQ0Bg8eXOH1dad7O0Zh4dYL2HEuBYZ8EwL02rIdIKozMCseULkYy4psqfwDlGBITgrQZCCgUgP3/xe4sBlocjeg0gDLRilfxPSBwMMbgFP/A3a8p0S2AaDbE8D+LwAIIKIVEHaH8uX/h0eANvcqo0NSLwBD5gKdpwIXtxfVY88nRaNQAGV4X9PBwLGVynBLi1H58vf0EWWu8NY5QH4G0GY80PpeJQgky86v+/gPyp0dawfINwKYsV+5JutCbsvGAP1eAVqNUTpoB5coHbbmw5UPsB3zlfMO+0AJpmj1wF1PKwEnAIj7C/huhHK9oxYWnTv1gnIeq5gNwIA3ALW2qOyNspOgP78BCJ0EqPRF6fkGJdBkvZNmZTYCh75ThhU36gu0GKEcvyJc3q2M4mlaxt+vbXOV98yElUDze5Q0i0kZUZQRC4xborwPLu1QOr93PQ34Rzo+nmxRdhUIb1qyHTNilQ5A9xnAHXeXrZ7ucO248l5rPsz1Mnnpyl0iv/DSn986R7muHe8rv0MqF79sWczK+1JSAQ+uK/v7orTfrdQLyvswooXy2PrFw9H7uaLkpSu/T23uAzS6spe3mJS7jT4h7q9bVXB5t/KeaTeh8l+bKiohIQFJSUno1KmTXXqnTp1w5MgRt5VxldFohNFYtFi5waDcMJBlGbKbpmXIsgwhxC0fr36INxY80AFTvzuIHw/FY0KXKHSsF1wyY+0OwIvnAa0PpHVPQEq7AKH1hVQ4YlXIMoQsAz4hUAEQOSkQR/8L1c9P2Q4h/OtAyroKcWYjJADCNwJSThJEZrxSFgBO/ARp40tAoz6wvbtNuZBzUot+p/MyoDIpIz5F3c6QYvdCZMYpx7i0E9LZ3yD3e7VE+0hefpCs65kUfjEX144VnbsyWAqUz7iIlpDO/wFJyJDjDgDhLUrPLwSkxJOQAMipF+1vylz/W9mJpU6HMlXhZu8d6cxvtraXUy8AtdqV6fg2V48CqeeANvdByklG8b9Wcr6hyk5Rcvl3y2KClBlvuy5xegNEvbvcVg9rm1l/P6SL25XHcfsgLBaP/f1319+e2xHbxjl3t09ZjuOxQIjBYMCRI0cwc+bMospoNBgwYAB27NjhpGSRnJwcrFq1Ci+88AJUrgYEqohG4X5oGOaLSyk52HshFYNb1Sr7Qcp7zXXtO3gIqA10mFz0+MGflcBAs3uU4ElglDIcUjYBfV9ROtqWAmVkx9gvgfBmypeUS9uBw0uLjvPby0pQxJQD4RsBY2hL6GO3KUNXfcOVLybJp5WRJTvmK0EQSQVkxirb//79g5IGKKNK/l6tzDWO2aAEL4LrA1FdgH6vKh/6lgLlA3bNNKWMT5hyvJwkpS7WLdrUOmV18t9eVr5wNuhZdKcjoK79HOMLW5Q1VwClU9Gwt/IhvfElZT7rkf8CXaYr2xuHNFLqDCj1unZMuWvybqTSluOX2b9mhV86pZ8eRdCVXRCxvyt5NF5AbhrwRR+lrUZ/BrQdr3zJPbYS2D6vKMhz+DsleNN9hlKnpkOAns8r06isjFnA3s+UzmKjfkBoY/sPyuwkQKNX0n55RgmQtZ+oBISWjlJe96mbgHp32r9vZAtwfLVShy7TgDbjlHSLWXn/AMC+z5RAiMUMrJmuTBsClF2OdP7K7kYAkHQKmLymqF7ZycrIpNAmgNmIkF8ehuraX0CvF4EB/7Kvx55PlfbPuAKE/KjMze3xjPL+cEXcX8DR/wL9/1W0oJ+VEEpbB0aX3rnIiAW+uUcZCj5hhRIMKchRAjwWExDZSmnv4ozZwKKeQF4a8MBKoH4PJQApScr5Us8XjZTKTlR+rxr3L3nulPNA/AGg1diitNi9QGzhNLWTa5X3jas2zlR+fx/ZqLxXMuOB2u2Arwco1/TELuV3fdtc5a7pQ7+UfE+U1eXdyrXX63bzvH++qbxfUs4Bd88u23kKspX3ctIp4LFtRUGdqspcoPze3vh+dJZ/5QTl71rSSWBQBcxLr4asi5yGhNgHv8LCwhwugFqeMq6aO3cuZs8u+d5NTk5Gfr6DtTjKSJZlZGZmQghxy/2iZoHA4GYh+PV0Kr7ZcQ5Rgxo4yZ0HfeSdCDrxI3JaTYTfUWU0W77KB5lJSdCZvRAMwJx6CfKR76EDIOuDUVCnKyz+deF7bAmkwlEG+bU6w/vCr0BGHJISE6HKuY6wX55RgivWz5BCaZePwxzWEpIxE+qsqwgDIOuDkOUViUAABUkXkZ6UhNBfZ0KbehoGvybICLvLrn0iIOHGv+7m+CNITSpl6rI5HwG758Ac1Ai57R4ue6M64L9nLnyPf4usbi/Av3DdlNyrMZAzPoIm5TQMvWfbBcRVOUmIKNxlJf96DAzWulpMiPhuGCTZhKQpuyB0/i7Xwdl7R51xGeGp52yPc+JOICe8fCOxw1Y/BI0hFina2vBJS0Cx3grSr1+BSeXkpogHufq7pc68gnDr9C0AltPrkdLhGfdUQghEFo4IERnxSEpKQvCV/dABkPIzkXzpb8h+5fg+catkC/SnViEnsB2EaFntvpNVNHf+Xb4dubt9srJcn2LnsUBIQoLyZbNWLftf2MjISBw7dsylY/zwww/IycnB1KlTnearqndhejYJxaWUHOw8m4y7W0S4pR5uoQ9SvkwDypd1XYCyUKt1zq0QwD0fAEPnF305nLAC+PtHZY5iYJRyp2L/Z7bhpaJxf6R3+xciYn+G6uh/IfrOAtIvQ/X7q8Cfbyh5IloCzUdA2jEPOLpcSWvYVxniuucTSIVTbAAA2deVf3H7IRJPKtNzjFmAl68SGW8/GWLoe0DiSUjfDIZkXSgWgDx5DXDtGKRjKyAlngDO/AoBCdDoIBUGQUSTgUDiKUhZV23lxJ9vKV+g0i9Bss1lFhBLBkMy23di5R7PQjq2ElLMemWbv5j1kHe8D/T+p3K3YPNs5Utd83sgXdkFAJDO/gax7gmIMV9BWv88pMzC1cbXTIc48ROQegFSYUdE+NcBmg0FjiyDFLMe4uJ2SAVZwPW/IfZ/DtTrDtF7JuAfCen7SZCuFf1OicBoiLvfBlqOAhIOQ/puOBBUD6L9RKhO/ARx6n8QEa0g7ZwPqXBLRLHpVYiRCwrnWwugbmdIP02FdEkZ7SOuHVdev8STgEoDlXVBvMs7IV/eA2nL25Bi90CotIBshnTip6L6qDSQLmyBfPx7ZeSPMQvS1/0hFa62rgLgZc278wOIxv2Vu2Z7P4Vo2AfS6V+UTmzaRYhv7oGUfV25U/LAKiA5BtIPDyntMexDAJIS6NLolGBccgyk5WMhGQ0QWh+IQe8ABTmQ9nwCofOHdGELpItbIVqMhBj7FZCdBGnjP5Uv1CoNoNIq7W5to4JcSJvfhFRs+La4Y7Bybutc+f1fQFW4LaRYNlZpz1ptIYa+B2nVA0C+ARIEBCTl/+Orld+D4jJiIS2+G1JeGqRD30HqOx+yHAYp5teiu1C7PoRodW/R76jhqjLs2C9SCXSc+VUJ1rQcBZz5Far9nxe28YfAtSOQMmIhOj4EqbBTLja9AjH6c0i7P4FkKYDY/h7EpB9xUwXZgEpbchRHyjnlvafSQEzbAunnGUBES4iRCwHZBGnH+8pr2ncWENLYdjdSWP9+qL1KPZ2NpQAyVBBmI/DDDNv6A2LvQogRn9y83gCwbxGkjCvK+2LnhwCE8jssufhBnZeuvE9K+zKSn6n8LfUOsk8XMqSlo4C4fRBDC0cEJZ2GtH0eRK8XgFptSh4rdj9U1q0n9yyAHNrUPrjtgCfvwlQGLy/lPZKXZ7+GQm5uru05d5Rx1axZs/D880ULTRoMBkRHRyM8PBwBAQFOSrpOlmVIkoTw8HC3dCin9tHi19Op2HwuHe/e2wEB3soos3OJWQjy8UK4f7Hf6/CpkJv1gk9oE8idJ0La9SF0g99FRGAE4H03xB8qaFNOKZ8DAPDIr/AKb64E+I8tsR1G12IQcOFXSBYjIvzUkLb+2zbC5EYh6lygIBbSt4OVQC0AKbAu/KOUEbBe+UmICA2ClK5MkQ0quAZjUFBR+xizoCoo2WnWZFxERLAfoPEu+hsqZEg/PgLp9M8Qkgp+Paa5Z4SZbIF0fj0AwO/ol7ZkX1MqsH8ZJFMO9N0fLZruAwCXYmw/eucnQx9R2IdMu2S7nnCkABGlTFdyVA1n753zq+we+hUkwzeiHP1WUy5UBuWzPUROhSTbr9kW7K0CynPc4oRQdlgMiHLr6AiXf7cMyqhgERgFKTMeGkMsIvzURVtIO3JqHaRt/4YYvxQIa1p6nrx0SIU39VTGDEQE+UBKKZpCFWZJBCLalum63OLof6Ha9RaCAJhfS7353564/cpNn/aTKqN2Hufuv8u3G3e3j16vv3mmQh4LhFg7TBqNfRW0Wi0sFtd2Ulm8eDGGDBmC6Ohop/mq6l2YNuFKZ2D7mUQkJTkYIl+dRA0p+rn2APjKXvD/62MAQEbEncgwZEHUHw1Vw8I72IEdEBLxPbySlHVHMttOh7HunYjY/TEkixH5DQYi4+5PAJUa2tDOCPrjaci6IBh6vQ6h0kCbchoBu96CdHFr0XnzCmAOqI+UTi8C6VmAVz343PkS/Pd/AEk2wRTWEqneTYBGTYB6wxG47RXoL26CoccrMNbvD21qDEzhrSH7hEFtiIPP38tQUKcrgv54FlLCX0DCX7ZTGaN7QRe3E5I5H7LWF7JvBGRdILLu/CdMwZ0h3dkEXg3ugdoQh4A9cyFtm4ucjCR4XTsEr8TCIdaFI0hyIjrCJ/k4pBM/oSAjEbr4XRAqDfKbDIP32f9BOvsbAOVOV3aHJ5Db6gFAo4efRQu/I59DKsiC2T8KkhBQZyco05jObwYkCZJshkUfAnNIE3hdPwIpMw74aSqyrzwFn9M/QmXOA1LOQGz7NwBAks2Ql98LVW4yhKSCUOugSjgIaVF327ULlUbJp/WB7B0GjSEW+LwHJCErQaViVN8OVequ9UXmgPnQXjsIv2OLYQ6IhqHPu9Be+wv+BxdAtfZxGA8uh9D6QJ8RC6HS2gIxRv/6EMGNoI/dCrHyAcjeIdBkXAJ2f2zrFACAlK0sFiad24S0Y78icNur0GReBlLOwpgaC21qDNTZ1yAkNfKbDINX/B7bF0j52PdIbvt/CNj1NnxOrbK7Cun0zzAvioEqLw2qPPu1T2SNN4TWB+r0S5AKRyNZfCIg+0ZAk3wS0rlNkL++G4Yer0J4+SFot/Il3BzYQKkbAFw7CnwzFFLhXSQBCdndXoD//vkQp/6HtKYTYA5qBJXRAE36efjv+Te0eWlK3eL2IWjtA0gZtRxhp9fb/qhLSaeRsf+/MDYaBK8r2xH82xPKcGuNNwy93kTg1pchQSCr2wvwOf5dsWv9X9HPh4uln/8TBSsmQmdWviBKFzYj5ex+WIIaFr4prLtNGaGL3QHZOxRQaRG8/iFIsgUFtbsgt/VE+Jz4L1S5ybD41YZeyErAYtkYqHKTgWvHkAtveF09AG1y4boEp39BTofp8LO+tjnJyPhrNYwN+kN//leYQ5vCHNrc7jVRZ1xCyM9TIEFCsFcQVBlni95Px1cjpfV0yLogQO0FTaqyQLc5tIVdp1mTfBJhv78CAMgxCfgdUb6g5KQmIKvHqzftYKszLiN0zb2QLCbkNx6CvGZjoDbEQzLnIb/JMIT+OAaq/AxkDPwQxoYD4R2zBvqz62AOawHfwlE90q8vwJCRCv2FX+GVeBSWa8eRMu5/tqCSZDRAnXkF+st/wq/YueXt85FSZ6AtYKNJPgld/B7kNR+rvC4ApPx0yFAjI8/ikbswlSEqKgoqlcp248UqISEB9euXPmKsPGVcpdPpoNOVnNalUqnc2jmWJMltx+xUPwTNIv1xJjELqw/F47HejXE4Nh1jP9uDdtFB+N+MHvYFIgp/F6M6AhOWF/0dDayjjGw7/6fyexhUD6qIwt+54iO0GvSCqt0EZeRZdiJUCX8BZ38DICkjF83WAJUEQEBlSFD+fgrZtgWvFFAXUnA95efMeEip55WRjQCk1HP27ZN9wwKTKi2g84OUlw7pi97Kwqz3LlamI+//ynZzRxIypPO/K6Mnb1X8X7bddKRii4VKcftti+Krkk8D9Ys+g1FsdIaUcQWS9bW23kABoEo5Y1/GBaW+d2S5aLRv/R7Ald2Q0i8VnbMs0i8X1c8QX2KNEFVBTvlHO1sdXQmse0LZZfHOJ27tWDdw6Xcr47KSt1ZbJWCfdhGqxBNA437K6Mr8zKIbI8Xt/wJIOQPpxI9A/9dKP/aN7XV5l90Cs6rk00CzUqYyy7LyO1CeaaWuKHazTZUZC1VoI+f5f5qmBKvqdABqta6YOlUxLr13Tv2sTIke9w0Q1qTyKlcFuPNzqyzH8FggJDxc+eKfkmL/pSIlJcX2nDNnz57Frl27sHbt2pvmrap3YQYFBGPWhouIyzDimtELbaMCId1Oc7uHvgG5/Rjg6mEEtJ8EY0pqyfa59wuIJYOA0CYIuHMKoFJDjP4MuHoEXn1fQYTWW8kXMRBofQJqSYWiWcoDIYJClJ1tmtwN0WoMpJgNUPV6ARG1inVY754J0fl+iL9/hLrlSESEFbvbMHEZhCkP/lpv+ANAo2KR9IgIoEkneANA5ilg30KI6DshWo0BJBW0HR/C/7d33uFRFesf/5zd9N4LISGFQOi99yYgiKhYERSxF+zt2q5er5d77T9RsWMFBBWQ3nuHEEILLYT03utmd35/THY3m0ZQpMh8nicP7Dlzzs6ZPWf3ne+8RXwzRsbj3vwtutYj0EGt/gVAmFT1hbEAbdenuB34Ur52cJfeIAfnI/SOlFzzPk5p69Gvfx3HFOkhIka8hmO/RzFlH0M79Kt0ce1xF26OHtZJz5hXEGdWQVEqulvmQHBXTJmH0bZ/iHb4VxAgQvuiXf8J9j4RiKpSWPUPtNjvcN8jJ+RC06EJE7rqcoTeAeyd0ZfVJOPq8zC4BcDaVxH2LjLMozQHrTgd4eQJk39Bp+kRXw5HE1Lc1JATYtH9LstEWgR3gRu/xNO3NYhbMfW4DV1ge7zsXaDTNYjKDIhfiGOytYqAuH0+InwApmoDefnF+Hs6IX64AV36AXSVMqGaWQQRAe3Rso7I/zv7oJXn4bP4TulR4eSJVlGIU9KGmuvVowkjzidqvJX82kBZHvqyHALjP0U7Ile+ROuR4OyNCB+MtuJZ7POO17xXO8SYt6E8F+34Kmg3Ac1QhvhlOniGQKdb0QY+id7BFZGdAD/fiT73JN6rHrFem18bdA9swZQRD8XpaAvuQhNGhEcI4qavwdENV/92iDMr0WUewveXSXI1spa7rXD2Qdz4JdrSJ3AsPEvgklvRijPkZ9hjGtruz/Da9i9EVE+0zS9LkUrvgK66HK8N1pBE913vWq4LTYfWQII+EXMd2rHfcUzbLV+7+KKV5eK34WnwCpfJ23KOS4NMZ4dWE9ImnLzQamL2HVO2Wu5twDKegPV+A1xrVoaFszcEdEBL2orbvk/kthovGa8Dn8Lxn9HObJHCW897EMNelqFz6XFoqx9GqzmnviwL4eSJuOkbWP86WnocAd8PlqvSHi3QCmR1COEZKj1SYsZD1zvQ1lhz/5hFEADXQ9/jkr4T0e9RaDMabddniOhRENpX5u3xaAEuvmgbnrLkHXA+vhjn41aByf3g12ilmQB4rXpUVt44ugQNgWOarEIiQnqipe7FY/tbluPsChIJTPgOMewlKMtFm3eT9NxxkN8IprFvo63/F3ZFSQQUH5JhbtkJaEvvQqssxi32MxkuVV0JhxZiGvwcRN9xSVZhLgYuLi4MGDCAJUuWMGXKFABKSkpYu3Ytb7zxhqVdQkICRUVF9OrVq9nHXC1omsZd/cP5x2/xvLP6OP2j/Hh7ZQIAcckFlFcZcXZoZg6jLrdbkqfTZoxVTAzuCl3ukN4VI16T4aFBneBkJqyRHqOEdAdnHzi5Rr4O7CCft8Jka0J0M+7BMswVpEda0jbrvpwE27Zm7z2/NlKo8W8rw29ProW8msof310PUxZZk5J6tJSTuGPLLowQ0lhS9QKrqEHmEdt92VaPEApTZPip3k6GiFra1LnW86G6Uk7aXXxk6GneKekdPOQ5OR61K5acD+YxBelhap7Yu/rL35HSLNnvGu+eP0TNwhGHFl5wIaRZmMUe7wiZpyvvtLQTo4bBwukyJ9+D22TOMzNGg1VMyGqiemZptu3ro7/bvs6qc5+YWf+GDEO/f2PDXoV/lupaHnSHf4PBTzfetjxfPj8g+1tbCEmPk17pzQ1t/rux7xvp4b7vGxj970vdm6uCSyaEBAQE0KpVK7Zt28b1119v2b5161auu+66cx7/1VdfERQUxPjx48/Z9nJdhfFycaRrqBf7kvK54dMdjIgJYPaUHtjr/0ZuUyFd5V+NUFRvfALby7K/dk5odjXusp0mQadJ9WJ2Gyxy1H2KTHjq6Cbbd7m1geMA30gY+lzDfXR0Pfd1XPMm9JyG5hNluwpy1+9QVYLmfo6YzLEzpeG24d8QPght5Gsy90rMODmhdQ5CGzAD0vbBqQ0w/j25KgaWRLcNXpejG9y/QYZzeLaU20K6ws3fQO/7wNEDLaij9Vgnd1lxyDdK5m9x9kbrPhW+myBDVtpeCwOflG6LIT3RQrrLYzvfgubqLw2t6io4tQ4toB2ad7g8701fynwoUcNh/hR53mvfkWEYrv5oPe9B09f6ugnrbf2/g7M8ftg/5IpI/ALocju66BFyv94BTVeKztkL7d518gciebe8T+ZNlmEUQ56X11OajdbvEfhypBRkPMPQbvtRGs8n10P3KWjtJkjD+MCP0HokWsdJMrnuzk/QdsyS79n9LrQJUijSQBowZ3eCsQqt/QQ0c6hDh4nWsY0eJUMgtFrx5oHt4J7VMvwrdb9c3QvsiDb8FTR7JwjtJduNew/2f4c27l20kO7WsZm6BH69F+3Ueus2Zx9odx1a/8fQ/KIx3fU7pq+vRV8sV7C1iCEw6g04swUt64jVk8c/Bu2On+HzIdIQsXOWBkjKHvlZ3zFfJj1e9rTMrxPaBxKWQVAntFu+lRUVNvwHfCLRxrwFP9wkRZO6wonRaDFqtYoCmeflpi9h1+cQ9xOE9JT5UfJOQ/gg6R5bnA5BncErTE4uutyONvxlKcJ92l+KLIDW92HYN8cieqF3QDNWwd6v0OIXyjxBZoPMMwxTv0eoOLMbp5H/QOfXGioLYKEMpdRMBjlpsHOSAlBhMhQmo51YJZ/TkgxZSauW+ESPaXBwvlxVXvp4zQp1Bdruz2TiYvOExquVPLeml3mUTm+EY0tl4uacBDRzic+216IlLAezF453uDSivVqh3b1Mli2P/1nua9kLUvagbX0Pzbe1vH9rJkpmwUXXribZ865P0W37QI7HqhelQGXvIsO49n5luRxd6l60NpMvySrMxeLf//43I0aM4Nlnn6Vfv37MmjWLoKAg7rvvPkubt99+m507d3Lo0KFmH5ORkcGxY8csVe4OHDgAQHh4OOHh4Rft+i4Gt/UKZf2xTNYezeKeOXvILa2y7DuVXULHEM/mnShmHDh6QmWhbQJunQ5u+NS2bfuJUowwez5EXyOfN7MQEtavRghJkf/WxiNE5sly8ZUTbfPEGGTy51pehJacYF5hMPa/1jZmwcZ8jvVvQMo+uW34S7DoIZlDbONMmWi+ZZ3ca83FZLQKLI4eMs9PQ9T9nq0tcggjFKfJa6jlcUHWUVmFz8lD7jsffr1f5qp6eAfsqfnO6HK7/J4G+X6GcjAvVoEs5Zt5CG75znZ7bXJrCSGFtYQQ7wg5yV/9svwb8SoMqjWZ3vZ/0mtmxD/P7TFivh9S98vvvvPIk3JBMFeM8YmQQtKRxVIIKS+AE6uk91LiJlshJOuo9bertshVl9I6eWvMQoh3hLTB6gpmZuIXyvv+xJq/RgipJdppR84hhNQWLnOsnk0UJMOXI6WQOeNA8zyDDOUyt13UCOhy6/n3uy4mI6x8EYI7Nyu89IJjHsfapcUVfymXtGrMI488wsyZM5k8eTKdOnVi1qxZnD17lvvvv9/S5rnnnmP//v2sXWvND1FdXc13333HtGnT6oXWXGk8NaoNM1cc42h6EeuOZfGf5cd49br2l7pbF5e6MfLni6Pbudv8WXQ6WR2nofdu7vt3nyL/atP+eumymJUl3dhv/UGuDNidRyy6s7dtJR4zrRrJUq7TwcAn5J+ZntPlBKnPg9Ciq/yrjbkEIsi+tR1ru9+cKBVqfsDs5PsMf6nZl4FPpDREzcZoQ+jtpMDTu2ZCMulrWQkoZjx0mGhtd9cSuaIVOUweE9zZ1qiKHmVbYab7VNjzpfwRbD+hfrJJr1DbktQN4dSId5mrL1w/q+lje06Tfw0dO/kXKQQ4eYBbUH3jwCuMnJsX45+2Bt2ZLXLFzt5Jig9fXSNXRD1C5ITcu5WscrRwujQ0e9wty0xHDJKGa7epsqJU+CDr9fZ5QCbpG/S0vE80nezLXUul4WU0SGPPJ0pWODKUS6MsfoF0Ix/5T/ns3PCpXOFw9pb5SvZ8Kcf9zFZZPWrMfyCsv0w861RrYnXNv+Gnm+X/e02Xx+ybI1cWR/5TGtLLn7Uaj87e0n175OvgE0lR+EScfGq8wDreBH5t5flNBml8hvWT7sIpe+Tflvet7vLDXoRTGyFpqzxu/PtSZNr7Nax/UyZStnMCQ1mNCCLd9S2rsj3utgi7lntg+0fS0O85Hca/JxPrbvs/KYKMmSkN5MAO8jMc/768rrI8uONnKajt/066fYMsbe4TCZnxsrqERwuZuHjXbCn2mVfCvVrBvWvlxODkGimQdJ2MCOkFTZSr/zswaNAgNm/ezCeffMJnn31G9+7dmTdvHm5u1u/ttm3b2oTkNueYAwcOMHOmDCccMmQIixYtYtGiRdx9993cfffdF+36LgY6nca7N3flptnbOZlVYrPveGZx84UQe2e45Vu5Chw1oum27cbD0ictIS20HgVYS+WK0N5oe76gMuUgjnVL5Jp/rzxD5fdDLSFZM1ahL0qBoJrQBHO5XbMHCcjfTrMofuevUjxO3CxfO3pA51th/b/lqvbG/8ik4TP2c96U58tqe7kn5PfIwCfkd6Gml9+5RqvgRNZhGX5o9qKpEYfRdHJinZ9UI4TU8gg5vQE+HyrFnMcPNC5O1KWiUE6whVEKQuaKgT3ult+vZjFr7T9lXq+WPaTgsO0D2ZeT6+Tn1xC1PUJyjsvqfCBFg5Td1n3r3pDfbR1ukMnT19QkSY++Ria4b4yqUqvYIoyQtAPaXNO8675QmL1lvCPkeIBc5T+zpdbreNtjUvfVOv40GCrkb0BdSm296DHnt+l2J6z/l/y9MBpsK8YVZ1oT7JvvmwtNbSEkI14KcuaFsrrU7kOtEC/S9st7viBJFlII7HDu901YDgfny8TrF0IIObsTdn8G9i7y3j4fW3zVS/Len77K1oZpLiZTTR4+ZDXC8oKG50dbP5DfD/0fO//3OBdVZdJ+P5/rvsK5pCrC008/TXp6On379kWv1+Ph4cG8efNo184aL5qXl0dGhm0M59KlS8nMzGT69OkXu8sXnAGt/fj9sYGsPJTBgz/s4+ttiZiE4KVx7f5eniGK5qFpl+YLaMxMGZPa2GT+fLiY/W8/Qf7VJWLw+Z0noB08tk96STRW0vZSodNZ4+4bQTi6SxGr38PWjYEd4Kkj0mXa2dsqoMSMg5drfafWNhLtHGDoC9bXt/9k+0a1f5QjBsm/xuhya33DxJxY0DMERta4vPtE2AqEdQ2I6FFS8ECzVuAZO9O2zYNbpUeQW6B0cTdfa0PJO2u74frUimOOHCr/uk2Vk46ADrKkc8ve8OsJ6bGkafIZGfiEDDtJ2SPH88ebpfE96Wvp5ZO6X640d7q5/vv3f0wKMubM/hGDbe/X1rUmiI5ucN8G+b46vfQcKkqXYkaL7lI8cg+SQlC3mjH0aw13zJeCS3aCFGEGPS1FqrZj5J+Zyyy56V9F37596du38QpHzz777HkfM2bMGMaMGdPo/r8bni72LHl0AP9bmcCGhCw8nOyJTy3kRB1h5JxEDZN/58LZW7Y7sVpO5M2lYHtOB/cgjmpRtAccC0/VP9acf8GzpcwfYkbvAMYq7PJPQmWM/D4zh8aYPSoB2oyFa9+RE27/GPk9YV7lb9lLPouDn5ZiSFmOnNznJ9m68wsBB36SXm1m0f3IYunxOfotKXz8UlNxzt4FbpgtveW2fSgF4ZzjtqJBRaEUbdyD5OSvRIbWEdJDfg+ZJ6K1Q2NACkklGbLyX0Mr3CajTTUazVAGiTutnnDxC+U5nLzk76SmyfHNLpSCa9xcePIwnN1lneSfXNu4EJJ7utb/azwDXAOkaFCXlf+QYYM1SdkBOel1C5KijmdI/WOyjlFbMCNx08UTQkwm2PKONfzKJ0J+tiA/z2O1QqCaEkKESQoEDXlulDRQycjeRQrgW9+XCx+Zh20Xs2qf+1zhUnmJ0muk25221QebwmSEQulZZXTxl6GuKXubJ4TknIRDv8pz1L7fT2+qL4RUV0qRp/biY2qNAFmUIp+RPyJANNQ3Q5n87gjt3WRzCyYT7P1Gev0m7bD9nW0upVnWSpkIadPEXGvbpijdUmCCiMGyst+FojRHeuB6toR7112yMswXm0sqhOh0Ot577z1mzpxJYWEhfn5+9XJkvP3221RVVdlsGz58OKmpqQQHB/N3YUzHIF4YG8PMFceYs/0MR9KL+PiO7rYZ2RWKvwqd7sKIIFcy5+s6fCXwZ42CywFNk+FaTaG3h8ghF+b93APln5nIIfBMA6toQR2tosp966WRZjYcW59jtbuhRHmNUTukTG8vRY68RNsy2JMX2B7TZrRt6IFCcQFwcbDjnxM68E868N2OM1IIybQmaswsqmBFfDrXdAiihVczvQ+aovtdUgjpOMkqbo5/D4Cj+1IoM7Whp67m2YwYbPXacK0Rs7tNkSFpZqJGwPEVeK96BLH5ZRm2aA6Nqf1M6nRWr0OQwsjOmpxB5pLhPe+Rf1+NhuSdcsLtPVXuE0JOSte9LsWXpxNk/qIlM6QHREA7OfE7uQb0jjBtuVXoeeqoPObHSdaJoTlE7+jvMu9FSk3Sdt9oCGhfI4TUCCC1Q2Nqs2u2rNBh/s7IS4QFd8lQiqBOMPAJtIMLCDi+0lYgNntpBHe2HhvUSa7Yg5x87psjvdbMnFxXU7klTfa3+1QpbAlhO9k107Knrf3h6i/DOIrTpHBUOyF+/EKI/VGKYzP2y7AXQ4X0fss6Yg210dlLAefwb+DgBv0frR8iU1EIu7+Q3hIte507FCI7AbucDJk/Li9R/r7Wrhp0aKEMqwTpNWQeRxc/KZjF1VpYyDpizesC1gm9+bPOOtawEGLOEWLOUwPSa8bZSwr5x5bKftgIIXut/885YetZVJfVL8tzHFsqPWubQ3EGmAwInR2V4SNwOTJPXk9tT+Ha1BZCso/VhKvKaoQWDi2UIW1Rw+XCg8kIswfJsNrpq61jmxZrPSbrqPX5BHmdm/4rvbhqLxIJIfO0BHezlqg3J3s3i3Mg76nmCiEFZyyJjaWXyx8QQmrnBALpLVtXCKntQbPrc5j4MReM2O+lwFqSKce1dpj235jLIq7EwcGh0QSp3t71Xf49PDwuWJLTy4kHh0QR4efK0z/HsTsxj+tnbeX3xwbi66bEEIVCobhs0embv3p2Id7rKssmr7j8iA6Qk8rjmdIj5Oe9yfxzyWHKqox8tP4kn0/tSY9WVvutuMLA8cwS2gS64e5k3+A569FuPDy239Zbo4aU/HK2Vo+gp0PNpCq0j/S0KjhrzWPRdoysHLLyebmtRTc4vgJAlgVf/rQMGwDb0Ji6tBltFULqTowih0ohJG6eXME9tUFOes15SIxV0hPE2dsaBrLzEzl5BBkuaBZBQAomIMN6zEQMknmGVtYkuXb0gB53Qe/7LZXnSN4tPQHqVBUBpPdJRrxcSW53vQxB2PRf66Q6bT/8PNWa26puQlmwjinIkNeAdtJzYf2/YMfH0lPFTOFZOeFe+5r0XklYKT/DY0vlSjtI70tzToyQHvKazIT0kOF8uz+DAz9Aco3wo+mtx5dmSRHDvy2seN4a+mGm443SC6YoFTbNlH2tG6q75T0ZzgOw71sZduNWE0YphMyZFdxVenbknkL7Yih+1RWynH3iJhny+chuq6hgFuJ6Todx79ZKBtzZGp6l6azhlLkn5DhWFFqFpehr5D1qfl0X82cW2MEqhHSvEeC63iHHOG6+zKViFllSagkhVcVSoDJ702x6W4ZoXfOmFADNwmHiJik4db1DhsB6htqG29TGPIH3bElVYFcphNQWKMwIId+rthBiDn0DW8HG7MWSuEk+EwHtrfflz3fB9DWyP2kHrMdkHZFeoV5h8ncyebcMXQO5oGH2MNk3RxZZiB4Nk3+Wee8+GyzPZ/78QYbb1F2EyT8jr8OnjgdT7Rw+tcWU88E8juZwtzOb67epfe74BTJU1yzm/BlMJjkuZo4svmqEEBV7cZkxukMQix8dQCtfF9IKK3hreRNJkxQKhUKhUCguMm0CpXt6cn4ZKfllvPzbIcqqjLg66MktreKeOXsoq5JiwOxNp+j8+mpu+nQ7T/8cd35v5BvVYMnP1IIylpv6UCBqhIOgTjKHxYhXbVe7+z4ow8vumG9JaGpy8kbYOcmJq3ly1YDYYiGsn3Tzdw+WngO1iRwq/03aJsNESjKsIohfTeWT+IVyn5n8MzK/UPggGdLQEGYPRRdfOTk203oUPLRdTly9wqzhB6c3SLd2kKLLsJryq4OflWGTIMNuvhwOy5+RE+qgTrKKSL9HARD2Lhi8a3Kh2TlJrwoztV3wvcNh0FMyzM89WCa7Nk98fWtE2v3fWpPUnt0ukz6bRQywTRTasqett0ZgR+g2Wf7/8G9ywq93kF4dIPNRgczTNO8OKYK4BcqxMhM1Au78RXoVAcT+AMufg/c6SJHGZJKfiwVhW13o6O+w4G6YPVDmZVr6BFp1BQBa4kbZPue4NWQKrGFYkUNt78FhL8twJ5BJgM2ikjk85uhSOfH1jbbeT1nH5AR952zIPi4n3+kHrSFRbUaDg7v0ogjtI7dFXyO9T0qzpMcDyOs0fzb6mufILETknIANb0qR79R6qKwT5rbkMfjmWvi/bvKeMVOSLcWI/4ZLkcUihIRh8K/xYkmPk14cZkwmmHsb/C/COpl38qJB7Gpyo2g1IVsrnpPCnZmMg1LAyk6wemEA7PgE/q8rzBkPFUVWkRCk+AgytGaL9Crj5FoozZVeT9lH5XkTa4kPZ3dKrx0zeYnw6QCZM6iiTlJjGyGkAa8nkJ9h7Pfyc2wIs1dXZE3oYMYhW08rsE00a6yUYl/eaZmnyOzVUlkiPdIO/SJFtrp9aIjEjbbeZEcWN972b4YSQi5DovzdeO+Wrmga/LI/hZ/3JpOQUczKQxlUG6+OmG6FQqFQKBSXJ75ujvi6OiAEvPH7EaqMJjqFeLLrpZEEezpRWG5gd2IeJ7NKeHtVgsWm3noyB6PpzxvYqQXlVOLAE4aHSW47Ddpe23jjkO4y9CVqBKY7F5F92wrE0Bet++2cm/YIsXOA+zfJCipmjw0zLWu58zu4wdTFMmfGU8dgyq9ye9JWmXcBZM4hkJO8sf9rPETB7Prv3w563Qc3fA4P74I7F9om7o4eLXMR+dUSFnR2MGAGTF8Lw16SOZZu/UFOmj3D5ER87NsyNKhFN+mV8tAOxEM7KBj7KSKwA/R9WOZHMVPbI8QyLo5w3f/Zbuv9gPx3xyw5ufdoWZNg20vmXQIpAFk8XjTZh9qhMUGdpPDSqlZS1NA+MPwVeU0P75RiiDDKax34JMyIhRu/sD1H5FC49m1Zaa04TXqYFKXIqiDJu+T/HdytHhVnagkhh36R/1aVSEEgcTPCzonCQa8hYmpVtjyzVXoDZcRby97WTTbfsgfcswJeTJVJzINrxtJcLtdcGazzrdZ8YMk7pUfNyufh2+vgl+nw2SBrWFRAO3gyXlYuNN9DentZHh1kVbHKEvjlHlmJyN7VmpvHLITUFuf2fGHd7uIry1kLoxSxAA7MlZPqtAMwe4D0linPrwktqhFCvEIxekXIcu6GUumNseltKWZt+q9t9SaQSc3r4uxTk1tLg4mfSOHIXGUHpNcXyGTrZ3fYHmsOGzm7XVZCPPyrdd/BBTJcZ+en1v4KIxz7XeYjMWNOUKx3kN4zGTWihRDw+wx5P1QUys+9NrUrV9WuhAMyf0pFIQ4pW9H9PkPmFKuupB7mRMcte9U8z6KBa6wRQsw5xtL2w6JH4Nf7rJ/nxv/IRMYL74HPhlgFrg3/gZmtrPddbcz3e5fbpRCVn2ibX+l8KUyRY15XXKuNodxWaLpEXBahMYr69GjlzeQ+Yfyw8yzPLbSqh3f0CePfEztSbjDi4qA+PoVCoVAoFBefbmFerD2axeojcpV6ar9WuDnaMSjaj5/3prDtZA6nsksxmgTDYwLYeTqXsiojp7JLaBP450qapubLsIqNpm5si+rEbY257ddG0yByCCIrC/rPkNVh0g7ISeW5Qtsaq26nt5deKCfWyIlb7fwaICfzSVvlpCt8kExw/N1E6aUR2ESFwJhxMOgZ+a+dQ+MVMRzd5OTaUAEzQ+VELrSPFClCa3mvtLtO/jVGYHswmTBWOSEe2Iqm08kQisx4KRQ1VDUPZCLSW3+ERQ/LCmM9p8mEpuYwh+Evyf44e0sR6cBPcgK87xu536+NzLXhUCsBpjk3xh3z5WQ2dZ/Mx6K3t17TLd/KyXn3qVbxoPUImDBLekQE1BRdsHOELrdZPQJA5mYxVwZrN156j+z/ToY2gZygmYWrrnfKaylKR4x4hfKw63APeAJtw79lYtR1b8hQKHtX6Qnk7GMb1lT3swIZ+gMyFCGsr3Ui3mmSFOTMyXnNfTYnu62Na0DD1QK73C6PS1gBvz0gQ110drIaX94pKUaseA4OL7L1Zjm+yhqiFdDeei8n75QT+4IkmT/k0K9SDLActwK0cQAIz5qQlKBOcgK/+e2GxwGkKOYXDQk175d3WnpJBXaQScGHPC8Fv1YDZJ+rK2RS2Os+lJ4aRamw6X/yXOGDbMvNOntbvWBc/KTnVNp++KJWkmZzueHDv8lKKbVxcJM5hxKWS6+RkO7So6i2t8ip9TJ/R3WlrPRS2yOkJENWUcpLlGOWuAnNry2OLfpb98cvqJ+TxuxZ4xUmrynnOCRukd8BZsxCSMcb5edcO1Hy3m+gw41SBAOroBH/s3x+4n6S1Z62fSgTu5sRQlbHA3kPVlfIcVn6lHxdlAYjXrMWQjCZpLAljBAxRIbHBbSTomviZulpVROCSJ+HbJPbF2fIRO5x8+Rz4+ILE2fL5POXCOURchnz6vgOPDmyDe6OdjjY6dA0+GnXWQb+dwPtX11FzzfX8N2OM5e6mwqFQqFQKK4yXr++Iy08pRu7l4s913WRCUcHtPYDYP6eZNYfy8JOp/HyuHZ0qimzeyC54E+9r8kkSCuosLxOL6xoonUThPaGPvc3Xf2qOQx6Gu5ZWV8EATlxG/IC3PaTTGoc1AmeOwVD6lcqssHeGUa80vw4fXsneDxO5g2p7e3yZzDnVAjqaFNZph7txsPzZ6ToobeXkywXX3BvAe2vl+FNLj5SlOg5TYbFBNYkmjZXzKqd2NtcQcbRTQod131YvzpGUCcY81b9imrdp8jPo7anTY9pclIY2NEaimQOS+k4yeqZkHVYJr/9sIv0aPAMlWXPH9kFL56VuT/MhNccU1ZTztYcotGi67mrbXS4UU4gq0pg/p2AkGKRT4ScbI6tJSAEdZIiC9iGZbn6NXzu4M4Q2EkKYuZ8H5MXynExh2qB9JooyZDj3mqA7MO2D+U+/xh5DUOeleFFPWrCi/Z/J/scPkh+3i5+1lLLYA3nqp30tMMNst8uvtLT47nEmsnxf6VAFdBBConm8J6AdnIMzF5PXqGW0C3ajpUhVOZExmYxa8ATYM5wEzFEVjwxX2vnW+T92Hac9PJw9Zfvf3uN98TpjbZlm0Her2YPs2NL5eR9dU1+GfP9emq9DIGZPQhm9bCKSuYqQRvegq9GWTxZtJwEnI/VCtXZ/pEUFIozrKE0NkJIjTdUbc8To8EavmL2jMk9afViSdktBYryfCmoDavp8+4vZDiT+fxHlsjqQyYjHFsmPT/M4Wdh/WDUv6QHV9p+WPUP6d1VW4hLWCbz7mx+G74dL72r9s2Bd6Kl55JZBAE4scr6/9Jc+Hq0PJ/5uSnLhZ9ukaE8lygUR7kUXMY42Ol4fGQ0Dw+LwmgSzFp/klkbTpJaIFdCckqqeHXxYYI9nRnVXlY5WH04gyVxaTw5qg05xZWsOZLJw8Na4+N69dSEVigUCoVC8dcS4uXMj/f15bUlh7mhWwuc7OVk2SyEFFVIt+cp/VoR6e9G11AvdiXmEZdcwC095USnoKyKH3edJbOogv5RfozpGNTwm9Uiu6SSqlphwhl/VAi5GPi1hmEXSJg4Fx4tZCjIhaLL7XIi1mv6udvqaq2rereS5ejR6ocSmel8q0zYaZ40+7eF8e/L0B3dBV6j9W8DMw7I8BshZK6M4jSZ6yRquHw/sxdG8k7rce2ua1zUCO0jPS3M+WDMBHc9d3/sHGSo0vw75UTZxQ8GPmXdHz1ShqYcWwoTP5UeOcVpcpK6uKb6TWMeSiATnK560XoN5pCY1iOkSOIbKSe98QtkKFNwF5kfxZzDpa641OkW6fkCMn/F7fOk8NZ2rMx5UVUs88mE9oZqEL3vR6sqkfdPWJ/6/avtIfBwjReOnaPMW9NQ5Z5h/5ACT3iNYNn9Lun9gIBr35Xj5ddG5vvpPlUKGfetk94crUdJQe32n2QYhqaz3l+tR8o2ID15TNUyjMg3Wl6bppNhJAumScEnuCvc/C283Vp613zUgEgZ3EV6w5i9eaJHy3vo+Ep0Zk8aexdZLWfpE9Izp7JIVsYxJ/z1CrOGpWXGW/OEpO2XXhj2rtKryMW3fnLkrTX5T7pPleLXxv/IJLI7PrK2MRlkDh9DOWx5t5bQ1ls+rw6u0iNo/p014oSQHiInVsuQF3PeETsn6T0SPVp6xBSlyGeq4yQ5fl9dI5+pgrNSWPl5qhRyvFrJ76mWveR9te8btPzE+mN5kVBCyBWAvV6HvR6eGBmNm5Mdro52jO4QyEfrTvL9ziQe+mEf3cO8cXbQs+m4zCh9LKOYjMIKSiqriU0u4Md7+1iMlLqsO5rJL/tT+Nf1HVWFGoVCoVAoFM0iws+V7+6xraTi5+ZIu2APjqYX4elsz+MjZFhF55ZeAMSlFCCEoNokuPubPRYPkXm7k9nx4nB83RzZfiqH7OJKJnRpgVZnMppSExZjJqPoMhZCrmTc/GVVjT9CQ2EbtdHbWRODmul5zx97r+bgEWz9/5i36u+PGSdX6cP6ywlxToI10WpDONRMRpN3SVEnfoHMZVE3P0hjOHnI8rQmY8PeNhM/AfGxddJurhR242fnPnenm2WOCFO1NWkuyIooD9XyMBj3rqzWYzLaluP1ryOEeIXK6iR5iTD6LSmCALSbIIUQTQeTvpJiUlaWTDx83QfNGQUrUcNlDp6G0OmlZ5EZFx9ZTUqntwpVEz+ROUA63ChfO7pLb5Ta6OtMeW+eA3PGSbGj0ySZo+PEKinKufpJsevsDuk9o7OX3kEuPtJLy5yrJaQndL0d1rwmBajayU073gQ3filDbGryowifKLR+j8Cyp6QYYWbr+zV9dJSCpt5e5gfKPgprXpWhS6VZso1vpLzuoM7W0tJRw62ViZy85L3r7C3vhf3fwvZZNWNXU8p58zvWZLZmb6baz2PMOJl3pyRLerbU9uwAGT706F7pfRLQDqpKpZBj9iYCmT8peZdMYnt8pQzTcXCXIW/m0LXrPoDIoYjo0ZBXJ7HrRUIJIVcQdnodDw6Jsrx+9br2pBeWs/ZoFrvPWB8+J3sdJ7OsMXz7kvIZ88FmWng5k5BRjL+7I35ujjja6RgaE8C/lx2hwmCitb8bT11jdZ37fPMp8koNPDe6LTrdOVz9FAqFQqFQKIDru7bgaHoRL4yNwctFeqR2CZXhD4dSi4h4cTkB7o5kFVfi4WSHj6sDZ3LL+H5nEsfSi1l5WLq9ezjZMywmwObcKfly5Vqv0zCaxOXtEaK4Mhj+ikzM2aKbnGALce4Ql7H/lWEhg56WyVuTtsp8I+dDYyFHmnbu928MN3+YtlwKIXW9O2pjDkfS20HPu2UVHpAT8LoMeLz+ttYjpUAS0EF6ZZguYjGHuqJGy562iYubg6M7TFsBx5ZD9CgZpuIZYg2fihlXk6xUgxs/t+au6XWfzJvS5wFZlUlvL4UHvb2sSHOophrRuHelkBU1HGHvgmYokyEvvaZL0WDr+9CiuwwXi/1Rfm6dbrGWKR72ovSiiP3ett/mSlHBtYSQ/jOkR1V1pRSizJ5Yve+TQoioET2GPCcFE3PiWrMwArLEcN338WpV421Tk0jXvYX0ThrwuBQXzQKjo5tV3DATOVQKIbs+la89w6RgVrddh4kX996pgxJCrmDs9Tq+mNqTpNwy9pzJo9xgpH2wB+mFFTw2NxZnez2vjG/Pm8uOcCa3jDO50njILa0CigFYdyzLcr5l8ek8OaoNmqax7mimpXRv55aeXNtJ3uxpBeU8NjeWrqFevHRtOyWQKBQKhUKhsOH+QZHc1L0l/u5WL9MQL2eL+AFY/v3fpM7klxl48dd4PlhrW3FhSVwaw2IC2HMmj5krjnEyq4TCcgMAHVp4cDClkPRCWw+RpjCZBKuO5WF3poI7+rSq522iuEqxc7SdSDfnvmjRzZpgdOjzwPOWXcl5ZXy1NZHpAyMI9TlHIt6/gvMVBbrfDbs+l94Irr7nbA7ISX5DAsmVhIMrdL5Z/t/ZS4oJZrpNkV4mMeNkclIzXW6VuUdq3yNm8aLnNFniuOtkq1eUg4v0Don9HtF2nMxmMvKfUvTwbS1DpcyVi2rT/noZKhT7gxQs+j0sBZOuNeFDlkpOmvRSqZ1nx0xQJwjtaw35Cu0tr2vBXTI8587fZAnl6kopytRF06RAuPl/0mvo0d1SMGooH1JdIoZYyx4Hd5EVtc7lKXYJUELIFY6maYT7uRLuZ43DFEJgr9cI8nSma6gX4zoFs+N0LgVlVcQEe5BXWklhuYH4lCLmbE8kyMOJnNIqTmWXkpBZTEtvF15eZC0F9X/rTjCmQxAmIXhi3gH2JeWzLykfRzsdz1zTluKKahzsdDg7NJFMS6FQKBQKxVWBTqfZiCAg7ZUPbuvKnsR8RrQL4Eh6ER5OdozpGExJZTVvLj1CaZURJ3sdT49qy7+XH2XNkUy2nczhvu/2UlZltDlf9zBvDqYUUlRRTWllNa6ODZu0OSWVuDrYUVlt5J45e9h/tgCACD83+rduJOlkMzAYTexPyic60N0mD1u10cSuxDxyS6vo0MKDKH+3Js6iuJjEJRfw6Nz9TO0bzn2DmzGZ+4O8/vth1h7NYv/ZfH59qD92+r+2NkW10fTn3sPNX+Z1sVPh8RacveDmbxre15hQ5uwtPYXqIMb+j5w2t+Mb3c+6samqUWaufUfmJokcJsOjBj1t3Rc+SIofIT0bFkHM9L5PCiHmhMF6e5m42WSSYtbNc5ruQ7+HpddI18lSOPKNarq9mZa9rCWzJy+8LEUQUELI3xJN0xjT0RoP6eli32ACshu6wQNDInGy1/PMgjjWHMlk2cF0iiuqSS+sINTHmYJSA8cyivlo/UnO5pWx+0weDnY6qqpNfLLxFD/uOktRhQF7vY7nRrdFr9MI9XZhZE3y1tosO5JL7oECHhsejbODnt2JeWw/lcPd/cMtrrN/lAqDEYPRhLuTPQajCTudplZ6FAqFQqG4jOgf5Uf/KCk+dAyxGu9ujnZMHxTJl1tO8/6tXRnVLpCvtyWSXljB5C93ATAo2o9Hh7XmxV/jOZ1TSr8oXxbuS6GkspqvtyYSE+yBh5Md+WVV+Lo5EhPkTlxyIfd8u4c2gW50D/O2iCAAiw+kWYSQ/NIqPlx3grZB7oztGMQHa08wpI0/g9v4sy8pn04hnjjZ69iXlM+qwxmcyCrhUGohOSVVhHg589sj/Qlwl7kT3l1znE83ykoQXi72bH9hOC4OjZvbsWfzcXeyo3WAbUnhCoMRB73O4nmbX1qFXq/h4dSMUsF/kuS8MnJKKukW9tdNXoQQrDmSibODnkHR/phMoiYi5K+x3YoqDDw6dz/JeeV8tTWRewdF/OH3EkKw/lgWxzKKmTYg3ObzTcottXhbH0wp5LPNp3lkWOsLcg0Nsf5YJo/9FMvNPUP554QOf/xETh4XrlNXKUKIhu8pOyeM3s0UEGpj72ytklMX90B48rBMfNsU7a+Xni0BMVbPFWh+UmJnb1tPmeZi5wAPbZNhZhc6AfIFRAkhVzmBHvKHe3znYNYcyeTzzact2dhn3tiZfUn5vLfmOO+vPW455u1JnckuruTDdScsLqpV1SbeXHYUkELp9/f0YWC0NDCEEPzfuhN8sO4MABsTsnFztLPkNTmdXcqN3UNYfSST50fH4OkiH9RT2SWsOpyBh5M9t/QMpbzKiIOdDid7HeuPZdHS24W2Qe5UGIxc+39byC2p4l8TO/LWsqMEeznx60P9630hHcsoorDMQJ9IW9e/wnIDrg76BhX10spqdJpm8XgRQlBWZbRZfTIYTTz9cxxGk+D/bu+G/gKEDAkhar4/tL/UQCitlB499n/xioVCoVAoFI3x1Kg2PD4i2vL7eW2nYL7aKqsJjGwXwEe3d8fZQc/yxwdxMquEDi08aOHlxPHMEt5dc7ze+Zzsdeg1japqE4dSiziUWgTAXb2C+HZPBisOpfPGxA6cyipl+rd7LGV4v9mWyPHMEn7adZb+rX3ZmJBNTJA7EX6urDiUUe99UgvKuWfOHhY+2J/8sipLn10c9BSUGVgen8GkHi3rHZdRWMGzC+PYciIHZ3s9a54aTEtvGUax50wek7/cRQtPJx4cEsXgNv6M/2grVdUmvrqrZz0bpi7HM4v5dOMpvF0cGNspiF7hPo22rao28cIvB/F2teeWjp48/fVutp2U1SgeGRbFM9e0PaftUVlt5P01J8gpqeTNiR0bTc5fe8yenH+A3Yl56HUay2cMYvq3e/Bzc+Slce34emsiPVp5M33gHxcr6vLG70dIzpNhVBlFFZzIKqFNoPs5jqpPpcHI9O/2sf2UHKOU/HL+c2Mny/45288ghEwanFNSydurEkjIKOa/N3WmtKqa+JRCfFwdyCyqwN/d8Q+LTYVlBpYfSue1JYepqjbx066zPD4iGm9VJfKiU1BWxWNzYzmRWcLSGQPxu1iFJxybcf/q7RtOENwIyXllrD2ayZ19W/35ecGfyXVzkVBCiAKQBseSA2kWFXtSj5YMaO1Hv0hffN0ceHf1cdyd7PjPjZ0sqzlT+4VzKK2QEC9nfo9L44edSWiaRmJOKTPmxRLm44Knsz2F5QZLVngXBz1H0qUxYk50tiQujZWHMqgymjBUm7h/cCT/XZnA2qOZlv7NWn+SrOIKWge4ce/ASJ775SA6De7s2wp/N0dOZ8usxzPmxgLyRy4+tZD9Sfl4ONvTO8KHubvP8unGU5gETB8YwYtjY9hyMofXFh/mbF4ZfSJ8mHtfX4xCEJdcgE6n4elsz62f7aDaJPjqrp70aOXD0wviWBSbyv2Do3hqVBsc7HS8syqBJXFpAEzsFkJhuYG80koCPZzIKqqkX5QvQZ5OLNibwvjOwZaY0b1n8qiqNhLhals/+2h6EU//HEdOSSW39Axl4b4UHO11/PO6DpbEcasPZ/Du6uMMaO3H82Pb4mh3/qFJB1MKuPPLXQR4OLHggX4N/oDuTszjp11JPDq8db0Vq4uF6Q/WF88pqWTaN3sY2tafp2slAlacP3/a9fYyICGjmFcXH2Jqv3DGdQ4+9wFXGNtP5vDo3Fj+OaEDE7q0uNTdUSjOm9qLCA8MiSSjqIL+Ub7c0TvMMiF2stdbvEmevqYt83afRa/TkVZQTllVNd6uDmQUVliEjRaeTqTV/L9HmBf392vByoR8MosqWXskiw/WHie9sAJXBz2lVUaOZ8pk81VGExsTrJX4jmUUY6/XGN+5Bb0jfGjl60KAuxO3fraDQ6lFfLjuBFlFlVRVm+gd4cOQNv68vSqB+XvO1hNCqqpNPPDDPuJqbKNyg5H/LD/Gx5O7I4TgzWVHqao2cSa3jBd+jSfA3ZG80ioA7vpmN3Pv61tvAl1YZmDFoXRGtg/ktcWH2XFaTtR/3pvM7pdG4GinZ+7usxxKLaRvpC/jOgdjr9fx7fYz/BqbCsCGo06czq1Ap4FJwMcbTmGv1/HEyDYIIfhqayI5JVWMah9I9zAvNE2jsNzA3d/sJrbG2yYmyJ3JfVphFAK3BsKVjmcWM/Wr3ZZqP0aT4NmFcaTkl5OSX87Ns2X1kBWHMth/Np8Pbu2Gg1393x4hBEfTiykoq0Kn03C219MpxNMmd12Fwci+pHw8ne35Zb+sihLu68KZ3DI2H8/+Q0LIysOZbD+Vi5O9jgqDibm7zzK2YxCD2/hTUlnNgr3yfd65uTO7EvP4bNMplsSlEeDuyOYT2Zb7C+T9vvLxQUSfZz9+3Z/CK4sOUVoTLqZp8n79LTaVewZGnPc1KZomo7CC/606xj0DImw82UwmwZqjmfx35THLPGTloQzu7NvqUnX1T/PoT/uJSynETqcxpV/4pe7OX44mxB+cYVzBFBUV4enpSWFhIR4eF8YVzGQykZWVRUBAALrL2AWoKYwmwaz1JzmeVcy/J3a0CVepNprQado5k6OWVxm5/uOtNl/0IFdmHh4QwvgeEXy97QxR/m6MbBfIu6sTWHQgzaatg15HldGEToOB0f7EpxSQX2aw7DcLKHUxiy5mogPcOJFVUq+dmdEdAtlxKpeiCmsd+Ml9wlhxKMNicDja6aisNlmu4a7+4Xy26bSlfacQTwZF+/FJjRssYJMMzoydTsPH1YGs4kpigtxZPmMQp7JLGP3BZkwCgtwdMJjgui4tuLZTMHd+ucvimVOXsR2D0Gkay+LTLdtigtx5eFhrru0Y1ORk9WRWMbsS8wjycKLaJHh50SGya/raN9KHL+/qhZujHUaTYMuJbA6nFfHh2hNUGU10bunJoocHnPMeWBGfTrnByLWdghtdFTqbW0ZLb2dAilYtvJxt9qcVlFNYbsDBTseMubEcyygi1NuFZ0a3ZXzn5k/wPlx7gvfXHsder7HtheGsPpzJkDb+FiFqy4lsXBzs6NHq/Fdk4lMK+S02lSBPR8Z2DL6gCdGOphfx8I/7ubVXqE2lqIZo6Lun2mgivbCClt7O9VbTKgxGtp3MoVeEj8XFusJgJKuoksziCo5lFBMd4EafCB/LsfN2n+WNpUd4cEgUjw1vfUFW6Ewm8ZcnW649NvllBibM2kZqQTl+bg5sfX74OVcta5NXWoVe0ywea5cjj8+LZfGBNFp4OrHpuWFNruZIt3vtgv5u/RW/rX9nlC3y1yGEYOfpPA4kF3BH7zBmzItl68kcfrinFxFuRr7Ym8tXW89gr9cwGAW+rg6sfGIwj8+LZefpXF4e154528+QnF/Gc6NjmL/nLOUGIx/f0Z2edbwr1hzJ5L7v9tps++Wh/rT0dqbff9ZhErD0sYGWCVRpZTVv/H6E+XuT8XCyY+ZNnXn0p/2YhEwoG+zpxN6kfFwc9NwzIIJZG04C0jbqGurF7jN5xAS5894tXVl/LJOqahNVRsGv+1PIKq4k1MeZ5Lxy9DoNPzcHMosqeeP6Diw7mM6uRGuFwZu6t+SFsTEMf2cjxZVWO0jTYMED/TiSXsSriw/jZK9jy3PDOZFZzB01YUoA4zoH89bETry7JoHvdiRZxtLDyQ4hwNXRjt8fG4i/uyPFFQYSMorxcnHg1s92kFtaRXSAG30jffl+Z5LlnGYBpkMLD45nFmMwCh4YEsmLY20rTcQlF/DG0iPsS8q32T6gtS/XdW7B55tP88SoNizYm8yWEzmWkO5xnYLpFubFm8uOMriNf73Sz7UpqjDg5mBHmcHIwr3JuDnaEelu4u1N6ew4ncsTI6PJK63iux1JOOh1zBjRGldHO17//QiR/q6sfXIIOp3G8vh0Hv5xv+W8TvY6PGrCuPPLDNzaM5Q+kT5UGEy0DXJnyYFU7PQ6hrb1Z2BrP8vv7ansEsJ9Xflkw0mLB1TrADcmdm2Bk72eN5cdpW2gOyufGNTob3SjoRtNkJhTSqi38zkXQiqqqvnnb7EUGXS8c0uXJsPBzkVhuYHDaYW0C/Kot0BnNAleXXwIX1cHnhzVhuySStwd7f/SPIXPLohjwb4UWge4seqJwRbB9sVfDzJ3d7JN2xExAXx1dy+bbVfK9/KB5AImfrwNgKFt/ZkzrfHn40JyocfnfH5blRCijI8LTlpBOb/HpRHi7Ux+aRWlVUZu6NoCUV5Yb3yS88q4btZWWno70ybA3bIqMaytPy+Pb0+UvxvZxZWsO5pJYbmB/6yQlWz83Bx564aO/OO3eHJKqojyd2Xe/f1YcySTsqpqS5gOYFHtu4R68cDgSISQE4bqGjGlc0tPRsQE2oT/eLvYU1plpKraRJiPCxF+rmw6nm3ZP7iNP3HJBTbCy7jOwSw7aBUnuod5yR8OgU15Y4D/u70bexLzbAyA2u+dX2ZgULQf/aJ8WRybxvjOwRRVGPh62xkbEWhSj5asPZpJQY1QFB3gxusTOtgkgCssNzBzxTE2H88mtaB+dv0of1cyCisorTLi6WzPPQMiOJZR1KAL8NOj2tA6wI1R7QMtP4qlldV8svEkheUGuod589TPcQD4ujrw/JgYimoMoMeGRxPq48wriw/xw86z9K4xJnefyePxEdE8OaoNGYUVzJgbW2+8anNXv1bcMzCCvWfy8Xd3JCmvjC+3nKZ3uA+39ArFxUGPg15HiLczo97bbLnmSD9XTueUEuThxK8P92fhvhTeW3McvU5j3v196dLSi9eWHGLX6TzevrkzK+IzOJNbxhMjo3Fx0PN7XDrbTuWgId16U/KtY6nTYGLXEF4YG0OAhxMHkgt4bclh8kur6NTSk2evaUu4nyuV1Ua+257ED7uSKCgz0D/Kl8dHRhMTZP0eEkJw2+c7LQbr/yZ15paeoZb9BWVV/H4wHU9ne0a1C8RBDwt2HKccRyZ2a8kv+1P4ZtsZUgvKGdkugDcndiLIU4bAbUzI4qXfDpFaUE4rXxc+m9KD8ioj9367t6aalJWOIR58O603BqNgxLsbLStPDw+N4s6+rXh8XiyDov2ZMSK63mckhGDd0Szm7TnLrsQ8RncI4p2buyCE4MN1J5i7+ywFZQamDYiwKc+983Quqw9nMrJ9AH0jfCmurGZjQhYtvZ3pGuptMT7iUwrZkJDFtZ2CbLyUDEYTQmBZPaz9vXzPt3stq7sgn51yg5GHhkTZrPA0xNojmTw2NxY7vcaXU3vSNcyrWR5YheUGHO10FsHldHYJxzNLGBTtZwmtu5CCUP//rLOsfH94W1eu7xpi2ZdVVMH7NXkPWno7M/3bPfznhk609xZKCLlEKFvk4lFVbSK/rAp/NweysrKwc/Xirm/2cDhNeqi+PakzN/cMxWQSZJdIb87SymrySqsI9XGhumZhorHJ4APf72XV4Ux0Grw8rr1lVf7+7/ay+kgmHk52RAe6czq7hAqDiXKD/D79fEoPrukQxJtLj/BlTUiNmUeHteaZ0W35addZ3lmdwJOj2jC+UzDD3t1o+c1viuu6tKC1vxvvrz1uERhcHfRM6BrC3N1n0TToFe7D7sQ8OoZ4YDRJD4tpA8J57boOCCG44ZPtHEgu4L5BERxKLWLH6VxaB7hxJqeUapMgyMOJrOIKTAJ+mN6HV5ccsqyMA4zrFMz7t3Zl0uztHEwptGzv0MKDH+/tQ15pFcPf3WTZvuiRAeSXVTGotR9rj2by4A9SQJjQpQXJ+WWcyiphcBt/1h3Notwgw6XDfV0wmgQp+eWWhSuwiiq1X69+cggmIbjm/c042unY/dJIPJ3tSS8s55d9KeSWVlFcUc3JrBIOJBfQK9wbDc1ik5jFHk2DLc8Nw8fVgcd+irV4U5v3/+v6DpbVdCEEEz/ZbvH+eeP6DkztF87eM3lMqvF+aYwXx8bwwJAo3l9znA/XnaBTiCeH0woxCXh8RDQzakLJCssM9H5rLZXVJl67rj3TBkQghKDCYMLZQU+10cSc7Wf4v3UniPB347FhrRvM5VeXlYfSefCH/fSL9OWbab0aXDwoq6pm8/EcvttxxhIudN+gCF4aVz8ZqBCCE1kleDnbU1RRzS/7U+gX6cugaD8qq02kFZTz3prjLItPRwhoF+zBkkcH2Ij6645mMv1bKTxe2ymIVYczcbLTcUP3EP5xbTtcHOwoqjCwMj6D0R2CGl28MJkE6UUVeLvYNynaFJYb6PPWWioM8t5675Yu3Ni9JYdSCxn/0VYAHhoaxcDWfkz+chdO9joOvHqNzVg19b2cV1rFDzuTiPBzZWhbf9ybkQOoqMLA4dQi+kT41LMfzGN4Z99WdA31Oue5QJYk/3HXWQ6mFFjC4hztdMS9dk2TC0Ymk+DH3WdpH+xOj1ZWgfhwWiFL4tK4o3cYrXxd6x1nNAkb7z8lhFxklPFx8WlqfCoMRvQ6jQqDkXdXH6djiCc3dQ+pp1oLIbh59g72JuVbfmQyCiuYu/ssE7q2sGRmLyirosebazGaBO6Odmx5Xq6M1s7p8ev+FJ76OQ57vcbvjw0kws+V0e9v5kxumeWHO7OoguXx6VzXpQUB7o78e/lRvtl2Bn93R9Y9PYTSymr+8Ws8p7JLeWZ0W67rHMzUr3ez5UQOnUI8+e1hmSlcCMG8PckcTS/C0U7HF1sSCfVxJq9EikSzbu+KsaKUPWmV/LDrLIDlPeomRTucVsh7q4/j7+7I1H7htG/hQU5JJT/sTGLO9jMUlBnQ6zQ+vqMbYzoGU15lZMpXu9hbs2pir9fo2cqH3FLpBdI7wocZw6M5lV3KS4vibQwYh5oVie6tvKkwGG3KGt7eO5QKg4k1RzLRwGY1CbC4GNfdFunvRnxqIQ3x2nXtWXownX1J+WgaONvrKasy0jXUk+eGhrApqYLPNp9u8NiGaKgPZjRN5m8y4+/uSAsvZ4uhUnd/Q+h1GmM7BpFbUmVxQY70d2VClxbMWn/SIrSBTAR436BINiRkWcLEzDjZ6/j3xE4MbuPPv5cdodokWFpLULPTaSx+dABZRZUsOpBaI/YZLdcY7udqMeYb6neUvyurnxzC/rP53PHFTgxGawNNk59zZbUJRzsdPq4ORPm7sf9sPmVVRku1qNVHMgn0cCSzSN435v9rGvz6UH+6hXljMJrILKrgaHoxH60/YWP0AiybMZDDaUU8t/CgzfboADe8XR24s28rXvotnuIaD61QH2cqDCaLx1KbQDd+uq8vsWcLePSn/RaDt1+kL3cPCKdvpC83fbqdlPwyBkf74+ygJ8TLmT4tHNA5uTHl6z3Y6zXu6B3GtzusAmSwpxPLZwwit7SSx+cdoG+kLw8PjbKIrlnFlWw9kU1dJ7Re4d58PLk7RpMgMacUX1dH2ga5YzQJjCZBZlEF1364BX8PR35+oB/xKYU88tN+ymqqYtzRuxUllQaWxKUxY0Q0Dw2JIr/MwI87kwj1caHcYOSzTae4q3840wbISVV1zQqiq6O+nuGWWlDOgJnrLa/bBXuw6JH+5JRUkZRTyiuLD3Gq5vk2Pxu9w7358PoIAgMDlRByCVC2yMWn9viUG0y8vSoBBzsdL4yJ+VOCZF5pFZ9uPMmwmABL+DBAdnElD3y/1yZJK0ArXxdeHBtjSWwvhOBsTYLS7SdzKSg38PQ1bSzPee2V/B93JfHSb7Ky34DWvrT2d0Ov09HS2xk/d0dLiPCiRwbg6+rAoP9tAKQQ8PMD/egZ7sOD3+9j5WG52GGn0/jlof4EuDuwbN9p7hwUg1PN+25IyGLaN3ssooK9XmPjs8PIKa7k8XmxnMktA2BMhyBmT+nBtpM5PLsgjgGt/fg1NhWjSdAl1Mvy2woQ5uPCLw/1t1QVGvHuRk5ll9KlpSeLHx1oM04v/RbPjzV2UV0GRfvx7s1dCKjJdbfpeDb3zNmDsUagMYfeTOnbitzSSnqF+1gEgmHvbORMbhldQr24Z0A4/1p6lJySygbfB8Dd0Y5wP1eL/TIo2o/vp/exfDZzdyfz0qJ4hAB3Jzt2vjjCxubcdjKHO7/aRXSAG8tmDMK+xjY0C00g7Yek3DLGdAjCXq9ZvKWnD4zgm22JNr9BN3QL4f1bu9r08eMNJ3l7VQIg8/6dyS3lUGoRMUHu5JVW1fNUfnlcO+4dZFs557fYFObtTuax4dEMaO3L2A+3cCyjGJCiw0e3d7eZwB5KLeShH/dZcq846DWqjHKS+88JHejS0hNPZ3vcnexJzivj/9adYN2xLDQNdJrVu9vsCV4bs/f3s6PbcnPPlvi7OaJpmkVcbIjeET58eVdP7v9uLztP59E11IufH+iHvV722fwMZRRWMPnLnZzKLkXT4MZuLXl5XDuL98nm49nEpxZyd/9wFu5L4bUlhy3PQEtvZ5Y/PoiHf9jP1pM5TOzagg9u64YQgv4z15NeWMGcab0Y2jbA0q+zuSXEn05ndLdI7Oz0Ngsgj/y43+LhHeXvyo/39mXG3Fg6hnjywtgYNh3Ppkcrb0tlqk3Hs3luYRyZRZUNCk4P/bCPFYcy8HS257kxbTmdXcrIdoH0i/KltLKaFYcy6NHKm4iaaqOV1UYmfrydozVpC0Da3+UGY73rqMv3O5N4ZdEh3BztWPPUYPzdHPnfqgS+3HIak5DXs/SxQTjZ61h7NItgTydyS6t49Kf99ImQz+MXW05zd79WxHhdmkUZJYQo4+OicKHGp7DMwMHUAht3wYaY/OVOtp3MbdCl0sy+pDwc7ayxxlnFFRw4W8CIdoGNJjs9lFqIn5ujZYW9LqeyS/hqayIPDYlqMFSipLKaEe9utEwoWwe4serxgWRnZ+Ph7cv4Wds4nV3KJ5O7c22n88thUFhm4JXFh1gSl4a9XmNK33B2nM7laE2Jwndv6Uq/KN8GY3ZBKrTL49P5eMNJsoormXVHN4tBV1ZVzV1f7yazqJLk/LJ6k+0QL2cqq03klFTSMcSDBQ/0Z872M7y/9jh+rg4EejpZ4oc1DZ4d3Za1RzLRaRrRge7M3W01dNwd7fjtkQGE+jhzLL2YtoFuFOTlEBAQwNaTubz++2FOZZfSLliKQFXVJu4dGEFcSiFH04swGE2UVRkpqRFnxnUKZuXhDIwmQc9W3iTnl5FZVImjnYx7Xrgv2TJBdLaXwsLR9CIc7HT0i/Rl0/FsHOx0dA/zYmLXEFwd7fB1c6BDsKdlpSEuuYCHfthnWY0HaYjc1iuM/1t3wsbDxdPZnhfHxtAmyJ0P1p5gc42nUd3QrvsGRXAmt4w1RzLxdXWw8diICXKnpLLa4pVip9MI8HAkraCCIA8nHh8ZTccWnkz5ehcFZQZeHBvDZ5tPk1daxegOgbx6XQdeW3yItUflKlbvCB++ubuXxXA7lFrI9R9vsxgpmgZLHhnI5hPZFkPLTKSfK+2CPdh8PNtGEHNx0DOlbyuOZxazIUH+kB9JK6LcYGTG8NaEeDvzj98O1QtzC/FyprDcYPn8QrycKSo3UFxZTbCnkyXuP8LPlaTcUotx2NLb2cZLpzZujnpKKo3c3T+cF8bGMOLdTaQXluPtIse1U4gnOSWVlnObvYdqc3vvMPJKK1l12GqA2ek0G8Hrpu4t2XQ8Gyd7HW0C3Vlfs0ro6+pAXlmVNJId7eoJhyA9yE5mldiE6oGcvPx0X18CPZyY8tUuUvLLsddrPDy0NQI4klbEnX3DKCgz8MT8A0T6u5JVVElJZTWtA9w4lV1ieV5dHPQWEa1HK2++uqsHFUX5yiPkEqFskYvPpRifymojP+w8i4uDnq6hXtjpNML9XP9wIkKjSfDt9jP4ujkwoUuLerbQvN1nMZgEU2ryFJjtoQeHRPHC2BhAfm9c+39bAHhhbAwPDolqcGyEEDw+74AlB9rtvcMsiUFLK6uZueIYR9KL+PC2rpZEr2ZmrT/BO6utnrYf3tYVX1dHOrSwDXf4YvNp/r38qMUrpzbVRhPLD2WQXlCOt6sDgR5OzNmWSKCHE69f36GeZ97eM3lkF1fSN9KX27/YiYeTPT/c26dejpEjaUVM/nKnTdh120B3hrcLwN3JDn83RyL9XfnHr4dIKyzn67t70T3Uk3eXx7P0aB7/vakL/aJsE9Yu2JvMK4sPMWNENA8PrV8l5khaEUGeTjallncn5vHq4kM8OCSK67vKsF9N0xBC8NqSw3xXS7QfFO1HUm4ZzvZ6fn6wH57OtgtlQghe//0Ic7afqffeIH+HnhjVhpOZxZbFgJk3dmJEu0CWHUzD3k7Hq4sPY6xJzj+0jT8bErJxttdjNAmqjCam9G3Fw8OimL8nmV/3p3I2TwphgR6ODG3jz7g27syPz2dZfH2PYjO1w9t7hXtzOK3I8rukadAnwodXxrfnSFoRz9ZaOAn1cWZ85xZ8sfk01SZB30gfdiXm8djwaLqFeTHjp1iKK6stk3gztRdxYoLc6Rvpy/pjWZa+m/Fzc+DBIVFsP5Vr+e3uGOJBRmElOSWVPDemLd/vSCK9UCa5zS6uxF6vsf7poRZ7/8Vf45m7+yyj2gfy2nXt+X5HEuuPZVnC9IfH+JNfZuBgSiGtfFwY0zHIElpvtgEj/FxJrLE/zKH2kf6uLH5kAMl55UyYtdXG7vhiak86hXiy+Xg2Op3GMwviGhz3CD9XisoN5JZW4ePqwHf39OZYRjEbjmWxLF56Gfu4OtClpSfODnrm7k6ma6gXfSJ8iAl255r2QTbiXn5plY13Wp8IH+z1OraezAGs3vg3dgshxNuZj9afRKdJj12zd42ZHq28+fiGSCWEXCyU8XHxudjjcyanlBWHMri7f/hfGjf4R0jJL+OdVQmsO5bF25O6cE37AJs8Bsn55c12Z6uL0SR4cr7VaAH55fr13T1t3NbORVPu+rM3nWLmimO4Odrx/q1d8Xd3tKw4LD6Qxo3dQyzViIorDDjb69E0jc0nsimtrKZNoLtNgjKTSfDpplN8s+0M+WVVFm8W637be8doEhRXGPByccD89VXXEDQYTXy7/Qz7z+bzz+s68P7aE6w5ksm8+/vi7+ZIdkkFrXylIZpaUM6SA2k42EkPmAB3R77bkcTA1n50CfWiqMKAq4PdOSsBncwq5tbPdlJuMPL6hA5M6tESTdOoNppYuC+FDQlZ2Ol1PD86hjBfF8vn9dH6E3y47gSiZqWhT4QvZVXVzLypM1XVJq55f5PFWLujTxg3dAuhZytvhIAj6UXEJecT6S7oFh3KwdQiOoV4Wu75d1cn8NH6k5Y+dgrx5OcH+ln2J+WWciC5gGvaB9V7TsyuuP7ujvx7Ykeu6RBkSeL3W2wqL13bjn/+ftjiwQFyVcfb1Z6JXUO4f3Akvm6ONu6jII25b6f1RqfTOJVdwonMEn7Zn8KaI5k42ulY/vggWng6s+aojH2/rkswyXnl3PjJNotIMKVvK167rj1ZxZXM2X6Gz2s8hex0Gm/f3JmsGm+V/Un5rDmaidEkRYDNzw3Dz00mHayqNpFbWsmNn2y3eJfUzgnkaKfjoaFRuDnaMSwmwOJxllFYQUF5FQ/9sJ/EnFL0Oo0QL+d6RpUZdyc7yxjd3juU1yd0ZOfpXN5ZnUBVtYmBrf1sXOLbBLpRUGagoMxAu2B34lIK8XS2x9leb1nhbIp7B0YwPCaAaXP2WK4l3NeFMF9X3pjQgY0JWSTmlPLsmBhc7HUqR8glRNkiF5+rcXwyiyrYnZjH2Do5xH7YmURuSRWPDW9dU52u8bE5m1vG0YwihrTxP6/cSttP5fDllkQ6hXjy5Kg2DbYRQpBRVEGwp3OD+/8qEjKKeW9NAsl55bRv4cFr17WvF5YghKCy2oSTvb5Z905dl/8/g9Ek+HlvMgv2JiOAr+/qhZeLPUaTaDRESwjBrsQ8dp3Ow9VRz8h2gew/m4+Hkz2D2/jjYCc9UWauPMZnm06jaVIgySmxLrRE+rvaeAc/MDiSTi09eWxubIOesqM7BPK/m7rg7qQnKysLV08fvth6hh2nckjJL6eo3EBplRFvF3t6hvvw7Oi2uDjoqao2EenvZglB83C2x93RzmJ7CiGY/u1eiyhRm25hXvz6UH8KygwWUS32bD6P/hRrCYe+o08YPzXiTQTS3pp3f18yiyp54ZeDNjkF9TXJd80LMq0D3Pjt4f4k5ZZx8+wdlNd4sr91Q0du7RVmOe5AcgGTPt1Odc19YBZ89DoNDWwEjNqM6xRMj1bevLH0SKP9HdbWn9zSKg6mFDKsrT8B7k7M35vcYNshbfxJzisjv6yKflG+rDmSafEGbizP4mdTejC6QxDQcN6jtoHu3D0gnHVHMwnydGJ3Yh7HM0to5etCWkG55fxO9jrev6Urbk52TPlqd4P969HKm4zCCjKKKrixWwgPD43E2ViqhJCLhTI+Lj5qfBrnQo+NySTr28/bc5aW3i48Nrw1vhewlJcQgi0ncojwc72gCUKrqk0UVRjqlR27UOPzR5KEnS9FFVKwqBvSdC62n8phY0I29w6MsLj5mtmQkMVby45yV//wBjORNzU+2cWVDPjveqqqTQR6OLL4kYGNejPVRQjB/rP5RAe617ses1C2OzGPdUcz8XJxoFe4N93DvBsU0B75cT8rDqVz76BInhrVpp4hXW008fPeFNoEutVLRGgm9mw+324/wy29Qm1czwGWx6fz3prj3Dswgtt6W40Sk8nEnmNnWX6ihEHR/g3GRCfllrIsPp3kvDIeGBzFtDl7SMwp5c2JHZvM/F5aWc2JrBLaBrrj7KBn8YFUPlp/kmFt/fktNo2ckkrGdAjimdFt2ZiQxTXtgywCWF3ikgs4nVOCj6sjA1v7YRJCGlqaxs2zd1gqbZldyjcmZPHq4sMEejjSv7UfC/elUFUjepiNme2ncpi/J5nbe4fRt5FSm5cyLlehbJFLgRqfxlFj0zR/p/ERQljytYH0vDQYZbLWL6b2JC65wLI49cnk7vi6OfLTrrP8e9kRSquMtAv24KGhUQxt62+xD5oan2qjSYoB52mDmfOcCARrjmTyy/5UDqYU8P6tXRnWQMiGwWhi7ZFMNA3GdAxm+6kcCssMdA3zAmBjQjanskoI9XFhfOdgi21cWW3k042n2JCQTfcwLyb3CcNogjeWHqZrqBePDou2LBZtPp7NV1sTuW9QJAOj/er1YVFsKk/MPwDICf+0AeEMiPIl9kQK721Jo22gBw8OkaHS/12ZgAYsmzGIUB9nBsxcT36Zgd4RPkzuE8aWEzkMbevPk/MPWIQGd0c71j49BHcnO174JZ7VRzKoMJjo0MKDE1kl6DWN3x8bQLivq6XIRW5JJUfTi6msNtIm0J2bZ+8go6iCNoFu9Gjlw5A2fnUWIAXfbD9DTkklZZXVLIvPaDB0zN3Rjm+n9+Z0dilLD6bRyseF23qH0S5Y/p6tiE9n5spjJOWWMWNENG0D3Yk9m89jw6NxtNdRVmXEx9VB5Qi52Cjj4+Kjxqdx1Ng0jRqfpjnX+Mxaf4KF+1L46PbudGrZdFLQv4pqo4nKapONW+XF4I/cO1lFFZzMLqFfpO8fFs4SMor5aVcSDw9rbfGO+qNUVZvYfDybvUn5TO4TZhEfZdUXHTqdxuG0Qh75cT/FFdWsf2ZoPZfpxlBCyKVF2SIXHzU+jaPGpmn+buNjMgk+WHeCwrIqnhndtllJOo0mgU6r74Urz/f3Gp8/w6bj2RSVGxjXKbhJb6vT2SWUG4x0aCFts1/2pTB70yk+uK2rZRvIxbI5285wMKWQf4xrx4Qu1uqJldVGSiqq8XVzpLDMQGW1sd6CWl1ySypJLSinU4hns+ycs7llTP16F9nFldw9IJyqahN+bo7c1ivsnJX0qo0mMooq6oXO1UYJIRcZZXxcfNT4NI4am6ZR49M0anwa52oaG6NJYDCazsttXQkhlxZli1x81Pg0jhqbplHj0zRqfBrn7zA2BqMJkxDNqph3vlxKW+TiLs8pFAqFQqG44Oh1Gnrd5ZUPSaFQKBQKxZXPH03ufLnz97wqhUKhUCgUCoVCoVAoFIoGUEKIQqFQKBQKhUKhUCgUiqsGJYQoFAqFQqFQKBQKhUKhuGpQQohCoVAoFAqFQqFQKBSKqwYlhCgUCoVCoVAoFAqFQqG4alBCiEKhUCgUCoVCoVAoFIqrBiWEKBQKhUKhUCgUCoVCobhqUEKIQqFQKBQKhUKhUCgUiqsGu0vdgUuBEAKAoqKiC3ZOk8lEcXExTk5O6HRKX6qLGp/GUWPTNGp8mkaNT+OosWmaCz0+5t9U82+sommULXLxUePTOGpsmkaNT9Oo8WkcNTZNcyltkatSCCkuLgYgNDT0EvdEoVAoFIq/F8XFxXh6el7qblz2KFtEoVAoFIq/hubYIpq4CpduTCYTaWlpuLu7o2naBTlnUVERoaGhJCcn4+HhcUHO+XdCjU/jqLFpGjU+TaPGp3HU2DTNhR4fIQTFxcW0aNFCrXo1A2WLXHzU+DSOGpumUePTNGp8GkeNTdNcSlvkqvQI0el0tGzZ8i85t4eHh7rJm0CNT+OosWkaNT5No8ancdTYNM2FHB/lCdJ8lC1y6VDj0zhqbJpGjU/TqPFpHDU2TXMpbBG1ZKNQKBQKhUKhUCgUCoXiqkEJIQqFQqFQKBQKhUKhUCiuGpQQcoFwdHTktddew9HR8VJ35bJEjU/jqLFpGjU+TaPGp3HU2DSNGp+/H+ozbRo1Po2jxqZp1Pg0jRqfxlFj0zSXcnyuymSpCoVCoVAoFAqFQqFQKK5OlEeIQqFQKBQKhUKhUCgUiqsGJYQoFAqFQqFQKBQKhUKhuGpQQohCoVAoFAqFQqFQKBSKqwa7S92BvwMmk4nDhw8D0KFDB3S6q1NfOnjwIEVFRTbbAgICaNOmTb22CQkJlJaW0qFDh7918qDU1FQSExPp0qUL7u7uDbZJSkoiOzubtm3b/qk2VyIHDx6ksrKSXr161du3Y8cOjEajzbbw8HBatmxps81oNHL48GE0TftbPX+pqank5uYSGRmJm5tbg20KCws5ceIEQUFB9cblfNpcaVRXV3P8+HEcHR0JDw9Hr9fb7D9+/DhZWVk22zw8POjcuXO9c505c4acnBxiYmIaHecrjYqKChISEnB3dyc8PLzBZ6K6uprDhw9jZ2dH+/bt0TTtD7VRXD4oW0SibJH6KFukaZQt0jjKFmkcZYs0zRVhiwjFn+LAgQMiIiJCBAcHixYtWoiIiAhx4MCBS92tS0KfPn1EWFiYGDBggOXvjTfesGmTlpYmevToIby9vUVkZKTw9fUVy5cvv0Q9/uvYuXOnuP7664Wfn58AxI4dO+q1KS0tFePHjxcuLi4iJiZGuLi4iM8+++y821yJfPbZZ6JTp07Cy8tLhISENNjG1dVVtGvXzuZ++uGHH2za7N+/X7Rq1UqEhISIoKAgERUVJeLj4y/GJfxlLF26VHTu3FmEhISITp06CRcXF/HSSy/Va/f+++8LJycn0a5dO+Hs7CwmTZokKioqzrvNlUR1dbV49dVXhb+/v2jfvr0IDQ0V4eHhYs2aNTbtJk+eLAICAmzunfvvv9+mTUlJiRg7dqxwdXUVbdu2FS4uLuLLL7+8mJdzwSkvLxdPPfWU8PX1Fd26dROBgYEiOjpabNu2zabdrl27RMuWLUVoaKgIDAwUbdq0EUePHj3vNorLB2WLWFG2iBVlizSNskUaR9kijaNskaa5kmwRJYT8CQwGg4iOjhaTJ08WJpNJmEwmcdttt4no6GhRXV19qbt30enTp4/417/+1WSbMWPGiP79+4vy8nIhhBCvvfaa8PDwENnZ2RejixeNL774Qvz666/i6NGjjRofTzzxhAgPDxeZmZlCCCHmzp0rNE0TsbGx59XmSuTZZ58VcXFx4j//+U+Txsdvv/3W6DmqqqpEZGSkuOuuu4QQQphMJnHzzTeLmJgYYTQa/4JeXxw++ugjGwNq69atwsHBQfz444822zRNE8uWLRNCCJGcnCyCgoLEK6+8cl5trjSKi4vF66+/LgoKCoQQ8jN/5plnhIeHh8jPz7e0mzx5suW+aIxHH31UREZGWr57vv/+e6HT6a5o4zUjI0PMnj1bVFZWCiGksTZlyhQRFhZmaVNRUSFatmxpMcaMRqOYMGGC6Ny583m1UVw+KFvEFmWLWFG2SNMoW6RxlC3SOMoWaZoryRZRQsifYP369QIQx44ds2w7dOiQAMSGDRsuXccuEX369BHPPPOM2L17t0hJSam3PzU1VWiaJhYtWmTZVlJSIpydncWnn356Mbt60Thx4kSDxofRaBTe3t5i5syZNtujo6PF448/3uw2VzrnMj5mz54t9uzZ06Bxunr1agGIkydPWrYdOHBAAGLLli1/WZ8vBT179hQPPfSQ5fU999wjevbsadPmhRdesBnL5rT5O3Dy5EkBiE2bNlm2TZ48Wdxyyy1i79694vTp0/WMUYPBIDw8PMQ777xjsz0iIkI8/fTTF6XfF4vPP/9cODo6WsZgyZIlAhDJycmWNjt37hSA2LNnT7PbKC4flC1ii7JF6qNskaZRtkjzULZI4yhbpGkuV1vk7xHAdomIjY3F1dWVtm3bWrZ16NABFxcXYmNjL2HPLh2ffPIJ9913H+3bt6d79+4cPHjQsu/AgQMIIejRo4dlm6urK+3atbvqxuvMmTPk5+fbjAVAr169LGPRnDZ/d1544QWmT59OaGgoY8eOJS0tzbIvNjYWT09PoqKiLNu6dOmCg4PD32p8zHG1rVu3tmyLjY2td1/07t2b1NRUsrOzm93m78CePXvQNI3IyEib7b/99hv33HMPvXr1onXr1qxfv96y7/Tp0xQVFf1tn61jx46xefNm5syZw1tvvcXrr79uic2NjY0lMDDQJka7Z8+eaJpmufbmtFFcPihbpD7KFmkeyhZpHsoWUbbIuVC2SH2uBFtECSF/gry8PHx9fett9/X1JS8v7xL06NLyyCOPkJOTw4EDB0hNTSU0NJSJEydSVlYGYBmTumN2NY5Xc8biah+vDz74gNzcXOLi4jh9+jTp6elMmTLFsv9qef4efPBB3NzcmDZtmmVbQ9dufl37/jlXmyudtLQ0nnrqKaZNm2bzQzlx4kQyMjKIi4sjPT2da6+9lhtuuIGUlBTg7/9s/fjjjzz//PM899xzhISEcP3111v2NXRf6PV6vLy8mrx36rZRXD5cLd+FzUXZIs1H2SLnRtkiEmWLNI6yRRrmSrBFlBDyJ7C3t6eioqLe9vLychwcHC5Bjy4tU6ZMwdnZGQA3NzfeffddEhMT2bVrFyDHC6g3ZlfjeDVnLK728br33nstynFwcDD//Oc/Wb9+vWUF4Wp4/p588klWrlzJ77//jre3t2V7Q9deXl4OYHP/nKvNlUxOTg6jR4+mbdu2zJo1y2bfpEmT8PHxAeQ4vPvuu1RUVLBixQrLNvj7Plv/+te/2LFjB6mpqXTq1Ilhw4ZRWloKNP7cVFRUNHnv1G2juHy4Gr4LzwdlizQfZYucG2WLKFukKZQt0jhXgi2ihJA/QatWrcjNzbX5kMrLy8nPzycsLOwS9uzyIDAwEJClt0COV+3XZlJTU6+68WrOWKjxsqWh+yknJ4eqqipLm9LSUgoLC/8W4/Pss88yZ84c1qxZQ7du3Wz2tWrVqsH7Qq/X06JFi2a3uVLJzc1l5MiR+Pj4sHTpUsukpzEcHR3x8vK66r6L7O3teeKJJ8jIyLC4kbZq1YrMzEybcpB5eXmUl5fbfPecq43i8kHZIk2jbJHGUbbI+aNsESvKFlG2SHO4nG0RJYT8CUaMGIEQguXLl1u2LV26FCEEw4cPv4Q9u/iUl5djMplstq1evRqAjh07AtCjRw98fHxYsmSJpU18fDyJiYmMGjXq4nX2MsDLy4uePXvajEVhYSEbN260jEVz2vxdMSvGtVm9ejVOTk6W+NQRI0ZgMBhYuXKlpc2SJUvQ6XRX/PP33HPP8cUXX7B69Wp69uxZb/+oUaNYs2aNzcRn8eLFDB48GEdHx2a3uRLJy8tj5MiReHp6snz5clxdXW32V1dXU1lZabMtLi6OrKwsy3eRn58fXbt2tXm28vPz2bx58xX9bDX03Jw8eRKwut6OHDmS0tJS1q1bZ2mzePFi7O3tGTJkSLPbKC4flC1iRdki54eyRZpG2SLKFmkMZYs0zhVli1yQlKtXMY899pgICAgQ3377rfj222+Fv7+/mDFjxqXu1kUnLi5O9O7dW8yePVusWrVK/O9//xNeXl5iypQpNu0+/vhj4eTkJD788EPx888/i3bt2olrrrnmEvX6ryM9PV1s2bJFzJs3TwDis88+E1u2bLHJfLx69WphZ2cnXnnlFbFo0SIxZMgQ0bZtW1FWVnZeba5E4uPjxZYtW8SDDz4o/P39xZYtW8SWLVsspQznzZsnrr32WjFnzhyxYsUK8fzzzwsHBwfx3//+1+Y8Dz30kAgKChLfffed+Oabb4Svr6946qmnLsUlXTBef/11oWmaeO+99yzjsmXLFnHkyBFLm4KCAhEeHi7GjBkjFi9eLJ555hlhb28vtm7del5trjTKyspE9+7dRUhIiFi5cqXN+Jiz+RcUFIiOHTuKDz74QKxcuVJ8+umnIiQkRAwaNEgYDAbLuZYvXy70er147bXXxKJFi8SgQYNE+/btLffglchXX30lbrzxRvHdd9+J1atXi/fff18EBgaKW2+91abdtGnTRMuWLcUPP/wgvvzyS+Hl5SX+8Y9/nHcbxeWDskUkyhaxRdkiTaNskcZRtkjjKFukaa4kW0QTQogLI6lcnZhMJmbPns3SpUsBGD9+PA8++KAlnvBq4tChQ8yePZvjx4/TokULJkyYwI033liv3YIFC/jxxx8pKytj8ODBPPXUU7i4uFyCHv91LF68mLfffrve9oceeojJkydbXm/atIlPP/2U7OxsunbtygsvvIC/v7/NMc1pc6Xx5JNPsmfPnnrb58+fT0hICAAbN27k+++/JyUlhfDwcKZOncqAAQNs2huNRj799FOWLVuGpmlMmDCB+++//4p+/h544AEOHz5cb/vgwYN56623LK/T09OZOXMmhw4dIigoiEcffZR+/frZHNOcNlcSGRkZTJo0qcF9r7/+OiNGjAAgOTmZjz76iIMHD+Lr68vw4cO5++670ev1Nsds2LCB2bNnk5ubS7du3Xj++efx8/P7y6/jr2TNmjXMnTuXlJQUQkJCuO6667jhhhvQNM3Sprq6mlmzZrFy5Urs7OyYOHEi06dPP+82issHZYtYUbaIFWWLNI2yRRpH2SKNo2yRc3Ol2CJKCFEoFAqFQqFQKBQKhUJx1XDlSpUKhUKhUCgUCoVCoVAoFOeJEkIUCoVCoVAoFAqFQqFQXDUoIUShUCgUCoVCoVAoFArFVYMSQhQKhUKhUCgUCoVCoVBcNSghRKFQKBQKhUKhUCgUCsVVgxJCFAqFQqFQKBQKhUKhUFw1KCFEoVAoFAqFQqFQKBQKxVWDEkIUCsXfkhMnTrB8+fJL3Q2FQqFQKBRXKcoWUSguX5QQolAo/pasWrWKp5566lJ3Q6FQKBQKxVWKskUUissXJYQoFAqFQqFQKBQKhUKhuGqwu9QdUCgUfz+SkpI4cOAAvr6+dO/eHRcXF8u+EydOcOLECUaNGkVcXBypqan06dOHoKCgeuc5ePAgJ0+eJDg4mD59+qDT1dduk5OTiY2NJTAwkJ49e6LX6232V1dXc/DgQdLT0+natSshISEX/oIVCoVCoVBcVihbRKFQNIUSQhQKxQVDCMETTzzBDz/8QN++fcnJySE9PZ1ffvmFXr16AdJN9M033yQkJARnZ2dMJhMHDhxg3rx5TJgwAZAGwy233MLGjRvp27cvBw8eJCgoiBUrVuDv7295r8cff5wvv/ySPn36UFFRgZ2dHcuWLcPDwwOAwsJCBg0ahKOjIwC7du1i/vz5lvdRKBQKhULx90LZIgqFolkIhUKhuEB8/vnnIioqSuTk5Fi2vfnmmyImJsby+qOPPhKAePvtty3bXnvtNREUFCTKysqEEELMmjVL+Pj4iKSkJCGEEEVFRaJz587ivvvusxzz8ccfCxcXFxEXF2fZtn37dpGVlWXzPgsXLrTsf+aZZ0Tnzp0v8FUrFAqFQqG4XFC2iEKhaA4qR4hCobhgfPPNN3Tu3JkNGzawYMECfv75Z9zc3Dh27Bjp6emWdo6Ojjz22GOW18888wxZWVls3rwZgHnz5nHnnXcSFhYGgLu7OzNmzGD+/PmWY7799lumTp1K586dLdv69etnWaUB8Pf356abbrK8Hjp0KAkJCRf+whUKhUKhUFwWKFtEoVA0BxUao1AoLhhnzpyhqqqKhQsX2my/9dZbqaqqsrwODg62uIgCuLm54e/vT1JSEiDjeidNmmRzjqioKIqKisjPz8fb25uzZ89y2223NdkfHx8fm9eOjo5UVlb+oWtTKBQKhUJx+aNsEYVC0RyUEKJQKC4YHh4eDB8+nP/9739NtisoKLB5LYSgoKAAPz8/APz8/MjLy7Npk5eXh729vSXm1svLi9zc3AvXeYVCoVAoFFc8yhZRKBTNQYXGKBSKC8aYMWP48ccfKS4uttmemppq87qgoICNGzdaXi9fvhyTyWRJYjZw4EAWLVqEyWSytFmwYAH9+vWzZGK/5pprmD9/vs3qTmlpKWVlZRf6shQKhUKhUFwhKFtEoVA0B+URolAoLhivvvoq69ato1evXtx33324uLiwa9cuTp8+bYm5BXB1dWXq1KnMmDEDk8nEzJkzmTFjBqGhoQC8/PLLLFiwgGuvvZYbb7yRHTt2sHjxYhuD5ZVXXmHlypX069ePu+66i4qKCubOncvy5cttSuQpFAqFQqG4elC2iEKhaA7KI0ShUFwwfHx82L17N08//TRHjx7l8OHDjBw5kvXr19u0a9myJcuWLSM/P5+jR4/y3nvv8fbbb1v2BwQEcODAAfr378/WrVvx9/dn//799O7d29LGz8+PvXv3MnXqVGJjYyksLGThwoUEBwcD0KZNG8aNG2fzvkFBQdx6661/4QgoFAqFQqG4lChbRKFQNAdNCCEudScUCsXVw6xZs5g1axbHjh271F1RKBQKhUJxFaJsEYVCoTxCFAqFQqFQKBQKhUKhUFw1KCFEoVBcVBpyE1UoFAqFQqG4WChbRKFQqNAYhUKhUCgUCoVCoVAoFFcNyiNEoVAoFAqFQqFQKBQKxVWDEkIUCoVCoVAoFAqFQqFQXDUoIUShUCgUCoVCoVAoFArFVYMSQhQKhUKhUCgUCoVCoVBcNSghRKFQKBQKhUKhUCgUCsVVgxJCFAqFQqFQKBQKhUKhUFw1KCFEoVAoFAqFQqFQKBQKxVWDEkIUCoVCoVAoFAqFQqFQXDUoIUShUCgUCoVCoVAoFArFVcP/A8LQS6q6EQNGAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1100x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot distillation loss curves.\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "for ax, key, title in [(axes[0], \"policy\", \"Policy loss (soft cross-entropy)\"),\n",
+    "                       (axes[1], \"value\", \"Value loss (0.5 x squared error)\")]:\n",
+    "  ax.plot(history[f\"train_{key}\"], label=\"train\")\n",
+    "  ax.plot(history[f\"val_{key}\"], label=\"validation\")\n",
+    "  ax.set_xlabel(\"epoch\")\n",
+    "  ax.set_ylabel(\"loss\")\n",
+    "  ax.set_title(title)\n",
+    "  ax.legend()\n",
+    "  ax.grid(alpha=0.3)\n",
+    "fig.suptitle(\"Policy Distillation Loss\")\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluate the Student Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "regret of exact minimax  : 0.0000 (must be 0.0)\n",
+      "regret of uniform random : 0.4212\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exact_regret(action_fn, states=all_states):\n",
+    "  \"\"\"Computes fraction of positions where agent move worsens optimal outcome.\"\"\"\n",
+    "  mistakes = 0\n",
+    "  for state in states:\n",
+    "    player = state.current_player()\n",
+    "    best = optimal_value(state, player)\n",
+    "    achieved = optimal_value(state.child(action_fn(state)), player)\n",
+    "    if achieved < best:\n",
+    "      mistakes += 1\n",
+    "  return mistakes / len(states)\n",
+    "\n",
+    "\n",
+    "def greedy_actions(forward_fn):\n",
+    "  \"\"\"Returns greedy action for every position in a batched pass.\"\"\"\n",
+    "  _, policies = forward_fn(observations, legals_masks)\n",
+    "  return np.argmax(np.asarray(policies), axis=1)\n",
+    "\n",
+    "\n",
+    "# Verify exact regret metric.\n",
+    "print(\"regret of exact minimax  :\", f\"{exact_regret(lambda s: optimal_actions(s)[0]):.4f}\",\n",
+    "      \"(must be 0.0)\")\n",
+    "print(\"regret of uniform random :\",\n",
+    "      f\"{exact_regret(make_random_agent(SEED)):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Greedy agreement with teacher (all positions)  : 0.931\n",
+      "Greedy agreement (held-out validation set)    : 0.917\n",
+      "\n",
+      "Exact regret (student)     : 0.0872\n",
+      "Exact regret (teacher-raw) : 0.0867\n",
+      "Exact regret (teacher+MCTS): 0.0033\n",
+      "Exact regret (random)      : 0.4212\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute agreement and exact regret for student model.\n",
+    "student_raw_agent = make_raw_agent(student_forward)\n",
+    "\n",
+    "teacher_greedy = greedy_actions(_teacher_forward)\n",
+    "student_greedy = greedy_actions(student_forward)\n",
+    "\n",
+    "agreement_all = float(np.mean(teacher_greedy == student_greedy))\n",
+    "agreement_val = float(np.mean(teacher_greedy[val_indices] == student_greedy[val_indices]))\n",
+    "\n",
+    "student_regret = exact_regret(student_raw_agent)\n",
+    "teacher_raw_regret = exact_regret(teacher_raw_agent)\n",
+    "teacher_mcts_regret = exact_regret(teacher_mcts_agent)\n",
+    "random_regret = exact_regret(make_random_agent(SEED))\n",
+    "\n",
+    "print(f\"Greedy agreement with teacher (all positions)  : {agreement_all:.3f}\")\n",
+    "print(f\"Greedy agreement (held-out validation set)    : {agreement_val:.3f}\")\n",
+    "print()\n",
+    "print(f\"Exact regret (student)     : {student_regret:.4f}\")\n",
+    "print(f\"Exact regret (teacher-raw) : {teacher_raw_regret:.4f}\")\n",
+    "print(f\"Exact regret (teacher+MCTS): {teacher_mcts_regret:.4f}\")\n",
+    "print(f\"Exact regret (random)      : {random_regret:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Student vs random    93W   6D   1L   (score 0.960)\n",
+      "Student vs minimax    0W  97D   3L   (score 0.485)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Evaluate student model in matches against random and minimax.\n",
+    "student_results = {}\n",
+    "for opp_name, opp_seed in [(\"random\", SEED + 1), (\"minimax\", SEED + 1)]:\n",
+    "  opp = make_random_agent(opp_seed) if opp_name == \"random\" else make_optimal_agent(opp_seed)\n",
+    "  student_results[opp_name] = play_matches(student_raw_agent, opp, N_GAMES)\n",
+    "  print(f\"Student vs {opp_name:<8s} {format_wdl(student_results[opp_name], N_GAMES)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Results Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "teacher: inference() 2.24 ms | jitted 0.1289 ms\n",
+      "student: inference() 1.37 ms | jitted 0.0993 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "def measure_latency(model, repeats=200):\n",
+    "  \"\"\"Returns (Model.inference ms/state, jitted forward ms/state).\"\"\"\n",
+    "  probe = game.new_initial_state().child(4)\n",
+    "  obs, mask = state_features(probe)\n",
+    "\n",
+    "  for _ in range(5):\n",
+    "    model.inference(obs, mask)\n",
+    "  t0 = time.time()\n",
+    "  for _ in range(repeats):\n",
+    "    model.inference(obs, mask)\n",
+    "  api_ms = (time.time() - t0) / repeats * 1e3\n",
+    "\n",
+    "  forward = make_batched_forward(model)\n",
+    "  forward(obs[None], mask[None])[0].block_until_ready()\n",
+    "  t0 = time.time()\n",
+    "  for _ in range(repeats):\n",
+    "    forward(obs[None], mask[None])[0].block_until_ready()\n",
+    "  jit_ms = (time.time() - t0) / repeats * 1e3\n",
+    "  return api_ms, jit_ms\n",
+    "\n",
+    "\n",
+    "teacher_api_ms, teacher_jit_ms = measure_latency(teacher)\n",
+    "student_api_ms, student_jit_ms = measure_latency(student)\n",
+    "print(f\"teacher: inference() {teacher_api_ms:.2f} ms | jitted {teacher_jit_ms:.4f} ms\")\n",
+    "print(f\"student: inference() {student_api_ms:.2f} ms | jitted {student_jit_ms:.4f} ms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "agent                     params  infer ms   jit ms  vs random  vs minimax  exact regret\n",
+      "----------------------------------------------------------------------------------------\n",
+      "random baseline                -         -        -      0.440       0.055        0.4212\n",
+      "student (distilled)        3,338      1.37   0.0993      0.960       0.485        0.0872\n",
+      "teacher-raw              338,698      2.24   0.1289      0.960       0.485        0.0867\n",
+      "teacher+MCTS             338,698         -        -      0.950       0.500        0.0033\n"
+     ]
+    }
+   ],
+   "source": [
+    "def score(record):\n",
+    "  w, d, _ = record\n",
+    "  return (w + 0.5 * d) / N_GAMES\n",
+    "\n",
+    "\n",
+    "# Print summary table comparing parameters, speed, match win rates, and regret.\n",
+    "rows = [\n",
+    "    (\"random baseline\", None, None, None,\n",
+    "     score(play_matches(make_random_agent(SEED), make_random_agent(SEED + 3), N_GAMES)),\n",
+    "     score(play_matches(make_random_agent(SEED), make_optimal_agent(SEED + 2), N_GAMES)),\n",
+    "     random_regret),\n",
+    "    (\"student (distilled)\", STUDENT_PARAMS, student_api_ms, student_jit_ms,\n",
+    "     score(student_results[\"random\"]), score(student_results[\"minimax\"]), student_regret),\n",
+    "    (\"teacher-raw\", TEACHER_PARAMS, teacher_api_ms, teacher_jit_ms,\n",
+    "     score(teacher_results[(\"teacher-raw\", \"random\")]),\n",
+    "     score(teacher_results[(\"teacher-raw\", \"minimax\")]), teacher_raw_regret),\n",
+    "    (\"teacher+MCTS\", TEACHER_PARAMS, None, None,\n",
+    "     score(teacher_results[(\"teacher+MCTS\", \"random\")]),\n",
+    "     score(teacher_results[(\"teacher+MCTS\", \"minimax\")]), teacher_mcts_regret),\n",
+    "]\n",
+    "\n",
+    "header = (f\"{'agent':<22}{'params':>10}{'infer ms':>10}{'jit ms':>9}\"\n",
+    "          f\"{'vs random':>11}{'vs minimax':>12}{'exact regret':>14}\")\n",
+    "print(header)\n",
+    "print(\"-\" * len(header))\n",
+    "for name, params, api_ms, jit_ms, vs_rand, vs_mm, regret in rows:\n",
+    "  print(f\"{name:<22}\"\n",
+    "        f\"{('-' if params is None else f'{params:,}'):>10}\"\n",
+    "        f\"{('-' if api_ms is None else f'{api_ms:.2f}'):>10}\"\n",
+    "        f\"{('-' if jit_ms is None else f'{jit_ms:.4f}'):>9}\"\n",
+    "        f\"{vs_rand:>11.3f}{vs_mm:>12.3f}\"\n",
+    "        f\"{('n/a' if regret is None else f'{regret:.4f}'):>14}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "alpha_zero_policy_distillation.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/open_spiel/colabs/alpha_zero_policy_distillation.ipynb
+++ b/open_spiel/colabs/alpha_zero_policy_distillation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "cellView": "form"
    },
@@ -42,66 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: open_spiel>=2.0.1 in /opt/anaconda3/lib/python3.12/site-packages (2.0.1)\n",
-      "Requirement already satisfied: absl-py>=0.10.0 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (2.5.0)\n",
-      "Requirement already satisfied: attrs>=19.3.0 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (23.1.0)\n",
-      "Requirement already satisfied: numpy>=1.21.5 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (2.5.1)\n",
-      "Requirement already satisfied: scipy>=1.10.1 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (1.18.0)\n",
-      "Requirement already satisfied: ml-collections>=0.1.1 in /opt/anaconda3/lib/python3.12/site-packages (from open_spiel>=2.0.1) (1.1.0)\n",
-      "Requirement already satisfied: PyYAML in /opt/anaconda3/lib/python3.12/site-packages (from ml-collections>=0.1.1->open_spiel>=2.0.1) (6.0.1)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n",
-      "Requirement already satisfied: flax in /opt/anaconda3/lib/python3.12/site-packages (0.12.8)\n",
-      "Requirement already satisfied: optax in /opt/anaconda3/lib/python3.12/site-packages (0.2.8)\n",
-      "Requirement already satisfied: orbax-checkpoint in /opt/anaconda3/lib/python3.12/site-packages (0.12.1)\n",
-      "Requirement already satisfied: chex in /opt/anaconda3/lib/python3.12/site-packages (0.1.92)\n",
-      "Requirement already satisfied: matplotlib in /opt/anaconda3/lib/python3.12/site-packages (3.11.1)\n",
-      "Requirement already satisfied: jax[cpu] in /opt/anaconda3/lib/python3.12/site-packages (0.11.0)\n",
-      "Requirement already satisfied: jaxlib<=0.11.0,>=0.11.0 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (0.11.0)\n",
-      "Requirement already satisfied: ml_dtypes>=0.5.0 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (0.5.4)\n",
-      "Requirement already satisfied: numpy>=2.1 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (2.5.1)\n",
-      "Requirement already satisfied: opt_einsum in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (3.4.0)\n",
-      "Requirement already satisfied: scipy>=1.15 in /opt/anaconda3/lib/python3.12/site-packages (from jax[cpu]) (1.18.0)\n",
-      "Requirement already satisfied: msgpack in /opt/anaconda3/lib/python3.12/site-packages (from flax) (1.1.2)\n",
-      "Requirement already satisfied: tensorstore in /opt/anaconda3/lib/python3.12/site-packages (from flax) (0.1.84)\n",
-      "Requirement already satisfied: rich>=11.1 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (13.3.5)\n",
-      "Requirement already satisfied: typing_extensions>=4.2 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (4.16.0)\n",
-      "Requirement already satisfied: PyYAML>=5.4.1 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (6.0.1)\n",
-      "Requirement already satisfied: treescope>=0.1.7 in /opt/anaconda3/lib/python3.12/site-packages (from flax) (0.1.10)\n",
-      "Requirement already satisfied: absl-py>=0.7.1 in /opt/anaconda3/lib/python3.12/site-packages (from optax) (2.5.0)\n",
-      "Requirement already satisfied: etils[epath,epy] in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (1.14.0)\n",
-      "Requirement already satisfied: prometheus-client>=0.20.0 in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (0.26.0)\n",
-      "Requirement already satisfied: aiofiles in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (25.1.0)\n",
-      "Requirement already satisfied: protobuf in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (3.20.3)\n",
-      "Requirement already satisfied: humanize in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (4.16.0)\n",
-      "Requirement already satisfied: simplejson>=3.16.0 in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (4.1.1)\n",
-      "Requirement already satisfied: psutil in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (5.9.0)\n",
-      "Requirement already satisfied: uvloop in /opt/anaconda3/lib/python3.12/site-packages (from orbax-checkpoint) (0.22.1)\n",
-      "Requirement already satisfied: toolz>=1.0.0 in /opt/anaconda3/lib/python3.12/site-packages (from chex) (1.1.0)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (0.11.0)\n",
-      "Requirement already satisfied: fonttools>=4.28.2 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (4.51.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (1.4.4)\n",
-      "Requirement already satisfied: packaging>=20.0 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (23.2)\n",
-      "Requirement already satisfied: pillow>=9 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (10.3.0)\n",
-      "Requirement already satisfied: pyparsing>=3 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (3.0.9)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in /opt/anaconda3/lib/python3.12/site-packages (from matplotlib) (2.9.0.post0)\n",
-      "Requirement already satisfied: six>=1.5 in /opt/anaconda3/lib/python3.12/site-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n",
-      "Requirement already satisfied: markdown-it-py<3.0.0,>=2.2.0 in /opt/anaconda3/lib/python3.12/site-packages (from rich>=11.1->flax) (2.2.0)\n",
-      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /opt/anaconda3/lib/python3.12/site-packages (from rich>=11.1->flax) (2.15.1)\n",
-      "Requirement already satisfied: fsspec in /opt/anaconda3/lib/python3.12/site-packages (from etils[epath,epy]->orbax-checkpoint) (2024.3.1)\n",
-      "Requirement already satisfied: zipp in /opt/anaconda3/lib/python3.12/site-packages (from etils[epath,epy]->orbax-checkpoint) (3.17.0)\n",
-      "Requirement already satisfied: mdurl~=0.1 in /opt/anaconda3/lib/python3.12/site-packages (from markdown-it-py<3.0.0,>=2.2.0->rich>=11.1->flax) (0.1.0)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install --upgrade \"open_spiel>=2.0.1\"\n",
     "%pip install --upgrade \"jax[cpu]\" flax optax orbax-checkpoint chex matplotlib"
@@ -109,28 +52,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "jax 0.11.0\n",
-      "backend: cpu\n",
-      "devices: [CpuDevice(id=0)]\n",
-      "pyspiel games available: 126\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
-      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import collections\n",
     "import os\n",
@@ -173,17 +97,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "tic_tac_toe: observation shape [3, 3, 3], 9 distinct actions\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Hyperparameters and environment setup.\n",
     "SEED = 42\n",
@@ -224,201 +140,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting game tic_tac_toe\n",
-      "Writing logs and checkpoints to: /var/folders/_6/m1f08ld958917y_vty9_8yvm0000gn/T/az_teacher_12uqm1rq\n",
-      "Model type: mlp(width=256, depth=4)\n",
-      "learner started\n",
-      "[2026-07-25 23:53:54.993] Initializing model\n",
-      "actor-0 started\n",
-      "actor-3 started\n",
-      "actor-2 started\n",
-      "actor-1 started\n",
-      "evaluator-0 started\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
-      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
-      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
-      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
-      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
-      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
-      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
-      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n",
-      "/opt/anaconda3/lib/python3.12/site-packages/open_spiel/python/algorithms/alpha_zero/model_nnx.py:34: UserWarning: Pay attention that you've been using the `nnx` api\n",
-      "  warnings.warn(\"Pay attention that you've been using the `nnx` api\")\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2026-07-25 23:53:57.386] Model type: mlp(256, 4)\n",
-      "[2026-07-25 23:53:57.399] Model size: 338698 variables\n",
-      "[2026-07-25 23:53:57.545] Initial checkpoint: 0\n",
-      "[2026-07-25 23:53:57.551] Collecting trajectories\n",
-      "[2026-07-25 23:54:20.095] Step: 1\n",
-      "[2026-07-25 23:54:20.097] Collected  2049 states from 258 games, 24.8 states/s. 6.2 states/(s*actor), game length: 7.9\n",
-      "[2026-07-25 23:54:20.098] Buffer size: 2049. States seen: 2049\n",
-      "[2026-07-25 23:54:21.652] Losses(total: 1.897, policy: 1.547, value: 0.201, l2: 0.149)\n",
-      "[2026-07-25 23:54:21.654] Checkpoint saved: -1\n",
-      "[2026-07-25 23:54:21.794]\n",
-      "[2026-07-25 23:54:21.794] Collecting trajectories\n",
-      "[2026-07-25 23:54:40.630] Step: 2\n",
-      "[2026-07-25 23:54:40.631] Collected  2052 states from 271 games, 99.9 states/s. 25.0 states/(s*actor), game length: 7.6\n",
-      "[2026-07-25 23:54:40.632] Buffer size: 4101. States seen: 4101\n",
-      "[2026-07-25 23:54:40.915] Losses(total: 1.750, policy: 1.488, value: 0.127, l2: 0.136)\n",
-      "[2026-07-25 23:54:40.916] Checkpoint saved: -1\n",
-      "[2026-07-25 23:54:40.929]\n",
-      "[2026-07-25 23:54:40.931] Collecting trajectories\n",
-      "[2026-07-25 23:55:00.407] Step: 3\n",
-      "[2026-07-25 23:55:00.408] Collected  2052 states from 265 games, 103.8 states/s. 25.9 states/(s*actor), game length: 7.7\n",
-      "[2026-07-25 23:55:00.409] Buffer size: 6153. States seen: 6153\n",
-      "[2026-07-25 23:55:00.806] Losses(total: 1.631, policy: 1.402, value: 0.105, l2: 0.124)\n",
-      "[2026-07-25 23:55:00.807] Checkpoint saved: -1\n",
-      "[2026-07-25 23:55:00.828]\n",
-      "[2026-07-25 23:55:00.829] Collecting trajectories\n",
-      "[2026-07-25 23:55:19.535] Step: 4\n",
-      "[2026-07-25 23:55:19.536] Collected  2053 states from 250 games, 107.3 states/s. 26.8 states/(s*actor), game length: 8.2\n",
-      "[2026-07-25 23:55:19.537] Buffer size: 8192. States seen: 8206\n",
-      "[2026-07-25 23:55:20.008] Losses(total: 1.536, policy: 1.326, value: 0.093, l2: 0.117)\n",
-      "[2026-07-25 23:55:20.010] Checkpoint saved: -1\n",
-      "[2026-07-25 23:55:20.030]\n",
-      "[2026-07-25 23:55:20.031] Collecting trajectories\n",
-      "[2026-07-25 23:55:38.515] Step: 5\n",
-      "[2026-07-25 23:55:38.516] Collected  2048 states from 240 games, 107.9 states/s. 27.0 states/(s*actor), game length: 8.5\n",
-      "[2026-07-25 23:55:38.517] Buffer size: 8192. States seen: 10254\n",
-      "[2026-07-25 23:55:39.120] Losses(total: 1.356, policy: 1.184, value: 0.060, l2: 0.111)\n",
-      "[2026-07-25 23:55:39.122] Checkpoint saved: -1\n",
-      "[2026-07-25 23:55:39.142]\n",
-      "[2026-07-25 23:55:39.142] Collecting trajectories\n",
-      "[2026-07-25 23:55:57.529] Step: 6\n",
-      "[2026-07-25 23:55:57.530] Collected  2055 states from 241 games, 108.1 states/s. 27.0 states/(s*actor), game length: 8.5\n",
-      "[2026-07-25 23:55:57.531] Buffer size: 8192. States seen: 12309\n",
-      "[2026-07-25 23:55:58.004] Losses(total: 1.233, policy: 1.086, value: 0.041, l2: 0.106)\n",
-      "[2026-07-25 23:55:58.005] Checkpoint saved: -1\n",
-      "[2026-07-25 23:55:58.015]\n",
-      "[2026-07-25 23:55:58.016] Collecting trajectories\n",
-      "[2026-07-25 23:56:16.478] Step: 7\n",
-      "[2026-07-25 23:56:16.479] Collected  2054 states from 236 games, 108.4 states/s. 27.1 states/(s*actor), game length: 8.7\n",
-      "[2026-07-25 23:56:16.481] Buffer size: 8192. States seen: 14363\n",
-      "[2026-07-25 23:56:16.988] Losses(total: 1.107, policy: 0.977, value: 0.028, l2: 0.102)\n",
-      "[2026-07-25 23:56:16.989] Checkpoint saved: -1\n",
-      "[2026-07-25 23:56:17.015]\n",
-      "[2026-07-25 23:56:17.016] Collecting trajectories\n",
-      "[2026-07-25 23:56:36.226] Step: 8\n",
-      "[2026-07-25 23:56:36.227] Collected  2053 states from 240 games, 104.0 states/s. 26.0 states/(s*actor), game length: 8.6\n",
-      "[2026-07-25 23:56:36.230] Buffer size: 8192. States seen: 16416\n",
-      "[2026-07-25 23:56:36.768] Losses(total: 1.073, policy: 0.951, value: 0.024, l2: 0.097)\n",
-      "[2026-07-25 23:56:36.769] Checkpoint saved: -1\n",
-      "[2026-07-25 23:56:36.780]\n",
-      "[2026-07-25 23:56:36.780] Collecting trajectories\n",
-      "[2026-07-25 23:56:56.230] Step: 9\n",
-      "[2026-07-25 23:56:56.232] Collected  2050 states from 242 games, 102.5 states/s. 25.6 states/(s*actor), game length: 8.5\n",
-      "[2026-07-25 23:56:56.235] Buffer size: 8192. States seen: 18466\n",
-      "[2026-07-25 23:56:56.734] Losses(total: 1.047, policy: 0.933, value: 0.021, l2: 0.093)\n",
-      "[2026-07-25 23:56:56.735] Checkpoint saved: -1\n",
-      "[2026-07-25 23:56:56.746]\n",
-      "[2026-07-25 23:56:56.747] Collecting trajectories\n",
-      "[2026-07-25 23:57:16.211] Step: 10\n",
-      "[2026-07-25 23:57:16.212] Collected  2049 states from 238 games, 102.6 states/s. 25.6 states/(s*actor), game length: 8.6\n",
-      "[2026-07-25 23:57:16.214] Buffer size: 8192. States seen: 20515\n",
-      "[2026-07-25 23:57:16.715] Losses(total: 1.037, policy: 0.928, value: 0.020, l2: 0.089)\n",
-      "[2026-07-25 23:57:16.716] Checkpoint saved: -1\n",
-      "[2026-07-25 23:57:16.739]\n",
-      "[2026-07-25 23:57:16.740] Collecting trajectories\n",
-      "[2026-07-25 23:57:35.522] Step: 11\n",
-      "[2026-07-25 23:57:35.523] Collected  2053 states from 237 games, 106.3 states/s. 26.6 states/(s*actor), game length: 8.7\n",
-      "[2026-07-25 23:57:35.525] Buffer size: 8192. States seen: 22568\n",
-      "[2026-07-25 23:57:36.054] Losses(total: 1.054, policy: 0.946, value: 0.023, l2: 0.085)\n",
-      "[2026-07-25 23:57:36.056] Checkpoint saved: -1\n",
-      "[2026-07-25 23:57:36.067]\n",
-      "[2026-07-25 23:57:36.068] Collecting trajectories\n",
-      "[2026-07-25 23:57:55.496] Step: 12\n",
-      "[2026-07-25 23:57:55.497] Collected  2053 states from 238 games, 102.8 states/s. 25.7 states/(s*actor), game length: 8.6\n",
-      "[2026-07-25 23:57:55.498] Buffer size: 8192. States seen: 24621\n",
-      "[2026-07-25 23:57:56.010] Losses(total: 1.041, policy: 0.940, value: 0.019, l2: 0.081)\n",
-      "[2026-07-25 23:57:56.011] Checkpoint saved: -1\n",
-      "[2026-07-25 23:57:56.030]\n",
-      "[2026-07-25 23:57:56.030] Collecting trajectories\n",
-      "[2026-07-25 23:58:14.932] Step: 13\n",
-      "[2026-07-25 23:58:14.933] Collected  2054 states from 236 games, 105.7 states/s. 26.4 states/(s*actor), game length: 8.7\n",
-      "[2026-07-25 23:58:14.935] Buffer size: 8192. States seen: 26675\n",
-      "[2026-07-25 23:58:15.440] Losses(total: 1.038, policy: 0.944, value: 0.016, l2: 0.078)\n",
-      "[2026-07-25 23:58:15.442] Checkpoint saved: -1\n",
-      "[2026-07-25 23:58:15.455]\n",
-      "[2026-07-25 23:58:15.456] Collecting trajectories\n",
-      "[2026-07-25 23:58:34.529] Step: 14\n",
-      "[2026-07-25 23:58:34.530] Collected  2048 states from 238 games, 104.5 states/s. 26.1 states/(s*actor), game length: 8.6\n",
-      "[2026-07-25 23:58:34.530] Buffer size: 8192. States seen: 28723\n",
-      "[2026-07-25 23:58:35.098] Losses(total: 1.033, policy: 0.942, value: 0.017, l2: 0.074)\n",
-      "[2026-07-25 23:58:35.099] Checkpoint saved: -1\n",
-      "[2026-07-25 23:58:35.127]\n",
-      "[2026-07-25 23:58:35.128] Collecting trajectories\n",
-      "[2026-07-25 23:58:54.499] Step: 15\n",
-      "[2026-07-25 23:58:54.500] Collected  2049 states from 240 games, 102.6 states/s. 25.7 states/(s*actor), game length: 8.5\n",
-      "[2026-07-25 23:58:54.501] Buffer size: 8192. States seen: 30772\n",
-      "[2026-07-25 23:58:54.978] Losses(total: 1.047, policy: 0.959, value: 0.017, l2: 0.071)\n",
-      "[2026-07-25 23:58:54.980] Checkpoint saved: -1\n",
-      "[2026-07-25 23:58:54.990]\n",
-      "[2026-07-25 23:58:54.991] Collecting trajectories\n",
-      "[2026-07-25 23:59:14.329] Step: 16\n",
-      "[2026-07-25 23:59:14.331] Collected  2052 states from 243 games, 103.5 states/s. 25.9 states/(s*actor), game length: 8.4\n",
-      "[2026-07-25 23:59:14.332] Buffer size: 8192. States seen: 32824\n",
-      "[2026-07-25 23:59:14.812] Losses(total: 1.041, policy: 0.955, value: 0.017, l2: 0.068)\n",
-      "[2026-07-25 23:59:14.813] Checkpoint saved: -1\n",
-      "[2026-07-25 23:59:14.836]\n",
-      "[2026-07-25 23:59:14.837] Collecting trajectories\n",
-      "[2026-07-25 23:59:34.330] Step: 17\n",
-      "[2026-07-25 23:59:34.331] Collected  2051 states from 240 games, 102.5 states/s. 25.6 states/(s*actor), game length: 8.5\n",
-      "[2026-07-25 23:59:34.332] Buffer size: 8192. States seen: 34875\n",
-      "[2026-07-25 23:59:34.845] Losses(total: 1.050, policy: 0.967, value: 0.018, l2: 0.066)\n",
-      "[2026-07-25 23:59:34.848] Checkpoint saved: -1\n",
-      "[2026-07-25 23:59:34.869]\n",
-      "[2026-07-25 23:59:34.874] Collecting trajectories\n",
-      "[2026-07-25 23:59:53.996] Step: 18\n",
-      "[2026-07-25 23:59:53.997] Collected  2051 states from 239 games, 104.3 states/s. 26.1 states/(s*actor), game length: 8.6\n",
-      "[2026-07-25 23:59:53.999] Buffer size: 8192. States seen: 36926\n",
-      "[2026-07-25 23:59:54.497] Losses(total: 1.047, policy: 0.965, value: 0.018, l2: 0.063)\n",
-      "[2026-07-25 23:59:54.500] Checkpoint saved: -1\n",
-      "[2026-07-25 23:59:54.520]\n",
-      "[2026-07-25 23:59:54.521] Collecting trajectories\n",
-      "[2026-07-26 00:00:13.926] Step: 19\n",
-      "[2026-07-26 00:00:13.927] Collected  2051 states from 237 games, 102.9 states/s. 25.7 states/(s*actor), game length: 8.7\n",
-      "[2026-07-26 00:00:13.928] Buffer size: 8192. States seen: 38977\n",
-      "[2026-07-26 00:00:14.406] Losses(total: 1.052, policy: 0.975, value: 0.016, l2: 0.061)\n",
-      "[2026-07-26 00:00:14.407] Checkpoint saved: -1\n",
-      "[2026-07-26 00:00:14.423]\n",
-      "[2026-07-26 00:00:14.423] Collecting trajectories\n",
-      "[2026-07-26 00:00:33.429] Step: 20\n",
-      "[2026-07-26 00:00:33.430] Collected  2056 states from 238 games, 105.4 states/s. 26.4 states/(s*actor), game length: 8.6\n",
-      "[2026-07-26 00:00:33.432] Buffer size: 8192. States seen: 41033\n",
-      "[2026-07-26 00:00:33.939] Losses(total: 1.044, policy: 0.970, value: 0.015, l2: 0.058)\n",
-      "[2026-07-26 00:00:33.940] Checkpoint saved: 20\n",
-      "[2026-07-26 00:00:33.951]\n",
-      "[2026-07-26 00:00:33.966] learner exiting\n",
-      "learner exiting\n",
-      "actor-2 exiting\n",
-      "actor-3 exiting\n",
-      "actor-0 exiting\n",
-      "actor-1 exiting\n",
-      "evaluator-0 exiting\n",
-      "\n",
-      "Teacher training finished in 6.7 minutes\n",
-      "checkpoints: ['checkpoint--1', 'checkpoint-0', 'checkpoint-20']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Train the teacher model using AlphaZero self-play.\n",
     "teacher_dir = tempfile.mkdtemp(prefix=\"az_teacher_\")\n",
@@ -478,17 +202,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Teacher reloaded: 338,698 trainable parameters (mlp, width=256, depth=4)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def build_model(width, depth, path, learning_rate=1e-3, seed=SEED):\n",
     "  \"\"\"Builds an AlphaZero Model (mlp torso) with the given capacity.\"\"\"\n",
@@ -523,17 +239,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Batched forward matches Model.inference() on 10 probe states.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def make_batched_forward(model):\n",
     "  \"\"\"Returns a batched forward function matching Model.inference.\"\"\"\n",
@@ -581,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,17 +352,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sanity - optimal vs optimal:   0W  20D   0L   (score 0.500)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def play_matches(agent_a, agent_b, n_games):\n",
     "  \"\"\"Plays n_games alternating seats and returns (wins, draws, losses) for agent_a.\"\"\"\n",
@@ -685,20 +385,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  teacher-raw vs random    92W   8D   0L   (score 0.960)   [0.2s]\n",
-      "  teacher-raw vs minimax    0W  97D   3L   (score 0.485)   [0.1s]\n",
-      " teacher+MCTS vs random    90W  10D   0L   (score 0.950)   [11.1s]\n",
-      " teacher+MCTS vs minimax    0W 100D   0L   (score 0.500)   [4.3s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Evaluate teacher variants against random and minimax opponents.\n",
     "random_agent = make_random_agent(SEED)\n",
@@ -733,17 +422,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reachable non-terminal positions: 4520\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def enumerate_non_terminal_states():\n",
     "  \"\"\"BFS from initial state to return deduplicated reachable non-terminal states.\"\"\"\n",
@@ -779,18 +460,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4520 positions -> 627 symmetry classes\n",
-      "class-size histogram: {1: 4, 2: 4, 4: 111, 8: 508}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Compute board symmetries for Tic-Tac-Toe.\n",
     "_grid = np.arange(9).reshape(3, 3)\n",
@@ -828,19 +500,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "train: 3628 positions from 502 classes\n",
-      "val:   892 positions from 125 classes\n",
-      "No symmetry class appears on both sides of the split.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Split symmetry classes into training and validation sets.\n",
     "_rng = np.random.default_rng(SEED)\n",
@@ -873,20 +535,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Teacher targets for 4520 positions in 0.08s\n",
-      "policy targets: shape (4520, 9), rows sum to 1\n",
-      "value targets:  shape (4520,), range [-0.298, 1.000]\n",
-      "teacher policy entropy: 0.6432 (irreducible floor of the distillation cross-entropy)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Compute teacher target outputs for all states.\n",
     "observations = np.stack([state_features(s)[0] for s in all_states])\n",
@@ -919,19 +570,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Student: 3,338 parameters (mlp, width=32, depth=1)\n",
-      "Teacher: 338,698 parameters\n",
-      "Compression: 101.5x fewer parameters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Build student model.\n",
     "student_dir = tempfile.mkdtemp(prefix=\"az_student_\")\n",
@@ -946,25 +587,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "epoch    0  train policy 1.0815 value 0.0609  |  val policy 1.0475 value 0.0580\n",
-      "epoch   50  train policy 0.6676 value 0.0059  |  val policy 0.7076 value 0.0080\n",
-      "epoch  100  train policy 0.6650 value 0.0050  |  val policy 0.7021 value 0.0083\n",
-      "epoch  150  train policy 0.6655 value 0.0049  |  val policy 0.6997 value 0.0081\n",
-      "epoch  200  train policy 0.6613 value 0.0047  |  val policy 0.6985 value 0.0098\n",
-      "epoch  250  train policy 0.6606 value 0.0044  |  val policy 0.6969 value 0.0064\n",
-      "epoch  299  train policy 0.6633 value 0.0045  |  val policy 0.6962 value 0.0071\n",
-      "\n",
-      "Distillation finished in 19.3s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def evaluate_losses(forward_fn, indices):\n",
     "  \"\"\"Computes policy cross-entropy and value loss against teacher targets.\"\"\"\n",
@@ -1018,20 +643,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEIAAAGNCAYAAAAVRNS/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAA9lBJREFUeJzs3Xd8k9X+B/DPk9Gke7eMli17T5E9ZMhGRGQ4EBw/vO4rol4VB1wUxxURF6jABUQFroKIyt7IllE2dADdbTrTJM/5/fE0aUObkJa0aenn/Xrxojk553nOc5I2J9/nDEkIIUBEREREREREVAOoPF0BIiIiIiIiIqLKwkAIEREREREREdUYDIQQERERERERUY3BQAgRERERERER1RgMhBARERERERFRjcFACBERERERERHVGAyEEBEREREREVGNwUAIEREREREREdUYDIQQERERERERUY3BQAgREVEFePHFF6HX62+aVhVVRD1dbY+KaqPq0vZERERU8RgIISIiKhQVFQVJkmz/fHx80KFDByxYsACyLHu6euXyzjvv2F2TXq9H7dq10b9/f8ydOxeJiYluO9dTTz0FPz8/tx2vup3fEetrcPToUU9XhYiIiMBACBERkZ1u3bpBCAEhBC5cuIA+ffrg6aefxiuvvHLLx54/fz7y8/PdUMuyO3LkCIQQyMrKwl9//YVp06Zh5cqVaN68OX799dcKr6cnr70qnJ+IiIiqDgZCiIiIHKhduzY++ugjNGvWDJ9++inMZrOnq3TLtFotoqKiMHHiRBw4cABNmzbFfffdhytXrni6akRERESVgoEQIiIiJyRJQtOmTZGTk4O0tDQAwB9//IG+ffvCz88PPj4+6N69O9atW3fTYzlap+Lvv//G+PHjERkZCR8fH3Tq1AnLli2DEAIffPABJEnCiRMnSpRbsGABJEnC4cOHy3Vter0e//73v5Gbm4tPPvnEaT3Pnz+PCRMmoE6dOvDx8UGbNm0wZ84c5OXlAQCGDx+OhQsXIicnx24qTnx8vNNrd8X8+fPtjhkYGIi+ffti06ZNtjzlPb8rr+W0adMQFhaGrKwsPPzwwwgMDERQUBAeeughZGdnl+uabiSEwMcff4xWrVpBr9cjNDQUY8eOxenTp+3y/fbbb+jduzdCQkIQHByMnj17Ys2aNWXOQ0REVJMxEEJEROSEEAJnz56Fj48PQkJCsG7dOgwZMgSNGzfGqVOncOHCBfTo0QNjxozB4sWLy3z8Xbt2oWvXrsjKysKmTZuQlJSEr7/+Gn/88QcuXbqEqVOnwtvbG5999lmJsp9//jnat2+Pjh07lvv6evXqBb1ej+3btzvMI4TA4MGDkZKSgm3btiEtLQ2rV69GXl4efvnlFwDA+vXrMWPGDPj6+tqmFgkhEBUVVe66Wb344ou241ksFhw/fhxt2rTByJEjcezYsXKfvyyvpRACTz31FCZMmID4+HisXLkSa9aswcsvv3zL1wcAM2bMwMyZM/HUU0/h6tWr2LlzJ1JSUnDnnXciJiYGAHDixAmMHDkSPXr0QExMDOLj4zF//nysXLnSttaLK3mIiIhqOgZCiIiIHLh+/TpeeOEFnDlzBv/3f/8HjUaDF154AS1atMDXX3+NevXqoXbt2pg/fz769OmDmTNnwmg0lukc//d//4e6devi559/Rvv27eHn54cOHTpg6dKlaNSoEYKDgzFhwgQsX77cbvTBtm3bcOrUKTz66KO3dI0ajQa1atXC1atXHeaJjY3FxYsX8eCDD6Jp06bQ6/Vo0aIF3n77bYwfP/6Wzl9WKpUK9evXx4IFCxAREYFvv/223Mcqy2uZlpaG0aNHY8iQIfD398fQoUMxZcoULF68+JYX0j1z5gw+//xzPPXUU3jyyScREhKCli1bYu3atbBYLHjttdcAALt374bJZMJzzz2HiIgI+Pr64s4778QPP/yAyMhIl/MQERHVdAyEEBERFbN//37btIqGDRti8+bN+PDDDzFv3jxcvnwZFy9exJgxYyBJkl25cePGITU1tUw7g8TFxeHvv//GfffdB61W6zDfjBkzkJWVhWXLltnSPvvsM+j1ekyaNKnM13gjIUSJ6ymudu3aiIiIwFtvvYXly5cjOTn5ls9ZFtnZ2Zg1axaaN28OvV5vN+3l/Pnz5TpmWV9LSZIwdOhQu3ytW7dGfn6+0yCSK7Zu3QohBMaOHWuXHhoair59+2Lz5s0AgLZt2wIAHnroIfz555+2aUnFuZKHiIiopmMghIiIqJjiu8bk5eXh2LFjeO6556BSqZCamgoAqFWrVoly1rSUlBSXz5WUlAQAqFu3rtN8nTp1QteuXbFo0SIAykiVdevWYcyYMQgODnb5fKUxm81ITExEnTp1HObx8vLC77//jmbNmmHatGmIiIhA69atMWfOnErZiWXChAn48ssv8d577+Hq1auwWCwQQqB58+YwmUzlOmZZX8vg4OASa4wEBAQAADIyMspVB1frkpGRAYvFgu7du2PlypVISkrCoEGDbGul/Pjjj7b8ruQhIiKq6RgIISIiclFISAgAlLrWgjUtLCzM5eOFh4cDABISEm6ad8aMGfj777+xa9cufPXVVzCZTLc8LQYAduzYgfz8fPTt29dpvnbt2mHDhg3IyMjAzp07cffdd+O1117Ds88+e8t1cCY1NRUbNmzAM888g5EjRyIkJAQqlQqyLN/STjdlfS2djZi5VTerS1BQENRqNQAlKHTo0CGkpKTgxx9/hE6nw3333We3wKsreYiIiGoyBkKIiIhc1LBhQzRs2BDr1q2DEMLuuZ9++gkhISFo3769y8erV68e2rRpgx9++OGmIxvuv/9+hIWFYcGCBfjqq6/QsGFD9O/fvzyXYZOfn49Zs2bBx8cHTz/9tEtl9Ho9evbsiY8++gh33XUXduzYYXvO19cXBQUFt1SnG1kDEDqdzi79xx9/LDHtoyznd/dreSusr+PatWvt0tPS0rBt2zYMGDCgRJmQkBCMHDkSP/30EwDYvQ5lyUNERFQTMRBCRERUBu+//z5OnDiBxx9/HHFxcbh+/TpeeuklbN26Ff/+979LfGG/mc8++wwJCQkYNWoUjh07hpycHBw9ehQPPfQQLl68aMun0+kwdepUrF69GnFxcXjkkUfKNUrBbDYjISEBK1euRNeuXXHu3DmsWbMG0dHRDsvs27cP48ePx+bNm5GcnIy8vDxs3LgRx48fR79+/Wz5WrduDZPJhI0bN8JisZS5bqUJCQlBjx49sHDhQvz111/IysrC//73P3z66ado0aKFXd6ynt/dr2V5NWvWDI899hg++eQTfPnll0hPT8fp06dx7733AgDeeustAMo2wi+99BIOHz6M7OxspKWl2bY9to7ocSUPERFRTcdACBERURnce++92LhxI2JiYtC8eXM0atQIO3bswI8//ojp06eX+Xg9e/bEvn374O3tjf79+yMiIgLTpk3DwIED0bBhQ7u8Tz75JFQqFVQqFR5++OEynadDhw6QJAm+vr7o1KkTvvzySzzwwAOIiYnB4MGDnZbt0qUL7r//frz33nto1aoVIiIi8NJLL+HVV1/FRx99ZMv3wAMP4JFHHsGUKVOg1WptC5requ+//x5du3bF4MGDERUVhaVLl+L777+Hl5eXXb6ynt/dr+XNWF+DG//t27cPixYtwpw5c/Dxxx+jVq1auOuuuxAYGIi9e/eiZcuWAIDp06cjMjISjz/+OGrVqoWmTZvi999/x9q1azFy5EiX8xAREdV0krhxPCgRERFVScnJyahbty4GDBiAjRs3ero6RERERNUSR4QQERFVE2vWrIHJZKqQ0QpERERENQVHhBAREVUDCQkJGDBgADQaDY4fPw6VivcyiIiIiMqDvSgiIqIqrn379mjYsCECAwPx/fffMwhCREREdAs4IoSIiIiIiIiIagzeUiIiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQIiIiIiIiIqoxGAghIiIiIiIiohqDgRAiIiIiIiIiqjEYCCEiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQIiIiIiIiIqoxGAghIiIiIiIiohqDgRAiIiIiIiIiqjEYCCEiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQIiIiIiIiIqoxGAghIiIiIiIiohqDgRAiIiIiIiIiqjEYCCEiIiIiIiKiGoOBECIiIiIiIiKqMRgIISIiIiIiIqIag4EQqnG+/fZbSJKE8+fPO03zRD2qkh9++AEBAQFITU2tsHOcPHkSAwYMQEBAACRJwo8//lhh56Kqb/HixYiMjITBYPB0VYiIKsSQIUPQuXPnGnduV9x777249957PV0NchO9Xo9nn33W09W4ZXfffTcefvhhT1eDKgADIVQtDBkyBJIk2f7p9Xo0a9YMr732GnJzcz1dvduO0WjEzJkz8eyzzyI0NLTCzjNp0iQIIRAbGwshBMaNG4fhw4ejdevWFXbOmiIjIwOSJOHf//63p6visoceeggBAQF49913PV0VIqrhRo4cCZ1Oh5SUFId55syZA0mSsHXr1kqs2e1px44dWLduHWbPnl3iubNnz2L06NEICgqCn58f+vbti71797p03DfffNOu/1j83/Xr1919GXQbeuedd7B06VIcOnTI01UhN2MghKoNX19fCCEghMC1a9fw1FNPYc6cORg/fvwtH/vhhx+GEAJNmjRxQ02rv5UrVyI2Nhb/93//V2HnMBgMOHbsGEaMGIGgoKAKOw9VHxqNBo8//jgWLlzIUSFE5FHTp09HQUEBli9fXurzQggsWbIETZo0Qd++fSu3crehOXPmoG/fviVuhMTFxaFnz54wmUw4ceIE4uLi0LJlS/Tv3x8HDx50+fhZWVm2PqT1X61atdx9GXQb6tatGzp27FitbiyRaxgIoWopODgY//jHPzB69Ghs2LAB586d83SVbiuff/45Bg4cWKGdhOTkZACAt7d3hZ2Dqp+JEyciNzcXy5Yt83RViKgGu+eee1CnTh0sXry41Oe3bt2KCxcuYNq0aZAkqZJrd3u5dOkSfv/9d0yZMqXEc2+//Tays7OxbNkyREVFITg4GAsWLEDdunXxz3/+0wO1pZpo8uTJWLduHUcR3WYYCKFqrXnz5gCUOwYAcPz4cYwaNQohISHQ6/Vo06YNFi5cCCGE0+M4Wq8jISEBjz/+OOrVqwe9Xo+WLVvivffeg9FoxKZNmyBJElatWlXieFu3boUkSVi6dGmZr8mVa0hLS8OMGTNQv359eHt7o2nTpnj22WfthvC6kqc0ycnJ2L9/P/r371/iOVePebNreOKJJ2yjb5588klIkoSwsDC0bt0aGzZswMmTJ21DVzUazU3bbOfOnRg2bBhCQ0Ph5+eHnj17YsOGDbbnBw4ciM6dOyM2NhYjR45EQEAAhg8fDgDIzs7Giy++iAYNGsDLywt169bF448/XuKavvjiC7Rv3x7+/v6oVasWhg8fjv3795c5jyMWiwUffvgh2rRpA71ej+DgYNx77712Qb7r169DkiR8/PHH2LBhgy1vy5Yt8b///c+W7+jRowgODgYAzJo1y9aW1jmuxY+zdu1atG3bFl5eXrb38tGjRzFy5EgEBwdDr9ejbdu2WLRokV1958+fD0mSkJCQgKeffhphYWHw8/PD6NGjcenSJVu+DRs2OFz/5Y8//oAkSVixYoUtrU6dOmjevDl+/vlnl9qNiKgiqNVqPPLIIzhx4kSpf8cXL14MjUaDhx56CIAystT6t1alUiEsLAwjR47E8ePHb3quqKgoTJ48uUT6ww8/XOoNiT///BMDBw5EYGAgvL290aVLF7vPgLL67rvv0LFjR3h7eyMwMBCDBw8ucc179+7F4MGDER4eDn9/f3Tp0gXffPMNZFkuU57SrF+/HkKIUvsda9asQZ8+fRASEmJLU6vVGDlyJLZv3267qVIRjh07Bh8fH0yaNMku/a+//oJOp8Ojjz7qtLyr7fHBBx+gUaNG8Pb2Rrdu3bBnzx5MmzYNYWFhdvnK8j5x9f145513om/fvrhw4QKGDh0Kf39/TJgwAQBgMpkwd+5ctGzZEnq9HiEhIbj//vtx+fJlu2MkJiZi8uTJCAoKQlBQEB588MEyjep05Tznz5+HJEn4+uuvsXLlSrRq1QparRbr16/Hxx9/DEmSEBcXh5deegm1a9e2C04uWbIEHTp0gLe3N4KCgjB06FD89ddfdnXo3LkzBg4ciLNnz2LIkCHw8/Oza+v+/fvDbDZj48aNLl8XVQOCqBoYPHiw8PX1LZE+duxYAUCcPXtWHD9+XPj6+or+/fuLU6dOidTUVPHJJ58IjUYjnnvuOVuZb775RgAQ586dc5p2+fJlERkZKdq1aye2b98uDAaDOH36tHj55ZfFxo0bhSzL4o477hC9evUqUa9x48aJgIAAkZOT4/CaSjunq9cwfPhw0bRpU3Ho0CGRl5cnLl68KBYsWCDmzZtXpjylWbNmjQAgNm/eXOI5V47p6jWcO3dOABCLFi2yO8ewYcNEq1atnNaxuO+//16oVCrx4IMPitOnT4usrCyxZ88eMWzYMGE2m4UQQgwYMEC0atVK3HPPPWLnzp0iJSVFLF++XJhMJnHXXXeJ8PBwsX79epGZmSm2b98uGjZsKJo1ayYMBoMQQojly5cLlUolvv32W5GZmSlSU1PFxo0bxbhx42z1cCWPM/fdd58ICgoSS5cuFWlpaeLixYtizJgxIiwsTMTFxQkhhLh27ZoAIMaNGycee+wxcfnyZZGYmCgmTJggtFqtuHLliu146enpAoCYO3duiXNZjzNq1CjxyCOPiEuXLomTJ0+Kbdu2iSNHjggfHx9x9913i5iYGJGSkiI++ugjoVarxT//+U/bMd5//30BQDzwwAPiu+++ExkZGeLQoUOibdu2IioqSqSmpgohhLBYLKJhw4aiX79+JeoxevRoERQUJPLy8uzSH3roIeHr6yssFotLbUdEVBEuXrwoJEkS06dPt0tPS0sTer1ejBkzptRyBQUF4uTJk2LkyJEiMjJSJCcn254bPHiw6NSpk13+unXrikmTJpU4zkMPPSQiIyPt0pYuXSokSRLPPfecuHLlikhLSxMffvihUKvVYsWKFU6vp7Rzv/vuu0KSJPH222+LpKQkceHCBTFmzBjh5eUlduzYIYRQPjP8/f3F1KlTRXx8vMjNzRWHDx8Wjz76qDh8+LDLeRwZP368CA8PL5EeHx8vAIhnnnmmxHNffvmlACC2bNni9NhvvPGGACAiIiKERqMRtWrVEhMmTBCnT592Ws5qyZIlAoD49NNPhRBCpKSkiHr16ol27dqV+OwqztX2eP3114VarRYff/yxSE1NFadOnRL33HOPGDhwoAgNDbU7ZlneJ8U5ez9269ZNdOrUSQwZMkTs27dPJCUliRUrVgiLxSKGDRsmwsLCxKpVq0R6ero4d+6cGDp0qKhdu7ZITEwUQgiRl5cnWrVqJRo2bCh27NghMjMzxbp168QDDzwgdDpdqa9dca6ex9pnHD16tHjyySfFlStXxJEjR8SePXvERx99JACIiRMnisWLF4vU1FTxxRdfCCGEmD17tlCpVGLOnDkiKSlJnDt3TowcOVLodDqxZ88eWz06deokunTpIoYMGSIOHDggkpKSxMqVK+3q6ePjIx5++GGn10PVCwMhVC3cGAhJT08XCxcuFJIkiSFDhgghhBg5cqQICAgQ6enpdmVnzJghVCqVuHDhghDC9UDIhAkThK+vr7h69arDen3wwQcCgDhx4oQt7erVq0Kj0YjHH3/c6TWVdk5Xr8HPz8/uS2lpXMlTmo8//lgAEKdOnSrXMV29BncEQvLy8kR4eLjo3bu303wDBgwQAMTu3bvt0lesWCEAlOg87ty50y6IMG3aNBEdHe30HK7kcWTDhg0CgPjmm2/s0nNyckRkZKSYMWOGEKIogNGqVSshy7ItX1JSklCr1WL27Nm2NFcCIY0bNy4RbLjnnntEUFCQyMzMtEt//PHHhVqtFpcvXxZCFAVC3njjDbt8p06dEpIkiddff92WNm/ePAHAruMZHx8v1Gq17dqKe/nllwUAWweIiMhTBg4cKPz9/UV2drYt7ZNPPhEAxK+//uq0rPXv8Ndff21Lu5VASHZ2tggODhajRo0qkXfy5MkiKirK7rPhRjeeOzU1Vej1ejF+/Hi7fPn5+aJu3bqiW7duQggh1q9fLwCIQ4cOOTy2K3kcufPOO0Xbtm1LpB87dqzUzxkhhFi9erUAIFavXu302J9++qn49NNPxYULF4TBYBB//vmnaN26tfDz8xNHjhxxqX5Tp04VXl5eYu/evWLIkCEiMDBQnD9/3mkZV9ojNTVV6HQ68eijj9qlJyUlCR8fH7cFQqxKez9269ZNABBHjx61y/v9998LAOKHH36wS8/IyBBBQUFi5syZQgghvvjiCwFAbN261S7f559/7jCIVZ7zWPuMbdq0KXEMayBk1qxZdunJyclCp9OJiRMn2qXn5eWJWrVqiR49etjSOnXqVKI/f6MGDRqUelOHqi9OjaFqIycnxzbMLzIyEh9//DFmzpxpG3K/efNm9O/fv8TCm+PGjYMsy2Ve1f3XX39Fv379ULt2bYd5HnnkEXh7e+Ozzz6zpX311Vcwm803HTJZGlevoV27dli8eDE+/fRTXLlypdRjuZKnNBkZGQAAf3//ch3T3a+DM3/99ReSk5MxceLEm+YNDQ3FXXfdVaKukiRhzJgxduk9e/ZEZGQkNm/eDEC57ri4ODz55JM4cOAALBZLieO7kqd9+/Z2K9Zbh5/+8ssvUKlUGDt2rF1+Hx8fdO/eHdu3b7dLv+eee+yGfYaHhyMiIgIXL168aTsUN3z4cKhURR8DQghs2bIFAwcOREBAgF3ecePGwWKxYNu2bXbpI0eOtHvcokULNGvWDFu2bLGlPfroo9Dr9XbTa7744gtYLJZSf0+s57a+F4mIPGX69OnIysrC6tWrbWmLFy9GdHQ0Bg8ebEu7evUqHnvsMdSvXx9eXl6QJMk2RfHGabfltWvXLqSnp+O+++4r8dzAgQMRHx9fps+BPXv2ID8/v8Rnj06nw/Dhw3HgwAFkZWWhRYsW0Gq1eOqpp/DLL78gKyurxLFcyeNIRkZGqX0OK2drsNxsfZYZM2ZgxowZaNSoEfz9/TFgwAD8+uuvEELg5Zdfdql+CxcuRIsWLdCvXz/89ttv+Oabb9C4cWOnZVxpj927d8NoNJb4HA0PDy/RXymrsrwf69evj3bt2tml/fLLL/Dy8ipRt8DAQHTu3NnWL9m8eTP8/f1LLBg8evRol+rp6nmsbszn7Lldu3bBaDSWeH/r9XoMGzYMe/futdt5snHjxmjVqpXD4wcEBLBfcpthIISqjeK7xhiNRpw9exZz586Fr68vjEYjcnJySp1La0272doYxRmNRhgMBtStW9dpvuDgYDzwwANYtmwZsrOzYbFY8NVXX6FNmzbo0qVLma6vLNewatUq3HPPPXj11VfRoEEDNGzYEM8995zdNbqSpzTWAEZp8ztvdkx3vw43k5SUBAA3fZ0c5UlNTUVgYCD0en2J52rVqmWr65NPPom5c+fijz/+QLdu3RAcHIzRo0fbzaF2JY8j169fhyzLCAkJgUajgVqthkqlgkqlwrp165CammqXv7TgXHk+oG9sk9zcXOTn55fp9YuMjCyRNzIy0i5faGgoxo8fj++++w65ubkwm834+uuv0aFDB3To0KFEeet7z9ppIyLylNGjRyM8PNy2aOrBgwdx7NgxTJ061RZILigoQN++fbFr1y4sX74cqampkGUZBQUFkCQJJpOpXOcWN6xvZl2o8cEHHyzxWWFdA+rGzwtnrHkd/c0XQiAtLQ2NGjXC+vXrbTcOgoODceedd+Lrr7+21dGVPI4EBQWV2ucIDQ0FAKSnp5d4zvp5V3ztEFdFR0ejY8eO2LVrl0v59Xo9Jk2ahPz8fLRs2RKjRo26aRlX2sPa/o4+R111Y/uW9f1YWv/o+vXrKCgogI+Pj917TZIk/Pnnn7a6p6amllrXiIgIuxstjrh6Hmd1dfTczd7fsizbvbdu1pc0GAzsl9xmGAih24JOp4Ovry8SExNLPGdNu3HRqZsdz9/fHwkJCTfNO2PGDGRlZWH58uX4+eefER8fX67RIGW5hqioKCxbtgypqak4fPgwpk2bhi+//NIuAu9KntLUr18fAEpdGftmx3T363Az4eHhAODS66TVakukhYSEIDMzE/n5+SWeS0xMtNVVrVbj5Zdfxvnz5xEbG4uFCxfiwoUL6NOnj+3Oiit5jh49ard1n3Vx0rCwMOh0OluQwGKxQJZlyLIMIQSuXr1qVzd37VBwY5v4+PhAr9eX6fVzlNfagbWaMWMGMjMzsWLFCqxduxbXrl1z+Hty7do1+Pr6ljgGEVFl8/LywpQpU7B7927ExMTg66+/hkqlwtSpU2159u3bh3PnzuGdd95Br1694O/vD0mScOXKlZsGAQDl7ndpIwZu/Gyz/v1ds2ZNqZ8VQgh07drV5WuzBhEc/R2XJMmWZ9CgQdi9ezfS0tKwYcMG1K9fH9OnT8fChQttZVzJU5r69evj2rVrJdLr1q2LkJAQnDlzpsRzp0+fhiRJaNOmjcvXW15Hjx7F66+/jq5du+L06dN4++23XSp3s/awfsY5+8wtztX3SVnfj6X1j8LCwhAQEICCggK795r1fXb27FnbNVhvShWXlJR000Vyy3IeZ3V19NzN3t8qlcousOHs2LIsIykpydZHptsDAyF02+jfvz+2bNlS4q7CTz/9BJVKhX79+pXpeMOHD8fWrVtL/XAurmPHjujWrRsWLVqEzz77DF5eXqWu6u2Ksl6DRqNBhw4d8Oqrr2LKlCnYs2dPiSkZruQprkePHgCUu16OODvmrb4O1hE+rujWrRvCwsLsdh0piwEDBkAIUWK1/T179uD69esYMGBAiTLR0dGYMmUKFixYAKPRiAMHDpQrT3EjRoyA0WjEunXrynUdpfHx8YEkSS63JaAEWPr164c///wT2dnZds9ZX78bh7/+8ssvdo9jYmJw9uzZEm3XtWtXdO7c2fZ7otfrHU5pOnDgAHr06OHS3SQiooo2ffp0AMCCBQuwcuVKDBo0CPXq1SuRT6fT2T12dee4xo0b4+TJk3ZpKSkpJUYU9u7dGwEBAfj+++/LUn2HevToAb1ej7Vr19qlFxQUYP369ejatWuJKSsBAQEYPHgwVq1aheDgYOzYsaPEcV3JU1zPnj2RkpKC2NjYEs+NGTMG27dvR1pami3NYrHg559/Ru/evW03RMoiPj4ehw8ftvV3nMnIyMC9996LRo0aYcuWLXjxxRfx1ltv4Y8//nD5fI7a46677oJOpyvxOZqSkoI9e/aUOI6r7xOr8r4fAaVfYjAY8NtvvznN179/fxgMhhJTWFzdxcjV85RHz5494eXlVeL9bTQasWHDBnTv3h0+Pj4uHevEiRPIzc1Fr1693F5P8qBKXI+EqNwc7RpT3NGjR+12u0hLSxOffvqp0Gq14umnn7blK8+uMTt27BBZWVkiJibGtmtMcUuXLhUABIASi445Uto5XbmGjIwM0a9fP7F27VoRFxcn8vPzxYEDB0TDhg1ti4a6kseZO++8UwwePNguzdVjuvo6OFos9a233hJeXl7iyJEjLu0aUnzXmJiYGNuuMcOHD7fbNebGxemEUFZS79atm4iIiBAbNmwQBoNB7Ny5UzRq1Eg0adLEtmDoY489Jj744ANx6tQpkZeXJ+Li4sTkyZOFXq+3Lf7qSh5nxo8fL4KDg8VXX30lrl69KrKyssSRI0fEa6+9Jt566y0hRNEipx999FGJ8s2aNSuxgF7Tpk1Fv379RFpaml26s+McOnRI6PV6MWTIEHHmzBm7XX+ef/55Wz7rYqkTJ04Uy5YtExkZGeLw4cOiffv2om7duiIlJaXEsa2r71vLlSYhIUFIkmRboZ+IqCro2bOnkCRJABA//fST3XPZ2dmiTp06olu3buLcuXMiNTVVLFq0SIwfP16o1Wrxwgsv2PKWtljqzz//LACId999V2RkZIgTJ06IMWPGiLvvvrvUXWNUKpX4xz/+Ic6cOSNyc3PFuXPnxJIlS8Tw4cOdXkNp537rrbdsu2okJyeLixcvinvvvVdotVqxfft2IYQQ3333nXjyySfF3r17RUZGhsjMzBRff/21ACA+++wzl/M4Yt2d58YFw4UQ4sqVKyI0NFTcc889Ij4+XqSlpYknn3xS6HQ6sX//fru8r776qgAgdu7cKYQQwmw2i759+4qff/5ZxMfHi6ysLLFlyxbRrl074evr69LCrqNGjRJ+fn62xb5NJpPo1auXCA8PF/Hx8Q7Ludoer732mtBoNOKTTz4RaWlp4vTp02L48OGl7hrj6vukLO/Hbt26iT59+pSov8ViEcOHDxfh4eHiu+++E9euXRMGg0EcOnRIzJw5U7z//vtCCCFyc3NFixYtROPGjcWuXbuEwWAQP//8s5g4caLLu8a4ch5rn/Grr74qcQzrYqnXrl0r8dzrr78uVCqVmDdvnkhOTrbbFWnXrl22fJ06dRIDBgxwWM+PPvpIaDSaUs9B1RcDIVQtuBIIEUKII0eOiBEjRojAwEDh5eUlWrZsKf7zn//YraLuaiBECCHi4uLE1KlTRZ06dYROpxMtW7YU8+bNE/n5+Xb58vPzRVhYmAAgNm3a5NI1OTqnK9ewdetWMW7cOBEVFSW8vb1FkyZNxIsvvmj3hdeVPI58++23Qq1Wl/iD7+oxXbkGR4GQzMxMMWbMGBEYGCgACLVafdP6btu2TQwaNEgEBgYKf39/0bNnT7F+/Xrb844CIUIIYTAYxHPPPSfq1atn21pv2rRpdjuWxMbGipdeekm0bNlS6PV6Ubt2bTFmzBhx4MCBMuVxxmKxiEWLFokuXboIX19f4e/vLzp27CjmzJlj24q2rIGQbdu2ifbt2wsvLy8BQDz00EM3PY4QSjBk2LBhttevVatW4tNPP7V7/ayBkPj4ePHkk0+KkJAQ4evrK0aMGOFwNf3c3FwREhLicHtm63F9fX1FRkaG8wYjIqpE3333nW0b1oKCghLPHz16VPTr10/4+fmJ8PBw8eSTT4qcnByXAiFCKH/7oqKihE6nEz169BBHjhxxuBvIzp07xYgRI0RoaKjQ6XSiadOmYtq0aU53vHB27sWLF4v27dsLnU4n/P39xd133223y1pubq744osvxF133SUCAwNFUFCQ6Natm13gwpU8zgwZMkT079+/1OdOnz4tRowYIQICAoSPj4/o3bu33ZdYqxsDIUIIsWvXLjF+/HgRHR0ttFqtqFu3rpgyZYqIiYm5aZ2sO56tWrXKLv3q1asiMjJS9OjRQ5hMplLLutoesiyL9957T9SvX1/odDrRuXNnsXPnTvHoo4+WCIQI4fr7xNX3o6NAiBBKIOnjjz8WHTt2FD4+PiIwMFB07txZvP/++3af0deuXRMTJkwQAQEBIiAgQEycOFFkZGS4FAhx9TzlDYQIoWy13K5dO9v7e9CgQWLfvn12eW4WCOnUqZMYN27cTa+FqhdJCBcmLxKRU0II1K9fH5Ik4dKlS9V+SH9BQQFatGiBSZMm4a233vJ0dagKmj9/Pv75z38iOTnZ5XVfZFlGdHQ0dDodLly4UGKtE7PZjBYtWmDs2LGYN29eRVSbiIiqoJ07d6Jv3744duwYWrdu7enqeNy0adOwbt06ty4wT+Wzf/9+dO/eHX/99Rc6derk6eqQG1Xvb2tEVcSePXsQFxeHRx99tNoHQQBlcbh58+bh448/LtMK9ETO7Ny5E1evXsW0adNKXfB16dKlyMzMxKuvvuqB2hERkaf06tULY8aMweuvv+7pqhDZ+de//oUHH3yQQZDbEEeEEN0ig8GA++67D/v378f58+fduisKUVVV1hEhmZmZuPfee3H48GFcuHCBW9ARERE5wBEhRBWv+t+6JvKgyZMnIzg4GFeuXMHq1asZBCEqxYQJExASEoKEhASsXr2aQRAiIiIi8iiOCCEiIiIiIiKiGsPjI0J27dqFyZMno3Pnzjh06FCFlSEiIiIiIiIi8mgg5JVXXsHMmTPRoUMHHDp0CFlZWRVShoiIiIiIiIgI8PDUmKysLPj7+yM+Ph7R0dHYunUr+vbt6/YyN5JlGVevXoW/v3+pOxcQERFR2QghkJWVhTp16twWu2dVNPZFiIiI3KssfRFNJdWpVP7+/pVS5kZXr15FdHT0LR+HiIiI7MXFxSEqKsrT1ajy2BchIiKqGK70RTwaCKksRqMRRqPR9tg6CObKlSsICAhwyzlkWUZKSgrCwsJ4J6wUbB/H2DbOsX2cY/s4xrZxzt3tYzAYUL9+fbfcsKgJrO0UFxfn1r5IcnIywsPD+Z4vBdvHMbaNc2wf59g+jrFtnHN3+xgMBkRHR7vUF6kRgZC5c+di9uzZJdKNRiPy8/Pdcg5ZlmGxWJCfn883eSnYPo6xbZxj+zjH9nGMbeOcu9vHesOB0zxcY22ngIAAtwZC8vPzERAQwPd8Kdg+jrFtnGP7OMf2cYxt41xFtY8rfZEaEQiZNWsWnn/+edtja6QoPDzcrZ0PSZIY7XOA7eMY28Y5to9zbB/H2DbOubt99Hq9G2pFREREVPFqRCBEp9NBp9OVSFepVG6PPLn7mLcTto9jbBvn2D7OsX0cY9s45872YRsTERFRdVHley3vvPMOJkyY4OlqEBEREREREdFtwKMjQtavX48333wTJpMJAPD444/D398fjz32GB577DEAwOXLl3HixIkylSEiIs+zWCy2v9WeIMsyTCYT1whxoKzto9VqoVarK6FmRERE7sG+SNXmyb6IRwMh3bt3x+eff14ivU6dOraf//WvfyE7O7tMZYiIyHOEELh+/ToyMjI8Xg9ZlpGVlcUFPEtRnvYJCgpCrVq12J5ERFSlsS9SPXiyL+LRQEhoaChCQ0Od5qlfv36ZyxARkedYOx4RERHw8fHx2Ae/EAJmsxkajYadj1KUpX2EEMjNzUVSUhIAoHbt2pVRRSIionJhX6R68GRfpEYslkpERJXDYrHYOh6eDlqz8+FcWdvH29sbAJCUlISIiAhOkyEioiqJfZHqw5N9EU5UIiIit7HOw/Xx8fFwTagiWF9XT863JiIicoZ9kdubu/oiDIS4gSwL7DibjJ0XM2CyyJ6uDhGRx/Gux+2pur6uOTk5iI+Ph8VicXuZlJQUZGVl3WoVb5ksC2wv7IsUmNkXISKqrp9Z5Jy7XlcGQtxAAHj424P4588XkG00e7o6RETkYUajETExMWX64k3uZ7FYMGPGDISEhKBt27aoVasWVq1a5ZYy27dvR9u2bdG4cWM0bdoUkydPhsFgqKhLcckj7IsQEVEh9kWcYyDEDdQqCWqVEpky8S4MEVG1k5+fj5iYGMiye/6Gnz59Gi1atEB6erpbjkfl895772H16tU4evQo0tLS8O6772Ly5Mk4ceLELZU5cuQIBg8ejAkTJiA1NRXXrl3DiBEjcOHChcq4rFKpVBKsN8kssvBYPYiIqHzYF6lcDIS4iVZdGAixsPNBRFTdnDhxAi1atHDbHX29Xo9mzZpBo+Ga5J60aNEiTJs2DS1atAAAPPbYY2jUqBG+/PLLWyrz2muvoUuXLnjllVdsr/H999+PDh06VODV3JzWelOG03SJiKod9kUqFwMhbqJVK01ZwM4HEVG1YjKZcOXKFQDAuXPnEBMTg6tXryIvLw8xMTG27drOnz+P3NxcWCwWxMTEICYmBhcuXCh1sa6GDRti3bp18Pf3BwC7Y1ksFsTHx8Ns5vSFipSYmIi4uDh0797dLr1Hjx44ePBgucuYTCZs3rwZY8eOhcViQUJCQpVZPFZT2BfhiBAiouqFfZHKx/CQm3gVdj54F4aIqHpJSkrCCy+8AACYNGkSVCoVhg0bhjFjxqBXr1545ZVXsHDhQkRGRmLZsmVo1KgRRo8eDQAoKCjA1atX8dBDD+HTTz+FVqsFoAxH7dChA5KTkxEWFoZDhw6hV69eeO2117Bo0SJ4eXkhOzsb3377LcaOHeupS7+tpaSkAECJrRPDwsKwe/fucpdJSUmB0WjEtWvX0LBhQ5jNZqSmpuL+++/HZ599Bj8/v1KPbTQaYTQabY+td/xkWXbbMGjrNN0Cs8Vtx7ydyLIMIQTbphRsG+fYPs5Vtfax1sf6z9OsdXBWl8TExBJ9kXvuuQdjxoxB7969MWvWLHz22WeIjIzE0qVLS+2LPPjgg3Z9kVOnTqFjx45ISkpCWFgYDh48iN69e+PVV1/F559/buuLfPPNNx7ti7jSPjfmt77fbnzPleU9yECImxRNjakafwCIiKoKIQTyTJW/UJde49qgx7p16+LHH39Ely5dcODAAQQFBQEAdu3aBUAZqnrt2jXb3vUAEBMTY/s5Pj4eAwYMwKJFi/D00087Pde5c+cQHx8PvV6Pd955B9OnT8eIESNsnRZyH5Wq8AbFDXfJCgoKoFary13Gulr9smXLsHPnTjRp0gSXLl2ydVQXLFhQ6rHnzp2L2bNnl0hPTk5Gfn5+Ga7MMetVJSanwB95bjnm7USWZWRmZkIIYXutScG2cY7t41xVax+TyQRZlmE2m20jHjzZF7F+OXe220lkZCRWrVqF7t27Y/fu3ba+iDUI//fffyM2NtauL/L333/bfo6Pj8fgwYOxcOFCPPXUUwBgu3ZrO1gXTT179iwuXboEvV6POXPm4LHHHsPQoUM90hexjk4BXN8Nxmw2Q5ZlpKamlqhzWXZxYyDETbS2ESGejzoSEVUleSYLWr6+qdLPe3L2IHi5oT/2zjvv2HU8rEwmk23Y6t13340//vjjpoGQd999F3q9HgAwefJk/Otf/0JsbCwaN2586xUlO1FRUQCA69ev26Vfv37d9lx5yoSHh0Ov12PChAlo0qQJAGX48eTJk/HTTz85rM+sWbPw/PPP2x4bDAZER0cjPDwcAQEBZby60mkLg3+BQcGIiAhyyzFvJ7IsQ5IkhIeHV4kva1UJ28Y5to9zVa198vPzkZWVBY1GY1sfI7fAjHZvb6n0upycPQhateRSkMEacC9eb2vau+++a5viUpy1L5Kfn4+7774bW7ZswbPPPms7TvHjWY81Z84c2+jFBx98EG+++SauXr3q0b5IWYIwGo0GKpUKoaGhtj6V1Y2PnR7H5ZzklG2NEO4aQ0R0W2nUqJHd44KCAjzxxBP473//i9DQUAQEBCAtLc3hl+vi6tata/vZ2gkpy90Lcp2/vz86deqETZs2YcKECQCU1+7PP/+0C0hYR2RER0e7VEatVqNPnz4lVuFPS0tzGtDQ6XTQ6XQl0lUqldu+ONjWCBFSlfgyUhVJkuTWNr+dsG2cY/s4V5XaR6VSQZIk2z/A9dEGFcHVOhTPd2OZxo0b25V31he5seyNbVE8jzW4kp2d7ZE2EkKU+TWyXktp77eyvP8YCHET610YTo0hIrLnrVXj1FuDK/28eo3KNtzyVtw4jWLBggXYvn07zp8/j+joaADAG2+8gf/973+3fC5yrzfeeANjx45F+/bt0b17d3z44Yfw8vLCE088Ycsza9Ys7Nu3z7Y9ritl3njjDQwcOBDdunVDjx49sH//fnz33XdYtGhRpV9jcdZpuuYqMk+fiKiqYF+EbsRAiJtw+1wiotJJkgQfr8r/uCnLAmnWoZSu7P5x+vRpdO/e3dbxAIAtWyp/uC3d3IgRI/DDDz/gk08+wZdffok2bdpgx44ddouhRkREoF69emUq0717d2zcuBHz5s3DwoULUa9ePaxYscLjC9+qC++EmdkXISKyw74I3YiBEDfhrjFERNVX/fr1odfrsXz5cgwZMgSBgYEO83bv3h0vvPACfvrpJ0RFReGbb77B3r170bp160qsMblq9OjRtpX1SzNnzpwylwGA3r17o3fv3rdYO/fSqqwjQhgIISKqbtgXqVwMhLiJloEQIqJqy9/fH8uWLcNnn32Gr776CkOHDsWkSZPQrFmzEvNNp06ditTUVMyfPx8mkwm9evXCe++9h507d9ry6PV6NGvWzLZQmY+PT4ljaTQaNGvWrEwLexE5oykcnWrh1BgiomqHfZHKJYmqsLlyJTMYDAgMDERmZqbbVmqf/PU+7Dqfig/Ht8XYjtE3L1DDyLKMpKQkREREVIlFlKoSto1zbB/nqlr75Ofn49KlS2jYsKHHP1SFEDCbzdBoNB5dJK2qKk/7OHt9K+Kz9Xbm9vaymHHw34ORl58P87jv0K9dk1s/5m2mqv29rErYNs6xfZyrau3Dvkj14cm+CEeEuAm3zyUiIiKPUanR2XQQUANbTPmerg0REVGV5vmQ3W3CFgjh9rlERERU2SQJZii7Cshmo4crQ0REVLUxEOImXCyViIiIPMkiKQN9ZfPNdxwgIiKqyRgIcROthtvnEhERkeeYwUAIERGRKxgIcRPr1JgCjgghIiIiD5ALR4QIC6fGEBEROcNAiJtw+1wiIiLyJE6NISIicg13jXEHWUb3tHXQqJMhm7h1LhEREVU+i21ECAMhREREznBEiJsMj5uP2drvIBVke7oqREREVAMVBUIKPFwTIiKiqo2BEHdQqSAXblknuGUdEREReYBtjRBOjSEiInKKgRA3saiUzofFzLswREQ10alTp9CgQQOkp6eX+rg0V65cQYMGDXD9+nW3nptqJlmlVX7g1BgiohqJfRHXMRDiJrKkdD54F4aIqGYqKCjAlStXYLFYSn1cGpPJhCtXrsBsNrt8nr///hsNGjSAwWBweG6qmWROjSEiqtHYF3EdAyFuYr0Lw84HEREBQMuWLXHp0iWEhIS49bhGoxFXrlyBLBftUlZR56LqpSgQ4npnloiIbl/sizjGQIib2AIhnBpDRFStyLKMzp07Y8WKFXbp8fHxaNiwIY4ePYrk5GQ0aNAADRo0wB133IFBgwZh7dq1To97/vx59O3bF5mZmba0v//+G8OGDUOrVq1w77334u+//7Yrc7PzxMfHY+TIkQCAtm3bokGDBvjHP/5R6rnOnz+PSZMmoXnz5ujatSvmz59v12E5ePAg7rjjDmzfvh2jRo1C69atMXbsWJw/f77sjUhVgm1qjMy+CBFRdcK+SOX3Rbh9rptwXi4RkQNCAKbcyj+vxtulbCqVCl27dsWSJUswceJEW/rKlSshhEC7du0gyzK2bdsGQBn6uWfPHkyZMgU//fQTBg8eXOpxbxwimpGRgf79+2PEiBF45513cPr0aTz66KN2ZUJCQpyep1atWvjiiy8wcuRIrF+/HgEBAfD19UVCQoLduQwGA3r16oW+ffviv//9L2JjY/HEE08gPT0d7777LgAgPz8fV65cwdNPP40PPvgAkZGReO211zB27FgcO3YMkiS53NRUNYjC9crAESFERPbYFwHAvkhxDIS4ieDUGCKi0plygTl1Kv+8sxIAlc6lrJMmTULv3r1x9epV1Kmj1PW///0vJk2aBEmSoFar0aBBA1v+pk2b4uTJk1iyZInDzseNvvjiC/j5+eGrr76CWq1Ghw4dkJCQgJdeesmW52bn0Wg0qF27NgCgXr16CAoKAgAkJCTYnevzzz+HWq3G0qVLodVq0alTJ2RnZ+Oxxx7DzJkzERAQYFev7t27AwDmzJmDNm3a4Nq1a7Z2oOqjaEQIb8oQEdlhXwQA+yLFcWqMmwjbiBAGQoiIqpsePXqgfv36WLVqFQDg5MmTOHbsGCZPnmzLs3r1agwZMgQtWrRAgwYNsHjxYly+fNnlcxw9ehR33XUX1Gq1La13794l8t3qeYqfS6vV2tL69++P/Px8nDlzxi5vmzZtbD/XqlULgDIslqof64gQiX0RIqJqh30RRWX1RTgixE2EmoEQIqJSaX2AV65W/nk13kAZVi6fOHEili9fjueffx7Lly9Hx44d0aJFCwDAmjVr8Oijj+Ljjz9Gly5dEBAQgIULF+KPP/5w+fhGoxGBgYF2aXq93u6xO84DKENNfX197dJ0Op3tueKKd4ashBBlOh9VDUKy9kU4NYaIyA77IgDYFymOgRB3UbHzQURUKkkCvHxvns/dyvgBOnnyZLz77rs4deoUVq5ciWeeecb23G+//YaRI0fazaONj48v0/HvuOMObNmyxS7t+PHjdo9dOY+1s+Csg9C0aVNs3LjRLu3YsWO2etDtyXZThlNjiIjssS8CgH2R4jg1xk2E2gsAIHGldiKiaql58+bo2LEjZsyYgfj4eDzwwAO25+rWrYuDBw8iLS0NALBu3Tr88MMPZTr+tGnTcOTIEXzzzTcAlLm077zzjl0eV85jnS977tw5h+d67LHHEBMTg88++wxCCKSmpmLWrFkYN26cbcgp3X6s03RVDIQQEVVL7ItUHgZC3EXNXWOIiKq7yZMnY9u2bRgwYIDdh/Szzz6LunXrok6dOggODrZ9kJfFHXfcga+//hrPPfccgoKC0L59e9x77712eVw5T2RkJGbMmIHevXujfv36+Mc//lHiXI0aNcKKFSswZ84cBAUFoXbt2oiIiMCiRYvKVGeqZqy7xsgcnUpEVF2xL1I5JFEDJwIbDAYEBgYiMzPTbrXaW5H+1SgEJ2zDv3VP4+VZb7vlmLcTWZaRlJSEiIgIqFSMvxXHtnGO7eNcVWuf/Px8XLp0CQ0bNiwx57SyCSFgNpuh0Whc3n7NaDTi2rVrCAoKsq2CXlxmZiZMJhPCwsJgMBiQnZ1tuytSUFCAq1evol69elCpVCUeWxUUFCAjIwMREREwm82Ij49HdHS03fxYZ+exys/PR1JSEry9vREYGFjquYQQSExMhK+vL/z9/UuUj4uLQ+PGjW1lZFlGbGws6tSpAy8vrxLX7+z1rYjP1ttZRbRXzOLpaB63GuuDp2D4M5+65Zi3k6r297IqYds4x/Zxrqq1D/si7Iu48tnKNULcRFJzOCoRUXWn0+nstoy7UfEFxgICAuw+ZL28vOzK3vi4eHpERAQAQKPRlJrH2Xms9Ho96tWrZ3tc2nEkSXI4/NR6rcU7ZiqVyun1UxXHqTFERNUe+yKV0xfxfMjudsE1QoiIiMiTCm/KSIJTY4iIiJxhIMRNpMJACO/CEBERkUfYRoQwEEJEROQMAyFuImmsI0LY+SAiIqLKx2m6RERErmEgxE1UhYEQNTsfRERE5AnWqTG8KUNEROQUAyFuYh0RohIMhBAR1cANyWoEvq5VW1FfhIEQIiJ+Zt2e3PW6MhDiJqrCuzBaWGCR+UtHRDWTVqv8LczNzfVwTagiWF9X6+tMVUzhGiFq3pQhohqMfZHbm7v6Itw+101UWuUujBZmmCwy1Cr1TUoQEd1+1Go1goKCkJSUBADw8fGx2xKtMgkhYDabodFoPFaHqqws7SOEQG5uLpKSkhAUFAS1mp9xVRFHhBARsS9SnXiyL8JAiJtY1wixBkL0WnYSiahmsu4Vb+2AeIoQArIsQ6VSsfNRivK0T1BQkO31papHUivdOjUDIURUw7EvUj14si9SJQIhp0+fxpkzZ9CzZ0+EhYW5VObIkSNITExEq1atEB0dXcE1vDmVRgcA0MAMk4VTY4io5pIkCbVr10ZERARMJs8N0ZdlGampqQgNDYVKxZmgNypr+2i12mo5EiQxMRErVqxAYmIi2rRpg/vvvx8ajfPuz83K/PDDD9i9e7ddmdq1a2PmzJkVcg2usi3czkAIEdVw7ItUD57si3g0ELJ9+3a88cYbuHz5Mq5cuYKtW7eib9++TstkZWVh+PDhOH36NJo1a4ZDhw7hpZdewptvvlkpdXbEOhzVS7LAZJE9WhcioqpArVZ79IuzLMvQarXQ6/XsfJSiJrTPuXPn0KNHD3To0AFdu3bFG2+8gW+++QabNm1y+N50pczmzZuxb98+PPzww7Zyrt7IqUiSmoEQIqLi2Bep2jzZPh4NhCQnJ+ONN97AHXfc4fKojtdeew0JCQk4c+YMgoODsWXLFgwYMAB9+/a9aRClQqmLpsYUmBkIISIi8rSZM2eiefPm2LhxI1QqFaZPn44mTZpgxYoVmDJlyi2VadKkCZ599tlKuhLXqDTKwnFcI4SIiMg5j4alxo0bh379+rmcXwiB5cuX49FHH0VwcDAAoH///ujUqROWLVtWUdV0jW3XGDNHhBAREXmYyWTCr7/+iokTJ9ruMtWrVw99+/bFunXrbrnMhQsX8Morr2DevHnYs2dPRV6Ky6TCvoiGgRAiIiKnqsQaIa6Kj49HWloa2rVrZ5fevn17HDt2zGE5o9EIo9Foe2wwGAAoQ3Fk2T1BCyEpTamFGUaTxW3HvV3IsmxbDIfssW2cY/s4x/ZxjG3jnLvbp6q1c2xsLIxGIxo3bmyX3rhx4xLre5S1jCRJCAkJgV6vx8WLF/Hmm29i2rRpWLBggcP6VEZfxBoIUcNc5V6PqoB/Exxj2zjH9nGO7eMY28Y5T/ZFqlUgJDMzEwBso0GsQkNDkZGR4bDc3LlzMXv27BLpycnJyM/Pd0vddDl5CAbgBTMSU1IRrMpzy3FvF7IsIzMzE0IIzo+7AdvGObaPc2wfx9g2zrm7fbKystxQK/fJzc0FAPj7+9ulBwQE2J4rb5mXX34Z9evXtz2eMGEC+vfvj1GjRmHgwIGlHrsy+iI5ucpx1MLs8Z0SqiL+TXCMbeMc28c5to9jbBvnPNkXqVaBEC8vZR2OGzsw2dnZ0Ol0DsvNmjULzz//vO2xwWBAdHQ0wsPDERAQ4Ja6iURlkTQNLNAHBCIiIvgmJWoWWZYhSRLCw8P5R+AGbBvn2D7OsX0cY9s45+720ev1bqiV+1iDGTfeKElPTy8R6ChrmeJBEADo168foqOjsWvXLoeBkMroi+B6KABldGpERIR7jnkb4d8Ex9g2zrF9nGP7OMa2cc6TfZFqFQipV68e1Go14uLi7NLj4uLQsGFDh+V0Ol2pgRKVSuW2N6RcuH2uVjLDLINv9FJIkuTWNr+dsG2cY/s4x/ZxjG3jnDvbp6q1cb169eDn54eYmBgMGTLElh4TE4OWLVu6rYxVQUGB0y0aK6MvotYqHUANLFXu9agq+DfBMbaNc2wf59g+jrFtnPNUX6TKvxpHjx7Fli1bACgRnn79+uGnn36yPZ+eno7Nmzdj6NChnqqionBerhfMMFmEZ+tCRERUw6lUKtx777349ttvbVNPjh8/jt27d2P8+PG2fN9//z3mzZvnchmz2Yzt27fbnWvFihVITEzEoEGDKuPSHFJrrWuEWCAE+yJERESOeHRESGxsLA4fPozU1FQAwK5du5CRkYHmzZujefPmAIBPP/0U+/btw4kTJwAoc2x79eqF6dOno3v37vjiiy/QuHFjTJ061WPXAcBu+1zuGkNEROR5//73v9GnTx906dIFHTp0wK+//orJkydj1KhRtjx//PEH9u3bh5kzZ7pURpIkzJkzB7NmzUKrVq0QGxuLHTt24O2330afPn08cp1Wao3SF/GCGRZZQKOWPFofIiKiqsqjgZDz58/j22+/BQCMGjUKBw8exMGDBzFhwgRbIKRDhw7w9fW1lencuTMOHjyIL774Aps2bcKIESPw9NNPe35usqpo+9wCBkKIiIg8rlatWjh69Cg2btyIxMREPPbYY+jZs6ddngkTJqBv374ul1Gr1di0aRMOHz6MI0eOYOjQoVi8eDGioqIq67IcUmuVqTcamGGWBTRqD1eIiIioivJoIKR///7o37+/0zwzZswokdaqVSt88sknFVWt8lEXBUI4IoSIiKhq8Pb2xtixYx0+X9ripjcrAwAdO3ZEx44db7l+7qTWWPsiFphlTo0hIiJypMqvEVJtWKfGSBYGQoiIiKjSWafGaGGGmX0RIiIihxgIcZfiI0LMvAtDRERElUutVQIhGo4IISIicoqBEHcptlgq1wghIiKiyiYV9kU0kgyz2eLh2hAREVVdDIS4iy0QwqkxRERE5AGFo1MBwFRg9GBFiIiIqjYGQtxFraw768XFUomIiMgTigVCZLPJgxUhIiKq2hgIcZdiU2NMZgZCiIiIqJKpigIhFnO+BytCRERUtTEQ4i6FgRCVJGDiXRgiIiKqbCqN7UeziX0RIiIiRxgIcRd18bswBR6sCBEREdVIkgQT1AA4NYaIiMgZBkLcpXBECABYChgIISIiospnhjIqxGLiYqlERESOMBDiLnbzctn5ICIiospnDYTIFt6UISIicoSBEHeRJFisw1FN7HwQERFR5TMX9kUsXCOEiIjIIQZC3EguHBUic40QIiIi8gCLZB0RwtGpREREjjAQ4ka2zgenxhAREZEHWKfGCC6WSkRE5BADIW5kHRFiYeeDiIiIPKDopgz7IkRERI4wEOJGsqQEQgQXKCMiIiIPsEjW7XPZFyEiInKEgRA3EoUjQgSnxhAREZEH2KbGWDgihIiIyBEGQtzIGggB78IQERGRB8iSNRDCvggREZEjDIS4kVDxLgwRERF5jsU6TZc3ZYiIiBxiIMSNhJojQoiIiMhzrGuECIvZwzUhIiKquhgIcSPb1BiZgRAiIiKqfJwaQ0REdHMMhLiTdUQI78IQERGRB1inxoDTdImIiBxiIMSdCkeESLwLQ0RERB7A9cqIiIhujoEQN5IKR4RIMjsfREREVPlk2xoh7IsQERE5wkCIO1mnxjAQQkRERB4gSxydSkREdDMMhLiRdUSISjZBCOHh2hAREVFNIxdOjYHM9cqIiIgcYSDEjSS1FwBACzNMFgZCiIiIqHJxjRAiIqKbYyDEjSSNMiJECwsKLLKHa0NEREQ1TuHC7cLMqTFERESOMBDiRipN0YiQAjMDIURERFS5hEYPAJDMeR6uCRERUdXFQIg7Fd6F8ZJMDIQQERFRpbNofAEAGnOuh2tCRERUdTEQ4kaicI0QL44IISIiIg8QWh8AgMac4+GaEBERVV0MhLiTRgcA0KEABRaLhytDRERENY3QKiNCtBYGQoiIiBxhIMSNhNoaCDHByBEhREREVNm8rIEQrhFCRETkCAMhbmQNhHhJnBpDRERUFSxYsACNGzeGn58funfvjr1797q1zCuvvAKNRoMXXnjBndUuP50SCNHJXCOEiIjIEQZC3KlwjRAdChgIISIi8rBvvvkGM2fOxAcffIALFy7grrvuwqBBgxAXF+eWMn/++SfWrFmDRo0awVJFpsSqCkeE6BkIISIicoiBEDcStkCICQUWBkKIiIg86f3338fUqVMxevRoREZGYv78+QgICMCiRYtuuUxSUhKmTp2KZcuWwcfHp6IvxWUqnR8AQC84NYaIiMgRBkLcqPgaIRwRQkRE5Dnp6ek4ffo0+vXrZ0uTJAn9+vXDnj17bqmMEAIPPvggHn/8cXTp0qXiLqIc1HolEOIt8j1cEyIioqpL4+kK3E6EpmiNkGwGQoiIiDzm2rVrAICIiAi79PDwcBw8ePCWyrz//vvIycnByy+/7HJ9jEYjjEaj7bHBYAAAyLIMWXZPn0GWZdvUGG/kQbZYAElyy7FvB7IsQwjhtva+nbBtnGP7OMf2cYxt45y726csx2EgxJ2KrxHCqTFERERVjkqlghCi3GUOHTqE999/H3/99RfUarXLx5g7dy5mz55dIj05ORn5+e4ZvSHLMvJMSj3VEEi8egVCW3Wm7XiaLMvIzMyEEAIqFQdFF8e2cY7t4xzbxzG2jXPubp+srCyX8zIQ4kZ22+eaGAghIiLylFq1agFQAg3FJSUlITIystxl9u7di9TUVDRp0sT2vMViwfHjx/Hpp5/CaDSWGiCZNWsWnn/+edtjg8GA6OhohIeHIyAgoBxXWJIsy8jILYAsJKgkgVB/b6gCIm5esIaQZRmSJCE8PJxfSG7AtnGO7eMc28cxto1z7m4fvV7vcl4GQtzIuliqF8wwckQIERGRx4SEhKBp06bYvn07xo4dC0BZ22Pbtm2YNGlSucvMmDEDTzzxhF25zp07o0+fPvjggw8cjhLR6XTQ6XQl0lUqlVs7x946LXKhgx/yYcrPgndQbbcd+3YgSZLb2/x2wbZxju3jHNvHMbaNc+5sn7Icg6+GG9l2jZG4WCoREZGnvfDCC1i8eDE2bdqEzMxMvPbaa0hLS7MLZDz++ONo3769y2UkSYJGo7H7Vzzd03QaFXKg3BEryDV4uDZERERVk+c/sW8ntqkxBQyEEBERedhjjz2GjIwMPPLII0hKSkLr1q3x66+/okGDBrY8FosFZrO5TGWqMpUkIQfeADJQkOf6XGkiIqKahIEQN+L2uURERFXLSy+9hJdeesnh819++WWJxVNvVuZGhw4dglSFdmfJl5QRIWaOCCEiIioVAyFuZN0+VwczCiwWD9eGiIiIbsYdc5LLsntMZciTfAABmPIYCCEiIioN1whxp+JrhJgYCCEiIqLKZ5S8AQCykVNjiIiISsNAiBtZp8YAgGzK92BNiIiIqKbKV/sAAOT8HA/XhIiIqGpiIMSNrLvGAIBsZiCEiIiIKp9JpYwIEfkcEUJERFQajwdCNmzYgMGDB6N9+/aYMmUKLl686DR/fn4+5s2bh/79+6Njx474v//7PyQlJVVSbW9CpYWAsliaxWT0cGWIiIioJjJpfJUfChgIISIiKo1HAyG//vorRo8ejbvvvhsLFy5EXl4eevXqhfT0dIdlHnjgASxevBgvvPACFi1ahIyMDPTp0wf5+VVgBIYkwaJSRoUITo0hIiIiDzAVTo0RBZwaQ0REVBqPBkLefPNNTJw4ES+++CJ69OiBFStWIC8vD59//nmp+ePi4rBu3Tp8/PHHGDZsGLp164bvvvsOSUlJWLp0aSXXvnTWQAg4IoSIiIg8wKJVRoSoTAyEEBERlcZjgZDs7GwcPHgQQ4YMsaV5eXlh4MCB2Lp1a6llDAZlG7jQ0FBbmlarRUBAADZv3lyxFXaRbF0w1cIRIURERFT5LIVTY1QF2R6uCRERUdWk8dSJ4+PjIYRA7dq17dJr1aqFEydOlFqmadOmiI6OxkcffYTvvvsOOp0Oq1atwuXLl0scpzij0QijsWiEhjWgIssyZFl2w9UoxxJCQFYpgRBhMrrt2LcDW/uwTUpg2zjH9nGO7eMY28Y5d7cP27nqkAtHhKjNuR6uCRERUdXksUCIxWIBoIwCKU6n08FsNpdaRqvVYs2aNZg6dSrCwsLg7++PBg0a4J577kFKSorDc82dOxezZ88ukZ6cnOy2tUVkWUZmZiZ8JDUAwGLMqTqLuFYB1vYRQkCl8vgavVUK28Y5to9zbB/H2DbOubt9srK4MGeV4WUNhHBqDBERUWk8FgixTm+5MYCRkpJiN/XlRp07d8bx48eRmpqKvLw8REVFoU+fPoiOjnZYZtasWXj++edtjw0GA6KjoxEeHo6AgIBbvBKFLMuQJAkqrbJAmRYWREREuOXYtwNr+4SHh/MLyQ3YNs6xfZxj+zjGtnHO3e2j1+vdUCtyB9nLHwCgZSCEiIioVB4LhNSqVQtRUVHYt28fRo4caUvfu3cv7r777puWtwZLEhMTsXfvXnz22WcO8+p0Ouh0uhLpKpXKrZ1jSZIgNMp5VLKRHe8bSJLk9ja/XbBtnGP7OMf2cYxt45w724dtXHVIhSNCtBZOjSEiIiqNR3stjz/+OL7++mucO3cOALBkyRKcP38e06dPt+X517/+ZRcoWbZsGS5cuAAAyMjIwCOPPILmzZtjypQplVt5RzTKHTHJUuDhihAREVFNpNL5AQC8GAghIiIqldtGhFy+fBkRERHw8fFxuczLL7+M2NhYtG7dGoGBgTCbzfj222/Rtm1bW55r167h4sWLtsctWrTAyJEjkZWVhdTUVAwYMAC///57qSM+PEKtrHkiWbh9LhERkbuUp59RU6n0ytQYnZwLCAFIkodrREREVLWUa0TIoUOH8I9//MP2ePLkyWjYsCFq1aqFPXv2uHwcjUaDL7/8EsnJydi/fz8SExMxefJkuzzvvPMOfvnlF9vjzp074+TJk9i7dy+uXbuGn3/+GbVq1SrPZVQMrTIiRC0zEEJERFQe7upn1FTWQIgaMmB2z6LwREREt5NyBUJefPFF3H///QCAEydO4JdffsG+ffvwz3/+E7NmzSrz8QICAtCwYUNotdoSz9WqVQsNGzYskV63bl23LXTqTlLhGiFqTo0hIiIqF3f3M2oajbdf0YMCLphKRER0o3IFQg4ePIhOnToBAH7//XeMGTMG3bp1w3PPPYejR4+6s37VjqrYYqlERERUduxn3Bq9lxdyReGUYSO3NSYiIrpRuQIhfn5+uHz5MgBg/fr16N+/PwAgMzMTfn5+Tkre/iTb1JgCCCE8XBsiIqLqh/2MW+OtVSEHhdsZF2R7tjJERERVULkWSx03bhyGDRuG1q1b4+jRoxgxYgQAYNOmTRg6dKhbK1jdqLy8AQBeMMEsC2jVXKCMiIioLNjPuDU6jRrZQo9wKZNTY4iIiEpRrkDIhx9+iCZNmuDKlSuYPXs2goODAQAxMTF444033FrB6kZdOCJEBxOMZhlatUd3KCYiIqp22M+4Nd5eauRaR4QYOSKEiIjoRuUKhGi1WjzzzDN2aZcvX8abb75Z47e1U2uVObleMKHALANVZFdfIiKi6oL9jFuj16iQAWWEKgq4RggREdGNPLp97m3JbkSIxcOVISIiqn7Yz7g1PjoNcoTSHxFcLJWIiKiEKrF97m1FUxgIkUwwmmQPV4aIiKj6YT/j1gToNbapMaY8To0hIiK6Ubmmxjja1q5Vq1aYP3++WytY7WiKpsYYzQyEEBERlRX7GbfGT6dBTuHUGGNOJrw8XB8iIqKqhtvnuptaCYTorGuEEBERUZmwn3FrJEmCSa2spVKQa/BwbYiIiKoebp/rbpqiQAjXCCEiIio79jNunaz1AUyAOY9rhBAREd2I2+e6W/E1QjgihIiIqMzYz7h1stYPMAGWfAZCiIiIbuS27XMB4L333rvlClV7xUaE5HBECBERUZmxn+EGOj8gFxBGLpZKRER0o3IFQqzOnz+P06dPQwiBli1bokmTJu6qV/XFNUKIiIjcgv2M8pN0hWupFDAQQkREdKNyBUIyMzMxdepUrFmzBiqVst6qLMsYO3YslixZgsDAQLdWslrhrjFERES3hP2MW6fW+wMAJFOOh2tCRERU9ZRr15hnn30WFy5cwM6dO5Gfn4/8/Hzs3LkT58+fx3PPPefuOlYvxdcIMTEQQkREVFbsZ9w6jXeA8r+JI0KIiIhuVK4RIf/73/+we/dutGjRwpbWs2dPrFq1Cj179nRb5aoljRcA7hpDRERUXuxn3DovHyUQojVnA7s+Aur3AKK7erhWREREVUO5AiF5eXkICwsrkR4aGorc3NxbrlS1Zh0RggJOjSEiIioHd/YzCgoKsHnzZiQmJqJNmzbo1KmTW8qkpaVh9+7dyM7ORqtWrdC2bdsy1aui6QsDIcHmZODPN5XENzM9VyEiIqIqpFxTY7p3747XXnsNBQUFtjSj0YhXX30V3bt3d1vlqiUvXwCAD4wwmjgihIiIqKzc1c9ITk5Gp06d8Oyzz2LDhg0YOHAgnnjiiVsu85///AddunTBt99+i3Xr1qF3794YO3YsTCZT2S60Ann7cR0VIiIiR8o1IuSjjz7C4MGDsW7dOrRr1w4AcPToUahUKmzatMmtFax2dIVzciUZcgEXKCMiIiord/UzZs2aBQA4cuQIfHx8cOjQIXTp0gUjRozAsGHDyl2mRYsWOH36NLy8lOmw586dQ9OmTfHLL79g7Nix5b5ud/L2D/J0FYiIiKqsco0IadeuHc6dO4d//etfaNy4MZo0aYLXX38d586ds3VYaiytD2SolZ+NHIJKRERUVu7oZ8iyjNWrV+ORRx6Bj48PAKBTp0646667sGrVqlsqM2jQIFsQBAAiIiKgVqthsVSdkaB+/hwRQkRE5Ei5RoQAgL+/P5566il31uX2IEkwanzhbTZAZczydG2IiIiqpVvtZ8TFxSErKwstW7a0S2/ZsiUOHjx4y2Xi4uKwYcMGGAwG/PDDD5g0aRLGjBnjsD5GoxFGo9H22GAwAFCCL7LsnjXFZFmGEAKyLMPfW4d8oYVeKpquI1ssgCS55VzVUfH2IXtsG+fYPs6xfRxj2zjn7vYpy3FcDoTExMS4fNDmzZu7nPd2VKD2VwIhBQyEEBERucLd/QxroCEoKMguPTg42PbcrZTJysrC0aNHkZKSgoSEBPTp08dpfebOnYvZs2eXSE9OTkZ+fr7Tsq6SZRmZmZkQQqCgQIYK9h3CpOsJgNrLQenbX/H2UanKNSj6tsW2cY7t4xzbxzG2jXPubp+sLNe/f7scCCm+hd3NCCFczns7Mml9ASOgZiCEiIjIJe7uZ3h7ewMo2SkyGAy2aS+3UqZly5b4/PPPAQCXL19Gu3bt0KBBA4ejWGbNmoXnn3/e7pjR0dEIDw9HQEDATa/HFbIsQ5IkhIeHA5Cgkeyn6kQE+QLewW45V3VUvH34hcQe28Y5to9zbB/H2DbOubt99Hq9y3ldDoTExcWVqzI1kVnjDwDQmLI9XBMiIqLqwd39jPr168PLywuXLl2yS7906RKaNGnitjIA0KBBA3To0AH79+93GAjR6XTQ6XQl0lUqlVs7x5IkOTymypwP1PCOuLP2qenYNs6xfZxj+zjGtnHOne1TlmO4HAiJiooqV2VqIrOXHwBAY+KIECIiIle4u5+h1WoxZMgQrFq1CtOnT4ckSbh69Sq2bt2KL774wpZv+/btSExMxPjx410qYzabcfXqVdSrV892jPT0dJw8eRJ9+/Z16zW4nSnX0zUgIiKqEsq9WCo5ZtEqQ1y9zBwRQkRE5Cnz5s3DXXfdhVGjRuHOO+/E0qVL0a1bN0yePNmWZ9myZdi3bx/Gjx/vUhmLxYJhw4ahW7duaNmyJTIyMrBixQpERUXhmWee8ch1uqwgx9M1ICIiqhI4PqcCyDplaoyXmSNCiIiIPKV58+Y4fvw47rzzTiQmJuLFF1/En3/+CY2m6D5Q3759cf/997tcRqfT4dChQ+jfvz+uXbsGlUqFDz74AIcOHUJwcNVaf+PfYXPwm6ULCgpv0MCU59kKERERVREcEVIBZC+lw6Gz8M4LERGRJ0VFReGVV15x+Hzx0SGulvHy8sLEiRMxceJEt9SxoiRH9MQT8Q3wV+BshJsMgIn9EiIiIoAjQipG4YgQnYVTY4iIiMgz6oUoO93kyFoloYBrhBAREQEMhFQMfSAAwFvmnRciIiLyjHqhynbABouXksCpMURERAAYCKkQKm9lagwDIUREROQp9UJ8AQDppsIRIZwaQ0REBICBkAohFY4I8RHscBAREZFnWKfGpJsKl4Tj1BgiIiIADIRUCI23EgjxFexwEBERkWeE+XnBx0uNXMGpMURERMUxEFIB1D5BABgIISIiIs+RJAn1QnyQB72SwKkxREREABgIqRBaH2WNED/kAkJ4uDZERERUU0WH+CAXOuUBp8YQEREBYCCkQmgKR4R4SRaYjex0EBERkWfUD/FBnm1qDPskREREAAMhFULnEwBZSACAgpwMz1aGiIiIaqx6oT7Is44IYSCEiIgIAAMhFcJLq0E2vAEABbmZHq4NERER1VTK1JjCNUI4NYaIiAgAAyEVQq2SkAVlyzpzbrqHa0NEREQ1VVSQN6fGEBER3YCBkAqSXRgIsXBECBEREXlInSBv29QYs5G7xhAREQEMhFSYXKkwEJLHQAgRERF5hq9OA5XOFwBgzs/2cG2IiIiqBgZCKkiuSul0yHkGD9eEiIiIajJ/vwAAgMw1QoiIiAAwEFJhciQ/AIDI4xohRERE5Dn+AYHKD1wjhIiICAADIRUmV+0PAJDyMzxbESIiIqrRggODAABqBkKIiIgAMBBSYXLVyjBUBkKIiIjIk0KCgwAAGjkfEMKzlSEiIqoCGAipIPkaZUSIKp+LpRIREZHnRIQGAwDUkAFLgYdrQ0RE5HkaT1fAYrFgz549SExMRJs2bdCsWbOblsnJycH+/fuRnp6OevXqoUuXLpVQ07IxFgZC1AUMhBAREZHnRISGFD0oyAE0Os9VhoiIqArwaCAkPT0dgwcPxvXr19GqVSvs2rULjz/+OObPn++wzJYtW3DfffehQYMGaNCgAfbu3Ys6derg999/R0hIiMNyla1AqyxMpjYyEEJERESeUzfEH0ahgU4yw2TMgdan6vSXiIiIPMGjU2NeffVVGAwGnDx5Ehs3bsSmTZvw4Ycf4o8//nBY5sUXX8SgQYNw6NAh/PTTTzh9+jRiY2Px6aefVmLNb07ogwAAGo4IISIiIg8K9fVCPpRRIClp3M2OiIjIY4EQIQRWrlyJRx99FP7+yjSSu+66C127dsV///tfh+VMJhOio6NtjwMDAxEUFASz2VzhdS4LjY8yH9fLxEAIEREReY5KJaFApQfAQAgRERHgwakxcXFxyMjIQOvWre3S27Rpg8OHDzss95///AfTp0+HTqdD/fr18ccffyAyMhJPP/20wzJGoxFGo9H22GAwAABkWYYsy7d4JbAdSwhhO57GTxl2qjNnQ7aYAalmr0t7Y/tQEbaNc2wf59g+jrFtnHN3+7CdqzaTSg9YgJyswkCIEIAkebZSREREHuKxQEhmpjJSIjg42C49JCTE9lxp6tati3r16uGXX35Bo0aNcPjwYYwYMQJ+fn4Oy8ydOxezZ88ukZ6cnIz8/PxyXoE9WZaRmZkJIQRUKhXMkhYAoIKMxPhLEDp/t5ynurqxfagI28Y5to9zbB/H2DbOubt9srKy3FArqigpumjUyU2AOukksGIVkBkPPLYVUGs9XTUiIqJK57FAiLe3NwAgOzvbLj0rK8v23I1kWcY999yDgQMH4osvvrDlb9++Pby8vPDBBx+UWm7WrFl4/vnnbY8NBgOio6MRHh6OgIAAd1wOZFmGJEkIDw+HSqVCrUgT8oQXvKUChPtpgOAIt5ynurqxfagI28Y5to9zbB/H2DbOubt99Hq9G2pFFeVaQFu0zd2HenE/AzkxSmL6ZSDsDo/Wi4iIyBM8FgiJjo6GVqvFlStX7NKvXLmCRo0alVomISEBFy9exNixY21p/v7+GDRoELZv3+7wXDqdDjpdya3iVCqVWzvHkiTZjhns64VM+MIbBVAZMwF2wu3ah+yxbZxj+zjH9nGMbeOcO9uHbVy1ZYR2AK4DkdYgCACYcj1XISIiIg/yWK9Fp9NhwIABWL16tS0tOTkZW7ZswbBhw2xp+/btw/r16wEAkZGR0Gq1OHnypN2xTp48abeAalUQ5KNFpvBVHuRneLQuREREVLOZItvDLG7o9hmzS89MRER0m/PYiBAAmDdvHnr06IEHHngA3bt3x5IlS9C6dWs8/PDDtjxff/019u3bh+HDh8PLywuvvvoqXnvtNSQlJaFRo0b4/fffceDAAezYscNzF1KKQG8vpKEwEJKX4dG6EBERUc0WEBiE06Ie2kiXixILGAghIqKayaPjWNu2bYujR4+iYcOGOHbsGB5++GFs374dXl5etjzdu3fHiBEjbI/feOMNbNiwAQDw119/oX379jh79iy6du1a6fV3JtC7aESInMut6oiIiMhzQn29cEhuap9o5AK3RERUM3l0RAgANG7cGHPmzHH4/KOPPloirV+/fujXr19FVuuWBXprkQllJxtjdipKX/6ViIiIqOKF+nnhE0s3PKj5AyoIJZEjQoiIqIbiymYVxEujQq5KCYQUZKV5uDZERERUk4X4emG/aIGOxi8gtx6nJHJECBER1VAMhFSgAq2yNa8ph1NjiIiIyHNCfJRpxxnCDwXqwjXMuFgqERHVUAyEVCCTNhAAIOdyRAgREZEn/Pbbbxg2bBg6d+6MRx55BJcvX77lMgkJCZg1axb69OmDAQMG4I033kBmZmbFXICbaNQqBPloAQC5UuGEXU6NISKiGoqBkApk0QUBACRun0tERFTpfvvtN4wYMQK9evXCBx98gIyMDPTs2RMZGRnlLmOxWNC7d28EBQXh7bffxj//+U/88ssvuPvuu1FQUFA5F1ZOob7KqJBsURgI4dQYIiKqoTy+WOptzTsQyABUDIQQERFVujfeeAMTJkzAyy+/DAC48847UatWLXz++ee2tLKWUavVOHXqFHQ6na1MvXr10KpVKxw4cAA9e/as+Asrp1BfHS4k5yBLFNadI0KIiKiG4oiQCmTxqw0A8M5P9HBNiIiIapbs7Gz89ddfuOeee2xpOp0OAwcOxNatW2+pTPEgCABoNMp9JVmW3XkJbhfqp4wIybQU1p9rhBARUQ3FESEVyBIQBQDwMaUDBTmAl6+Ha0RERFQzJCQkQAiB2rVr26XXrl0bJ0+edFsZAHjzzTcRHR2Nrl27OsxjNBphNBptjw0GAwAleOKuAIosyxBCODxecOEaIakmJSAijFkQVTx44043a5+ajG3jHNvHObaPY2wb59zdPmU5DgMhFcjbPxQG4YMAKRfIiAMimnu6SkRERDWC2WwGAHh5edml63Q6mEwmt5WZO3cu1q5diz///BN6vd5hfebOnYvZs2eXSE9OTkZ+fr7jCykDWZaRmZkJIQRUqpKDfr0l5fqu5UgAAHNuBlKTktxy7urgZu1Tk7FtnGP7OMf2cYxt45y72ycry/W1rxgIqUBBPlokiDAESLFAJgMhRERElSU0NBQAkJqaapeempqKsLAwt5T56KOP8NZbb2HdunXo0aOH0/rMmjULzz//vO2xwWBAdHQ0wsPDERAQcPMLcoEsy5AkCeHh4aV2KKMj8gBcQ7pQRqhq5HxERES45dzVwc3apyZj2zjH9nGO7eMY28Y5d7ePsxsSN2IgpAIFeWsRL8LRArFAxhVPV4eIiKjGqFWrFurUqYP9+/djxIgRtvS9e/diwIABt1zmP//5D1555RWsXbsWgwcPvml9dDpdibVFAEClUrm1cyxJksNjRgX7AABis5XnJGMWpBrWMXfWPjUd28Y5to9zbB/H2DbOubN9ynIMvhoVKMjHC/Gi8A5SRqxnK0NERFTDPP744/j6669x8eJFAMDSpUtx9uxZTJs2zZbnjTfewJgxY8pUZsGCBXj55Zexdu1aDBkypJKu5tbVD1UCIRcylakxXCyViIhqKo4IqUDh/jr8aQuExHm2MkRERDXMK6+8gsuXL6N58+YICwtDbm4ulixZgvbt29vyJCQk4Ny5cy6XSU9PxzPPPAN/f3+8+OKLePHFF21l33rrLYwdO7ayLq/MokOUQEiiUQPoAZjzAIsZULM7SERENQs/+SpQuL8O8SIcACCnX+HwGyIiokqk0WiwZMkSfPDBB0hJSUG9evVKTE956623kJub63KZgIAAHD9+vNTz1a1bt2IuxE30WjVqB+qRmlls4deCbMA7yGN1IiIi8gQGQipQgF6DZJWyCJng1BgiIiKPCA4ORnBwcKnP1alTp0xl1Go1Wrdu7db6VaZ6IT64lpkPWdJAJcwMhBARUY3EQQoVSJIk5Pspd4fUucmAKc/DNSIiIqKazLpOiFGt7ByDrET2T4iIqMZhIKSC6f3DkC0Kt/HJjPdsZYiIiKhGqx+qBEDyJG8l4ev+wOJBgGwBfv8XcGajB2tHRERUORgIqWDhAXpcErWUBxe2eLYyREREVKPVK1wwNct6kwYArh8HTqwB9nwCbHrFQzUjIiKqPAyEVLAIfz2+t/RTHuz9VFmdnYiIiMgDrFNjMi32i8Yi5hfl/4w4QJYruVZERESVi4GQChbur8OPlt7IVgcCGbHA6Z89XSUiIiKqoeqHKFNjMsxe9k+c36z8L5uAnORKrhUREVHlYiCkgoX765APHTb7jVQSjn/v2QoRERFRjRXoo0W4vw5G3BAIKcgu+tnANc2IiOj2xkBIBYvwV4ae7hGtlITEUx6sDREREdV03RuFor503XGGzITKqwwREZEHMBBSwcILAyGH8woXTM2MBfINHqwRERER1WQ9moQiUMpxnMHAQAgREd3eGAipYBH+yqrsF3N0EP61lcTkGA/WiIiIiGqyuxqH4TXTVGQLPYwD3i6ZIZNTY4iI6PbGQEgFC/XzgiQBFlnAFNpMSUzi9BgiIiLyjOgQH8QE9UIb49fYEzYe0OjtM3BECBER3eYYCKlgWrUKIT7KgmRZAXcoiUmnPVgjIiIiqul6NA6DgAr7LqUDIY2VROvI1Us7gIXdgIPfeK6CREREFYiBkEoQGaDcabmuK+xocEQIEREReVD76CAAwImrmUCtNkpis6HK/7mpyjTeg0s8UzkiIqIKxkBIJWgY5gsAOCuilATuHENEREQe1KpOIADg5FUDxN2zgTFfAj2fs8+UfAawmD1QOyIioorFQEglaBSuBEKO5EcCkIDcFCAr0bOVIiIiohqraS0/aFQSMnJNSDAHAO3uBwKi7DNZjEDaRc9UkIiIqAIxEFIJrIGQM6kWIKypknj1iAdrRERERDWZTqPGHZH+AJRRIQAAVSndQk7nJSKi2xADIZWgUZgfAOBiSg4Q1VlJTDjowRoRERFRTdeqTgCAYoEQAOj+FOBXC2jQS3nMQAgREd2GGAipBA0LR4QkZxmRH9FOSYxnIISIiIg8xxoIOXU1syhx8LvACzFAs3uUx4knPVAzIiKiisVASCUI0GsR5qcDAMT5tFQSEw4DsuzBWhEREVFNZl0w9USCwf4JSQIiC/srHBFCRES3IQZCKol1nZBTlmhAoweMmUDaBQ/XioiIiGqqlnUCoJKA64Z8JBry7Z+MKAyEpF0C8g0lC7vq6EpgyRAgJ6X8xyAiInIzBkIqSePCQMiFVCNQu72SyOkxRERE5CF+Og2aFi6YeiQ2/YYnI4DgBgAE8PNT5RvFajED654AYvcCB5fccn2JiIjchYGQSmJdMPVsYjYQ3UVJjFnvwRoRERFRTdehXjAA4EhsRsknR38OqLTAqf8BBxeX/eCXdxT9LLHLSUREVQc/lSpJ+3pBAIADl9Mgt5usJMasB5LPeK5SREREVKN1KOyflBoIqd8d6P+q8nN5bt6c+Kno5/xSjk9EROQhDIRUkvbRQfD1UiMtpwAxljpA8+HKE7s+9mi9iIiIqObqWDgi5HhCBkyWUqa/3DFI+T/uL2Wqi6vMRuD0L0WPc1JvoZZ028pJBQ5+c2vr0BARlQMDIZVEq1aha8MQAMDu8ylAz+eVJ46vAuIPebBmREREVFM1CvNFgF6DfJOMmGtZJTOEtwB0gYApB4jbD5z62bWASNIpIL/Ytry5XCyVSrH7Y2D9s8Chbz1cESKqaRgIqUQ9moQBAHZfSAGiOgFt7gOEDKyZDvw0HfhpGrDnU8Bc4OGaEhERUU2gUkm2dULWH79aWoaitc3+Ow5YPQU49M3ND2y44VjcNYZKkxGr/J91zbP1IKIah4GQSmQNhOy/mIYCswwMfQ/wDVe20f17NfD3D8DvrwJb3/VwTYmIiKimmHJnfQDAkt2XcDE5u2SG6DuV/025yv/nfr/5Qa2BEN8I5f9cF6fGXN4NZCW6lpeqP+v7wsipMURUuRgIqUTNIv0R5ueFPJNF2abOJwQYvxRoPQ7o/xrQ8zkl4+7/AIsHASsfAEx5nq00ERER3dYGtIhA32bhMFkE5m6MKZmhXjf7x1f2ABaT84Na7/DXaqP870ogJOEw8O09wJppN89Lt4fcNOV/rhFCRJWMgZBKpFJJ6N7YOj2msENQ/y5g3GKg9z+BgW8CHaYAEMo83DO/Age+8lh9iYiI6PYnSRJmDW0BANh2JglZ+TcEOep2BvzrAIHRgHcwUJANJNxkfTPriJDabZX/C7IBU77zMtf/Vv5PPFXGK6Bqy7p2DEeEEFElYyCkkvVsEgqgcMHU0gx9TwmIdCm8G7LrQ+DLfsDS0YyWExERUYVoVssfDUJ9YLII7D5/w+gNLx/gqQPAk3uAhr2VtEs7ip4/8BWw/jlAthSlWQMhYc0AlVb5+WYLpqZfLsrnaESsEPaLsFL1JUSxqTGlLNRLRFSBGAipZHcVjgg5GpdR8o4LoHQ2ej4HDJkHhDUF8tKBq4eBi1uBVROBgtybn8RsBH55BvigBfBhS+D0ejdfBREREd1u+jZT1vPYfjap5JM6f0AfADTsozzeNlfpY1w/Afw2Czi4BLiyuyi/dWpMQB3AR7kJVGLB1GvHgOXjgJRzymNrIAQAMhNKr+S2fwPzGgCXdpZ8znAN+PWfwOa3gPiDTq+VqgCjAZALdyDizT4iqmQMhFSy6BAf1A/1gUUWOHApzXFGtQYY9iEQ2gTo+BDg5Qdc3gl82gXY/h5wcVtR3qTTwIYXgBNrlC3tdn+ibEOWdRUwJADfTwaOLFci71ePKIESqzMb2VkgIiIi9GkWDgDYdiYZQojSMzUdAmh9lF3vDAnKjndy4Y2dq0eK8llHhATULQqE3DgiZPt7wPk/gANfKo+LB0IM8aWf//JO5dyxe0s+d3CJcqydHygjaW+2jgl5VvF1Yzg1hogqGQMhHmDdPWZzTCl3XIpr2Av4xyFg5CfApB+UubmGeGVXmaWjgMPLlOGoX/QG/voa+PER4D9tgZ3zlfJD3wM6PQxAAOufB9Y+DnzZF/j5aeX5mA3AygnAdyOB7GTXLyAzHjCWsqo8Fbn+N5B+xdO1ICIiAJcuXcK+ffuQnp7u1jLx8fHYtm0bMjIy3FBLz+veKBQ6jQrXMvNx6IqD6w6sCzx3UrlZAwDJp4ueSzgMpJxX/i8o7CcE1AZ8rSNCin3xleWiESRJhcfIKPa5mekgEJIRV/h8XCnPxRb9XJDFLVmruuLvh9tpREjaReB/M+zfj+6SfkUJ9OVluP/YRDUMAyEecE/r2gCA9ceuIt9kuUnuQvXvAmYcUKbM3DFYSds4E/j1RcBSANTrrmzFa0gAzPlAg15A18eA4R8DjQcAFiNw/Hul3PFVwPnNynxeADDlAHs+Ue7EZF1XRo4AyuiSg98A/70PuHpUSYvdD/ynPbD8XiVfQW5RfkfMRkhb34U28biLLVTNpV5Q1nX5ZqjShkRE5BF5eXkYNWoU2rRpg+nTp6NOnTr46KOPbrnMgQMHMHr0aHTu3Bn9+vXD0aNHK/AqKo9eq8bQ1rUAAP9YeQRJWQ4WN/UJAdpPAnQB9ulX9ig3XL7qpzzWBQJevoCPcgPIbkRI4gll+i8AJMcoX4SLjxAoLRBiMSv9HEfPG26YTuMomFKcMVvpE8nyzfPWZLIF+HGqcmPNXYq/3ua822cEz96FykjsLe+4/9g7P1Cmfh1Z5v5jE9UwHg+ErF69Gj169ECTJk0wZswYnD592mn+Zs2aISoqqsS/V199tZJqfOu6Nw5FnUA9DPlmbD59k1EhxXn5AHc+AUxYAUS2VgIYAHDXP4BHNgLPngBGfaZMpRm9CJAk5d+I/wBe/kpe/zrK/8vHAtmJyurvALBnAfCfdsAHzYBPOwOx+4Alg4D1zwLnfgd+/ofSAfn1RWUIbNw+4I9/AfPqKyNSruxxXO8jyyHtnI+gTf+n3CESAvjjdeXfzYIo7mYxu7bOyq04uVZpI0OCsvsPERF5xJtvvokjR47gwoUL+Pvvv7F69Wo8//zz2Ldv3y2VOXPmDB566CHs33/7/Y2fPao1GoX74lpmPp5YdghGs4MbNlo90GJk4c8+yv85ScpIDKuAwj6Hb2EgpPgaIZeLrfGRk6ysh1ZcaSM+sq4BorA+pQU5rCNApMLubUYpx7jR5tlKn2jz7MK+UHvPjuiULSXXUilN/EHgz9mOF5V1t7j9wImfgIOL3Tca4cYtlW+XBVNTLyj/n/vd/TfErO/7tEtFaRe2KDcyiahMPBoIWbt2LSZNmoQpU6bgp59+gr+/P/r06YPkZMfTNLZu3Yp9+/bZ/i1YsAAJCQno2bNnJdb81qhVEsZ0rAsA+PGQCx/SJQ6gUYIbWl+g3QPAwLeUgIdWD3SYpEylCYouyh8UDTz6OzDuG2DqRkCtU9JDGgEP/QLU7QRAAJJa6TykngeWDFa2xtMHKee5fhxY9YDyv9WeBcpolOvHgW+HAWc3KelC2A9xPP+nUu3cZEh7FgCnfwF2/0f5d2ZjUT7DVWV9k+snyt4mNzIXAJd3KdOHUs4rabIMLB4IfNTSPeuimPJKv4N0al3Rz2d+vfXzVEey7FpHjkp3/W/g4zbcPpvoFn377beYNm0aIiMjAQAjRoxA27Zt8c0339xSmSlTpmDMmDFQq9UVewEeEOitxeKHuiBAr8Hh2Ay8utbJZ3KXqYDaSxkdEtK45PMBygjYohEhqcrnw6WdyvTc4qx9CKvSAh3F0zLj7W+mCFG0Lkl0t8I8LvSxrOuT7P4Y2PURkH4JOP3zzctVlLVPAPPvABJPOs/3+2vKzoI3tmNFKd6fSb/kOF9Z3BgIuV12A0q7qPyfl67cOHSnnMLvSNbRT+c3A8vGFE17JyKXaTx58rfffhsPPfQQnnjiCQDAkiVLULt2bSxatAivv/56qWXq1Klj9/itt95CdHQ0Bg8eXOH1dad7O0Zh4dYL2HEuBYZ8EwL02rIdIKozMCseULkYy4psqfwDlGBITgrQZCCgUgP3/xe4sBlocjeg0gDLRilfxPSBwMMbgFP/A3a8p0S2AaDbE8D+LwAIIKIVEHaH8uX/h0eANvcqo0NSLwBD5gKdpwIXtxfVY88nRaNQAGV4X9PBwLGVynBLi1H58vf0EWWu8NY5QH4G0GY80PpeJQgky86v+/gPyp0dawfINwKYsV+5JutCbsvGAP1eAVqNUTpoB5coHbbmw5UPsB3zlfMO+0AJpmj1wF1PKwEnAIj7C/huhHK9oxYWnTv1gnIeq5gNwIA3ALW2qOyNspOgP78BCJ0EqPRF6fkGJdBkvZNmZTYCh75ThhU36gu0GKEcvyJc3q2M4mlaxt+vbXOV98yElUDze5Q0i0kZUZQRC4xborwPLu1QOr93PQ34Rzo+nmxRdhUIb1qyHTNilQ5A9xnAHXeXrZ7ucO248l5rPsz1Mnnpyl0iv/DSn986R7muHe8rv0MqF79sWczK+1JSAQ+uK/v7orTfrdQLyvswooXy2PrFw9H7uaLkpSu/T23uAzS6spe3mJS7jT4h7q9bVXB5t/KeaTeh8l+bKiohIQFJSUno1KmTXXqnTp1w5MgRt5VxldFohNFYtFi5waDcMJBlGbKbpmXIsgwhxC0fr36INxY80AFTvzuIHw/FY0KXKHSsF1wyY+0OwIvnAa0PpHVPQEq7AKH1hVQ4YlXIMoQsAz4hUAEQOSkQR/8L1c9P2Q4h/OtAyroKcWYjJADCNwJSThJEZrxSFgBO/ARp40tAoz6wvbtNuZBzUot+p/MyoDIpIz5F3c6QYvdCZMYpx7i0E9LZ3yD3e7VE+0hefpCs65kUfjEX144VnbsyWAqUz7iIlpDO/wFJyJDjDgDhLUrPLwSkxJOQAMipF+1vylz/W9mJpU6HMlXhZu8d6cxvtraXUy8AtdqV6fg2V48CqeeANvdByklG8b9Wcr6hyk5Rcvl3y2KClBlvuy5xegNEvbvcVg9rm1l/P6SL25XHcfsgLBaP/f1319+e2xHbxjl3t09ZjuOxQIjBYMCRI0cwc+bMospoNBgwYAB27NjhpGSRnJwcrFq1Ci+88AJUrgYEqohG4X5oGOaLSyk52HshFYNb1Sr7Qcp7zXXtO3gIqA10mFz0+MGflcBAs3uU4ElglDIcUjYBfV9ROtqWAmVkx9gvgfBmypeUS9uBw0uLjvPby0pQxJQD4RsBY2hL6GO3KUNXfcOVLybJp5WRJTvmK0EQSQVkxirb//79g5IGKKNK/l6tzDWO2aAEL4LrA1FdgH6vKh/6lgLlA3bNNKWMT5hyvJwkpS7WLdrUOmV18t9eVr5wNuhZdKcjoK79HOMLW5Q1VwClU9Gwt/IhvfElZT7rkf8CXaYr2xuHNFLqDCj1unZMuWvybqTSluOX2b9mhV86pZ8eRdCVXRCxvyt5NF5AbhrwRR+lrUZ/BrQdr3zJPbYS2D6vKMhz+DsleNN9hlKnpkOAns8r06isjFnA3s+UzmKjfkBoY/sPyuwkQKNX0n55RgmQtZ+oBISWjlJe96mbgHp32r9vZAtwfLVShy7TgDbjlHSLWXn/AMC+z5RAiMUMrJmuTBsClF2OdP7K7kYAkHQKmLymqF7ZycrIpNAmgNmIkF8ehuraX0CvF4EB/7Kvx55PlfbPuAKE/KjMze3xjPL+cEXcX8DR/wL9/1W0oJ+VEEpbB0aX3rnIiAW+uUcZCj5hhRIMKchRAjwWExDZSmnv4ozZwKKeQF4a8MBKoH4PJQApScr5Us8XjZTKTlR+rxr3L3nulPNA/AGg1diitNi9QGzhNLWTa5X3jas2zlR+fx/ZqLxXMuOB2u2Arwco1/TELuV3fdtc5a7pQ7+UfE+U1eXdyrXX63bzvH++qbxfUs4Bd88u23kKspX3ctIp4LFtRUGdqspcoPze3vh+dJZ/5QTl71rSSWBQBcxLr4asi5yGhNgHv8LCwhwugFqeMq6aO3cuZs8u+d5NTk5Gfr6DtTjKSJZlZGZmQghxy/2iZoHA4GYh+PV0Kr7ZcQ5Rgxo4yZ0HfeSdCDrxI3JaTYTfUWU0W77KB5lJSdCZvRAMwJx6CfKR76EDIOuDUVCnKyz+deF7bAmkwlEG+bU6w/vCr0BGHJISE6HKuY6wX55RgivWz5BCaZePwxzWEpIxE+qsqwgDIOuDkOUViUAABUkXkZ6UhNBfZ0KbehoGvybICLvLrn0iIOHGv+7m+CNITSpl6rI5HwG758Ac1Ai57R4ue6M64L9nLnyPf4usbi/Av3DdlNyrMZAzPoIm5TQMvWfbBcRVOUmIKNxlJf96DAzWulpMiPhuGCTZhKQpuyB0/i7Xwdl7R51xGeGp52yPc+JOICe8fCOxw1Y/BI0hFina2vBJS0Cx3grSr1+BSeXkpogHufq7pc68gnDr9C0AltPrkdLhGfdUQghEFo4IERnxSEpKQvCV/dABkPIzkXzpb8h+5fg+catkC/SnViEnsB2EaFntvpNVNHf+Xb4dubt9srJcn2LnsUBIQoLyZbNWLftf2MjISBw7dsylY/zwww/IycnB1KlTnearqndhejYJxaWUHOw8m4y7W0S4pR5uoQ9SvkwDypd1XYCyUKt1zq0QwD0fAEPnF305nLAC+PtHZY5iYJRyp2L/Z7bhpaJxf6R3+xciYn+G6uh/IfrOAtIvQ/X7q8Cfbyh5IloCzUdA2jEPOLpcSWvYVxniuucTSIVTbAAA2deVf3H7IRJPKtNzjFmAl68SGW8/GWLoe0DiSUjfDIZkXSgWgDx5DXDtGKRjKyAlngDO/AoBCdDoIBUGQUSTgUDiKUhZV23lxJ9vKV+g0i9Bss1lFhBLBkMy23di5R7PQjq2ElLMemWbv5j1kHe8D/T+p3K3YPNs5Utd83sgXdkFAJDO/gax7gmIMV9BWv88pMzC1cbXTIc48ROQegFSYUdE+NcBmg0FjiyDFLMe4uJ2SAVZwPW/IfZ/DtTrDtF7JuAfCen7SZCuFf1OicBoiLvfBlqOAhIOQ/puOBBUD6L9RKhO/ARx6n8QEa0g7ZwPqXBLRLHpVYiRCwrnWwugbmdIP02FdEkZ7SOuHVdev8STgEoDlXVBvMs7IV/eA2nL25Bi90CotIBshnTip6L6qDSQLmyBfPx7ZeSPMQvS1/0hFa62rgLgZc278wOIxv2Vu2Z7P4Vo2AfS6V+UTmzaRYhv7oGUfV25U/LAKiA5BtIPDyntMexDAJIS6NLolGBccgyk5WMhGQ0QWh+IQe8ABTmQ9nwCofOHdGELpItbIVqMhBj7FZCdBGnjP5Uv1CoNoNIq7W5to4JcSJvfhFRs+La4Y7Bybutc+f1fQFW4LaRYNlZpz1ptIYa+B2nVA0C+ARIEBCTl/+Orld+D4jJiIS2+G1JeGqRD30HqOx+yHAYp5teiu1C7PoRodW/R76jhqjLs2C9SCXSc+VUJ1rQcBZz5Far9nxe28YfAtSOQMmIhOj4EqbBTLja9AjH6c0i7P4FkKYDY/h7EpB9xUwXZgEpbchRHyjnlvafSQEzbAunnGUBES4iRCwHZBGnH+8pr2ncWENLYdjdSWP9+qL1KPZ2NpQAyVBBmI/DDDNv6A2LvQogRn9y83gCwbxGkjCvK+2LnhwCE8jssufhBnZeuvE9K+zKSn6n8LfUOsk8XMqSlo4C4fRBDC0cEJZ2GtH0eRK8XgFptSh4rdj9U1q0n9yyAHNrUPrjtgCfvwlQGLy/lPZKXZ7+GQm5uru05d5Rx1axZs/D880ULTRoMBkRHRyM8PBwBAQFOSrpOlmVIkoTw8HC3dCin9tHi19Op2HwuHe/e2wEB3soos3OJWQjy8UK4f7Hf6/CpkJv1gk9oE8idJ0La9SF0g99FRGAE4H03xB8qaFNOKZ8DAPDIr/AKb64E+I8tsR1G12IQcOFXSBYjIvzUkLb+2zbC5EYh6lygIBbSt4OVQC0AKbAu/KOUEbBe+UmICA2ClK5MkQ0quAZjUFBR+xizoCoo2WnWZFxERLAfoPEu+hsqZEg/PgLp9M8Qkgp+Paa5Z4SZbIF0fj0AwO/ol7ZkX1MqsH8ZJFMO9N0fLZruAwCXYmw/eucnQx9R2IdMu2S7nnCkABGlTFdyVA1n753zq+we+hUkwzeiHP1WUy5UBuWzPUROhSTbr9kW7K0CynPc4oRQdlgMiHLr6AiXf7cMyqhgERgFKTMeGkMsIvzURVtIO3JqHaRt/4YYvxQIa1p6nrx0SIU39VTGDEQE+UBKKZpCFWZJBCLalum63OLof6Ha9RaCAJhfS7353564/cpNn/aTKqN2Hufuv8u3G3e3j16vv3mmQh4LhFg7TBqNfRW0Wi0sFtd2Ulm8eDGGDBmC6Ohop/mq6l2YNuFKZ2D7mUQkJTkYIl+dRA0p+rn2APjKXvD/62MAQEbEncgwZEHUHw1Vw8I72IEdEBLxPbySlHVHMttOh7HunYjY/TEkixH5DQYi4+5PAJUa2tDOCPrjaci6IBh6vQ6h0kCbchoBu96CdHFr0XnzCmAOqI+UTi8C6VmAVz343PkS/Pd/AEk2wRTWEqneTYBGTYB6wxG47RXoL26CoccrMNbvD21qDEzhrSH7hEFtiIPP38tQUKcrgv54FlLCX0DCX7ZTGaN7QRe3E5I5H7LWF7JvBGRdILLu/CdMwZ0h3dkEXg3ugdoQh4A9cyFtm4ucjCR4XTsEr8TCIdaFI0hyIjrCJ/k4pBM/oSAjEbr4XRAqDfKbDIP32f9BOvsbAOVOV3aHJ5Db6gFAo4efRQu/I59DKsiC2T8KkhBQZyco05jObwYkCZJshkUfAnNIE3hdPwIpMw74aSqyrzwFn9M/QmXOA1LOQGz7NwBAks2Ql98LVW4yhKSCUOugSjgIaVF327ULlUbJp/WB7B0GjSEW+LwHJCErQaViVN8OVequ9UXmgPnQXjsIv2OLYQ6IhqHPu9Be+wv+BxdAtfZxGA8uh9D6QJ8RC6HS2gIxRv/6EMGNoI/dCrHyAcjeIdBkXAJ2f2zrFACAlK0sFiad24S0Y78icNur0GReBlLOwpgaC21qDNTZ1yAkNfKbDINX/B7bF0j52PdIbvt/CNj1NnxOrbK7Cun0zzAvioEqLw2qPPu1T2SNN4TWB+r0S5AKRyNZfCIg+0ZAk3wS0rlNkL++G4Yer0J4+SFot/Il3BzYQKkbAFw7CnwzFFLhXSQBCdndXoD//vkQp/6HtKYTYA5qBJXRAE36efjv+Te0eWlK3eL2IWjtA0gZtRxhp9fb/qhLSaeRsf+/MDYaBK8r2xH82xPKcGuNNwy93kTg1pchQSCr2wvwOf5dsWv9X9HPh4uln/8TBSsmQmdWviBKFzYj5ex+WIIaFr4prLtNGaGL3QHZOxRQaRG8/iFIsgUFtbsgt/VE+Jz4L1S5ybD41YZeyErAYtkYqHKTgWvHkAtveF09AG1y4boEp39BTofp8LO+tjnJyPhrNYwN+kN//leYQ5vCHNrc7jVRZ1xCyM9TIEFCsFcQVBlni95Px1cjpfV0yLogQO0FTaqyQLc5tIVdp1mTfBJhv78CAMgxCfgdUb6g5KQmIKvHqzftYKszLiN0zb2QLCbkNx6CvGZjoDbEQzLnIb/JMIT+OAaq/AxkDPwQxoYD4R2zBvqz62AOawHfwlE90q8vwJCRCv2FX+GVeBSWa8eRMu5/tqCSZDRAnXkF+st/wq/YueXt85FSZ6AtYKNJPgld/B7kNR+rvC4ApPx0yFAjI8/ikbswlSEqKgoqlcp248UqISEB9euXPmKsPGVcpdPpoNOVnNalUqnc2jmWJMltx+xUPwTNIv1xJjELqw/F47HejXE4Nh1jP9uDdtFB+N+MHvYFIgp/F6M6AhOWF/0dDayjjGw7/6fyexhUD6qIwt+54iO0GvSCqt0EZeRZdiJUCX8BZ38DICkjF83WAJUEQEBlSFD+fgrZtgWvFFAXUnA95efMeEip55WRjQCk1HP27ZN9wwKTKi2g84OUlw7pi97Kwqz3LlamI+//ynZzRxIypPO/K6Mnb1X8X7bddKRii4VKcftti+Krkk8D9Ys+g1FsdIaUcQWS9bW23kABoEo5Y1/GBaW+d2S5aLRv/R7Ald2Q0i8VnbMs0i8X1c8QX2KNEFVBTvlHO1sdXQmse0LZZfHOJ27tWDdw6Xcr47KSt1ZbJWCfdhGqxBNA437K6Mr8zKIbI8Xt/wJIOQPpxI9A/9dKP/aN7XV5l90Cs6rk00CzUqYyy7LyO1CeaaWuKHazTZUZC1VoI+f5f5qmBKvqdABqta6YOlUxLr13Tv2sTIke9w0Q1qTyKlcFuPNzqyzH8FggJDxc+eKfkmL/pSIlJcX2nDNnz57Frl27sHbt2pvmrap3YQYFBGPWhouIyzDimtELbaMCId1Oc7uHvgG5/Rjg6mEEtJ8EY0pqyfa59wuIJYOA0CYIuHMKoFJDjP4MuHoEXn1fQYTWW8kXMRBofQJqSYWiWcoDIYJClJ1tmtwN0WoMpJgNUPV6ARG1inVY754J0fl+iL9/hLrlSESEFbvbMHEZhCkP/lpv+ANAo2KR9IgIoEkneANA5ilg30KI6DshWo0BJBW0HR/C/7d33uFRFesf/5zd9N4LISGFQOi99yYgiKhYERSxF+zt2q5er5d77T9RsWMFBBWQ3nuHEEILLYT03utmd35/THY3m0ZQpMh8nicP7Dlzzs6ZPWf3ne+8RXwzRsbj3vwtutYj0EGt/gVAmFT1hbEAbdenuB34Ur52cJfeIAfnI/SOlFzzPk5p69Gvfx3HFOkhIka8hmO/RzFlH0M79Kt0ce1xF26OHtZJz5hXEGdWQVEqulvmQHBXTJmH0bZ/iHb4VxAgQvuiXf8J9j4RiKpSWPUPtNjvcN8jJ+RC06EJE7rqcoTeAeyd0ZfVJOPq8zC4BcDaVxH2LjLMozQHrTgd4eQJk39Bp+kRXw5HE1Lc1JATYtH9LstEWgR3gRu/xNO3NYhbMfW4DV1ge7zsXaDTNYjKDIhfiGOytYqAuH0+InwApmoDefnF+Hs6IX64AV36AXSVMqGaWQQRAe3Rso7I/zv7oJXn4bP4TulR4eSJVlGIU9KGmuvVowkjzidqvJX82kBZHvqyHALjP0U7Ile+ROuR4OyNCB+MtuJZ7POO17xXO8SYt6E8F+34Kmg3Ac1QhvhlOniGQKdb0QY+id7BFZGdAD/fiT73JN6rHrFem18bdA9swZQRD8XpaAvuQhNGhEcI4qavwdENV/92iDMr0WUewveXSXI1spa7rXD2Qdz4JdrSJ3AsPEvgklvRijPkZ9hjGtruz/Da9i9EVE+0zS9LkUrvgK66HK8N1pBE913vWq4LTYfWQII+EXMd2rHfcUzbLV+7+KKV5eK34WnwCpfJ23KOS4NMZ4dWE9ImnLzQamL2HVO2Wu5twDKegPV+A1xrVoaFszcEdEBL2orbvk/kthovGa8Dn8Lxn9HObJHCW897EMNelqFz6XFoqx9GqzmnviwL4eSJuOkbWP86WnocAd8PlqvSHi3QCmR1COEZKj1SYsZD1zvQ1lhz/5hFEADXQ9/jkr4T0e9RaDMabddniOhRENpX5u3xaAEuvmgbnrLkHXA+vhjn41aByf3g12ilmQB4rXpUVt44ugQNgWOarEIiQnqipe7FY/tbluPsChIJTPgOMewlKMtFm3eT9NxxkN8IprFvo63/F3ZFSQQUH5JhbtkJaEvvQqssxi32MxkuVV0JhxZiGvwcRN9xSVZhLgYuLi4MGDCAJUuWMGXKFABKSkpYu3Ytb7zxhqVdQkICRUVF9OrVq9nHXC1omsZd/cP5x2/xvLP6OP2j/Hh7ZQIAcckFlFcZcXZoZg6jLrdbkqfTZoxVTAzuCl3ukN4VI16T4aFBneBkJqyRHqOEdAdnHzi5Rr4O7CCft8Jka0J0M+7BMswVpEda0jbrvpwE27Zm7z2/NlKo8W8rw29ProW8msof310PUxZZk5J6tJSTuGPLLowQ0lhS9QKrqEHmEdt92VaPEApTZPip3k6GiFra1LnW86G6Uk7aXXxk6GneKekdPOQ5OR61K5acD+YxBelhap7Yu/rL35HSLNnvGu+eP0TNwhGHFl5wIaRZmMUe7wiZpyvvtLQTo4bBwukyJ9+D22TOMzNGg1VMyGqiemZptu3ro7/bvs6qc5+YWf+GDEO/f2PDXoV/lupaHnSHf4PBTzfetjxfPj8g+1tbCEmPk17pzQ1t/rux7xvp4b7vGxj970vdm6uCSyaEBAQE0KpVK7Zt28b1119v2b5161auu+66cx7/1VdfERQUxPjx48/Z9nJdhfFycaRrqBf7kvK54dMdjIgJYPaUHtjr/0ZuUyFd5V+NUFRvfALby7K/dk5odjXusp0mQadJ9WJ2Gyxy1H2KTHjq6Cbbd7m1geMA30gY+lzDfXR0Pfd1XPMm9JyG5hNluwpy1+9QVYLmfo6YzLEzpeG24d8QPght5Gsy90rMODmhdQ5CGzAD0vbBqQ0w/j25KgaWRLcNXpejG9y/QYZzeLaU20K6ws3fQO/7wNEDLaij9Vgnd1lxyDdK5m9x9kbrPhW+myBDVtpeCwOflG6LIT3RQrrLYzvfgubqLw2t6io4tQ4toB2ad7g8701fynwoUcNh/hR53mvfkWEYrv5oPe9B09f6ugnrbf2/g7M8ftg/5IpI/ALocju66BFyv94BTVeKztkL7d518gciebe8T+ZNlmEUQ56X11OajdbvEfhypBRkPMPQbvtRGs8n10P3KWjtJkjD+MCP0HokWsdJMrnuzk/QdsyS79n9LrQJUijSQBowZ3eCsQqt/QQ0c6hDh4nWsY0eJUMgtFrx5oHt4J7VMvwrdb9c3QvsiDb8FTR7JwjtJduNew/2f4c27l20kO7WsZm6BH69F+3Ueus2Zx9odx1a/8fQ/KIx3fU7pq+vRV8sV7C1iCEw6g04swUt64jVk8c/Bu2On+HzIdIQsXOWBkjKHvlZ3zFfJj1e9rTMrxPaBxKWQVAntFu+lRUVNvwHfCLRxrwFP9wkRZO6wonRaDFqtYoCmeflpi9h1+cQ9xOE9JT5UfJOQ/gg6R5bnA5BncErTE4uutyONvxlKcJ92l+KLIDW92HYN8cieqF3QDNWwd6v0OIXyjxBZoPMMwxTv0eoOLMbp5H/QOfXGioLYKEMpdRMBjlpsHOSAlBhMhQmo51YJZ/TkgxZSauW+ESPaXBwvlxVXvp4zQp1Bdruz2TiYvOExquVPLeml3mUTm+EY0tl4uacBDRzic+216IlLAezF453uDSivVqh3b1Mli2P/1nua9kLUvagbX0Pzbe1vH9rJkpmwUXXribZ865P0W37QI7HqhelQGXvIsO49n5luRxd6l60NpMvySrMxeLf//43I0aM4Nlnn6Vfv37MmjWLoKAg7rvvPkubt99+m507d3Lo0KFmH5ORkcGxY8csVe4OHDgAQHh4OOHh4Rft+i4Gt/UKZf2xTNYezeKeOXvILa2y7DuVXULHEM/mnShmHDh6QmWhbQJunQ5u+NS2bfuJUowwez5EXyOfN7MQEtavRghJkf/WxiNE5sly8ZUTbfPEGGTy51pehJacYF5hMPa/1jZmwcZ8jvVvQMo+uW34S7DoIZlDbONMmWi+ZZ3ca83FZLQKLI4eMs9PQ9T9nq0tcggjFKfJa6jlcUHWUVmFz8lD7jsffr1f5qp6eAfsqfnO6HK7/J4G+X6GcjAvVoEs5Zt5CG75znZ7bXJrCSGFtYQQ7wg5yV/9svwb8SoMqjWZ3vZ/0mtmxD/P7TFivh9S98vvvvPIk3JBMFeM8YmQQtKRxVIIKS+AE6uk91LiJlshJOuo9bertshVl9I6eWvMQoh3hLTB6gpmZuIXyvv+xJq/RgipJdppR84hhNQWLnOsnk0UJMOXI6WQOeNA8zyDDOUyt13UCOhy6/n3uy4mI6x8EYI7Nyu89IJjHsfapcUVfymXtGrMI488wsyZM5k8eTKdOnVi1qxZnD17lvvvv9/S5rnnnmP//v2sXWvND1FdXc13333HtGnT6oXWXGk8NaoNM1cc42h6EeuOZfGf5cd49br2l7pbF5e6MfLni6Pbudv8WXQ6WR2nofdu7vt3nyL/atP+eumymJUl3dhv/UGuDNidRyy6s7dtJR4zrRrJUq7TwcAn5J+ZntPlBKnPg9Ciq/yrjbkEIsi+tR1ru9+cKBVqfsDs5PsMf6nZl4FPpDREzcZoQ+jtpMDTu2ZCMulrWQkoZjx0mGhtd9cSuaIVOUweE9zZ1qiKHmVbYab7VNjzpfwRbD+hfrJJr1DbktQN4dSId5mrL1w/q+lje06Tfw0dO/kXKQQ4eYBbUH3jwCuMnJsX45+2Bt2ZLXLFzt5Jig9fXSNXRD1C5ITcu5WscrRwujQ0e9wty0xHDJKGa7epsqJU+CDr9fZ5QCbpG/S0vE80nezLXUul4WU0SGPPJ0pWODKUS6MsfoF0Ix/5T/ns3PCpXOFw9pb5SvZ8Kcf9zFZZPWrMfyCsv0w861RrYnXNv+Gnm+X/e02Xx+ybI1cWR/5TGtLLn7Uaj87e0n175OvgE0lR+EScfGq8wDreBH5t5flNBml8hvWT7sIpe+Tflvet7vLDXoRTGyFpqzxu/PtSZNr7Nax/UyZStnMCQ1mNCCLd9S2rsj3utgi7lntg+0fS0O85Hca/JxPrbvs/KYKMmSkN5MAO8jMc/768rrI8uONnKajt/066fYMsbe4TCZnxsrqERwuZuHjXbCn2mVfCvVrBvWvlxODkGimQdJ2MCOkFTZSr/zswaNAgNm/ezCeffMJnn31G9+7dmTdvHm5u1u/ttm3b2oTkNueYAwcOMHOmDCccMmQIixYtYtGiRdx9993cfffdF+36LgY6nca7N3flptnbOZlVYrPveGZx84UQe2e45Vu5Chw1oum27cbD0ictIS20HgVYS+WK0N5oe76gMuUgjnVL5Jp/rzxD5fdDLSFZM1ahL0qBoJrQBHO5XbMHCcjfTrMofuevUjxO3CxfO3pA51th/b/lqvbG/8ik4TP2c96U58tqe7kn5PfIwCfkd6Gml9+5RqvgRNZhGX5o9qKpEYfRdHJinZ9UI4TU8gg5vQE+HyrFnMcPNC5O1KWiUE6whVEKQuaKgT3ult+vZjFr7T9lXq+WPaTgsO0D2ZeT6+Tn1xC1PUJyjsvqfCBFg5Td1n3r3pDfbR1ukMnT19QkSY++Ria4b4yqUqvYIoyQtAPaXNO8675QmL1lvCPkeIBc5T+zpdbreNtjUvfVOv40GCrkb0BdSm296DHnt+l2J6z/l/y9MBpsK8YVZ1oT7JvvmwtNbSEkI14KcuaFsrrU7kOtEC/S9st7viBJFlII7HDu901YDgfny8TrF0IIObsTdn8G9i7y3j4fW3zVS/Len77K1oZpLiZTTR4+ZDXC8oKG50dbP5DfD/0fO//3OBdVZdJ+P5/rvsK5pCrC008/TXp6On379kWv1+Ph4cG8efNo184aL5qXl0dGhm0M59KlS8nMzGT69OkXu8sXnAGt/fj9sYGsPJTBgz/s4+ttiZiE4KVx7f5eniGK5qFpl+YLaMxMGZPa2GT+fLiY/W8/Qf7VJWLw+Z0noB08tk96STRW0vZSodNZ4+4bQTi6SxGr38PWjYEd4Kkj0mXa2dsqoMSMg5drfafWNhLtHGDoC9bXt/9k+0a1f5QjBsm/xuhya33DxJxY0DMERta4vPtE2AqEdQ2I6FFS8ECzVuAZO9O2zYNbpUeQW6B0cTdfa0PJO2u74frUimOOHCr/uk2Vk46ADrKkc8ve8OsJ6bGkafIZGfiEDDtJ2SPH88ebpfE96Wvp5ZO6X640d7q5/vv3f0wKMubM/hGDbe/X1rUmiI5ucN8G+b46vfQcKkqXYkaL7lI8cg+SQlC3mjH0aw13zJeCS3aCFGEGPS1FqrZj5J+Zyyy56V9F37596du38QpHzz777HkfM2bMGMaMGdPo/r8bni72LHl0AP9bmcCGhCw8nOyJTy3kRB1h5JxEDZN/58LZW7Y7sVpO5M2lYHtOB/cgjmpRtAccC0/VP9acf8GzpcwfYkbvAMYq7PJPQmWM/D4zh8aYPSoB2oyFa9+RE27/GPk9YV7lb9lLPouDn5ZiSFmOnNznJ9m68wsBB36SXm1m0f3IYunxOfotKXz8UlNxzt4FbpgtveW2fSgF4ZzjtqJBRaEUbdyD5OSvRIbWEdJDfg+ZJ6K1Q2NACkklGbLyX0Mr3CajTTUazVAGiTutnnDxC+U5nLzk76SmyfHNLpSCa9xcePIwnN1lneSfXNu4EJJ7utb/azwDXAOkaFCXlf+QYYM1SdkBOel1C5KijmdI/WOyjlFbMCNx08UTQkwm2PKONfzKJ0J+tiA/z2O1QqCaEkKESQoEDXlulDRQycjeRQrgW9+XCx+Zh20Xs2qf+1zhUnmJ0muk25221QebwmSEQulZZXTxl6GuKXubJ4TknIRDv8pz1L7fT2+qL4RUV0qRp/biY2qNAFmUIp+RPyJANNQ3Q5n87gjt3WRzCyYT7P1Gev0m7bD9nW0upVnWSpkIadPEXGvbpijdUmCCiMGyst+FojRHeuB6toR7112yMswXm0sqhOh0Ot577z1mzpxJYWEhfn5+9XJkvP3221RVVdlsGz58OKmpqQQHB/N3YUzHIF4YG8PMFceYs/0MR9KL+PiO7rYZ2RWKvwqd7sKIIFcy5+s6fCXwZ42CywFNk+FaTaG3h8ghF+b93APln5nIIfBMA6toQR2tosp966WRZjYcW59jtbuhRHmNUTukTG8vRY68RNsy2JMX2B7TZrRt6IFCcQFwcbDjnxM68E868N2OM1IIybQmaswsqmBFfDrXdAiihVczvQ+aovtdUgjpOMkqbo5/D4Cj+1IoM7Whp67m2YwYbPXacK0Rs7tNkSFpZqJGwPEVeK96BLH5ZRm2aA6Nqf1M6nRWr0OQwsjOmpxB5pLhPe+Rf1+NhuSdcsLtPVXuE0JOSte9LsWXpxNk/qIlM6QHREA7OfE7uQb0jjBtuVXoeeqoPObHSdaJoTlE7+jvMu9FSk3Sdt9oCGhfI4TUCCC1Q2Nqs2u2rNBh/s7IS4QFd8lQiqBOMPAJtIMLCDi+0lYgNntpBHe2HhvUSa7Yg5x87psjvdbMnFxXU7klTfa3+1QpbAlhO9k107Knrf3h6i/DOIrTpHBUOyF+/EKI/VGKYzP2y7AXQ4X0fss6Yg210dlLAefwb+DgBv0frR8iU1EIu7+Q3hIte507FCI7AbucDJk/Li9R/r7Wrhp0aKEMqwTpNWQeRxc/KZjF1VpYyDpizesC1gm9+bPOOtawEGLOEWLOUwPSa8bZSwr5x5bKftgIIXut/885YetZVJfVL8tzHFsqPWubQ3EGmAwInR2V4SNwOTJPXk9tT+Ha1BZCso/VhKvKaoQWDi2UIW1Rw+XCg8kIswfJsNrpq61jmxZrPSbrqPX5BHmdm/4rvbhqLxIJIfO0BHezlqg3J3s3i3Mg76nmCiEFZyyJjaWXyx8QQmrnBALpLVtXCKntQbPrc5j4MReM2O+lwFqSKce1dpj235jLIq7EwcGh0QSp3t71Xf49PDwuWJLTy4kHh0QR4efK0z/HsTsxj+tnbeX3xwbi66bEEIVCobhs0embv3p2Id7rKssmr7j8iA6Qk8rjmdIj5Oe9yfxzyWHKqox8tP4kn0/tSY9WVvutuMLA8cwS2gS64e5k3+A569FuPDy239Zbo4aU/HK2Vo+gp0PNpCq0j/S0KjhrzWPRdoysHLLyebmtRTc4vgJAlgVf/rQMGwDb0Ji6tBltFULqTowih0ohJG6eXME9tUFOes15SIxV0hPE2dsaBrLzEzl5BBkuaBZBQAomIMN6zEQMknmGVtYkuXb0gB53Qe/7LZXnSN4tPQHqVBUBpPdJRrxcSW53vQxB2PRf66Q6bT/8PNWa26puQlmwjinIkNeAdtJzYf2/YMfH0lPFTOFZOeFe+5r0XklYKT/DY0vlSjtI70tzToyQHvKazIT0kOF8uz+DAz9Aco3wo+mtx5dmSRHDvy2seN4a+mGm443SC6YoFTbNlH2tG6q75T0ZzgOw71sZduNWE0YphMyZFdxVenbknkL7Yih+1RWynH3iJhny+chuq6hgFuJ6Todx79ZKBtzZGp6l6azhlLkn5DhWFFqFpehr5D1qfl0X82cW2MEqhHSvEeC63iHHOG6+zKViFllSagkhVcVSoDJ702x6W4ZoXfOmFADNwmHiJik4db1DhsB6htqG29TGPIH3bElVYFcphNQWKMwIId+rthBiDn0DW8HG7MWSuEk+EwHtrfflz3fB9DWyP2kHrMdkHZFeoV5h8ncyebcMXQO5oGH2MNk3RxZZiB4Nk3+Wee8+GyzPZ/78QYbb1F2EyT8jr8OnjgdT7Rw+tcWU88E8juZwtzOb67epfe74BTJU1yzm/BlMJjkuZo4svmqEEBV7cZkxukMQix8dQCtfF9IKK3hreRNJkxQKhUKhUCguMm0CpXt6cn4ZKfllvPzbIcqqjLg66MktreKeOXsoq5JiwOxNp+j8+mpu+nQ7T/8cd35v5BvVYMnP1IIylpv6UCBqhIOgTjKHxYhXbVe7+z4ow8vumG9JaGpy8kbYOcmJq3ly1YDYYiGsn3Tzdw+WngO1iRwq/03aJsNESjKsIohfTeWT+IVyn5n8MzK/UPggGdLQEGYPRRdfOTk203oUPLRdTly9wqzhB6c3SLd2kKLLsJryq4OflWGTIMNuvhwOy5+RE+qgTrKKSL9HARD2Lhi8a3Kh2TlJrwoztV3wvcNh0FMyzM89WCa7Nk98fWtE2v3fWpPUnt0ukz6bRQywTRTasqett0ZgR+g2Wf7/8G9ywq93kF4dIPNRgczTNO8OKYK4BcqxMhM1Au78RXoVAcT+AMufg/c6SJHGZJKfiwVhW13o6O+w4G6YPVDmZVr6BFp1BQBa4kbZPue4NWQKrGFYkUNt78FhL8twJ5BJgM2ikjk85uhSOfH1jbbeT1nH5AR952zIPi4n3+kHrSFRbUaDg7v0ogjtI7dFXyO9T0qzpMcDyOs0fzb6mufILETknIANb0qR79R6qKwT5rbkMfjmWvi/bvKeMVOSLcWI/4ZLkcUihIRh8K/xYkmPk14cZkwmmHsb/C/COpl38qJB7Gpyo2g1IVsrnpPCnZmMg1LAyk6wemEA7PgE/q8rzBkPFUVWkRCk+AgytGaL9Crj5FoozZVeT9lH5XkTa4kPZ3dKrx0zeYnw6QCZM6iiTlJjGyGkAa8nkJ9h7Pfyc2wIs1dXZE3oYMYhW08rsE00a6yUYl/eaZmnyOzVUlkiPdIO/SJFtrp9aIjEjbbeZEcWN972b4YSQi5DovzdeO+Wrmga/LI/hZ/3JpOQUczKQxlUG6+OmG6FQqFQKBSXJ75ujvi6OiAEvPH7EaqMJjqFeLLrpZEEezpRWG5gd2IeJ7NKeHtVgsWm3noyB6PpzxvYqQXlVOLAE4aHSW47Ddpe23jjkO4y9CVqBKY7F5F92wrE0Bet++2cm/YIsXOA+zfJCipmjw0zLWu58zu4wdTFMmfGU8dgyq9ye9JWmXcBZM4hkJO8sf9rPETB7Prv3w563Qc3fA4P74I7F9om7o4eLXMR+dUSFnR2MGAGTF8Lw16SOZZu/UFOmj3D5ER87NsyNKhFN+mV8tAOxEM7KBj7KSKwA/R9WOZHMVPbI8QyLo5w3f/Zbuv9gPx3xyw5ufdoWZNg20vmXQIpAFk8XjTZh9qhMUGdpPDSqlZS1NA+MPwVeU0P75RiiDDKax34JMyIhRu/sD1H5FC49m1Zaa04TXqYFKXIqiDJu+T/HdytHhVnagkhh36R/1aVSEEgcTPCzonCQa8hYmpVtjyzVXoDZcRby97WTTbfsgfcswJeTJVJzINrxtJcLtdcGazzrdZ8YMk7pUfNyufh2+vgl+nw2SBrWFRAO3gyXlYuNN9DentZHh1kVbHKEvjlHlmJyN7VmpvHLITUFuf2fGHd7uIry1kLoxSxAA7MlZPqtAMwe4D0linPrwktqhFCvEIxekXIcu6GUumNseltKWZt+q9t9SaQSc3r4uxTk1tLg4mfSOHIXGUHpNcXyGTrZ3fYHmsOGzm7XVZCPPyrdd/BBTJcZ+en1v4KIxz7XeYjMWNOUKx3kN4zGTWihRDw+wx5P1QUys+9NrUrV9WuhAMyf0pFIQ4pW9H9PkPmFKuupB7mRMcte9U8z6KBa6wRQsw5xtL2w6JH4Nf7rJ/nxv/IRMYL74HPhlgFrg3/gZmtrPddbcz3e5fbpRCVn2ibX+l8KUyRY15XXKuNodxWaLpEXBahMYr69GjlzeQ+Yfyw8yzPLbSqh3f0CePfEztSbjDi4qA+PoVCoVAoFBefbmFerD2axeojcpV6ar9WuDnaMSjaj5/3prDtZA6nsksxmgTDYwLYeTqXsiojp7JLaBP450qapubLsIqNpm5si+rEbY257ddG0yByCCIrC/rPkNVh0g7ISeW5Qtsaq26nt5deKCfWyIlb7fwaICfzSVvlpCt8kExw/N1E6aUR2ESFwJhxMOgZ+a+dQ+MVMRzd5OTaUAEzQ+VELrSPFClCa3mvtLtO/jVGYHswmTBWOSEe2Iqm08kQisx4KRQ1VDUPZCLSW3+ERQ/LCmM9p8mEpuYwh+Evyf44e0sR6cBPcgK87xu536+NzLXhUCsBpjk3xh3z5WQ2dZ/Mx6K3t17TLd/KyXn3qVbxoPUImDBLekQE1BRdsHOELrdZPQJA5mYxVwZrN156j+z/ToY2gZygmYWrrnfKaylKR4x4hfKw63APeAJtw79lYtR1b8hQKHtX6Qnk7GMb1lT3swIZ+gMyFCGsr3Ui3mmSFOTMyXnNfTYnu62Na0DD1QK73C6PS1gBvz0gQ110drIaX94pKUaseA4OL7L1Zjm+yhqiFdDeei8n75QT+4IkmT/k0K9SDLActwK0cQAIz5qQlKBOcgK/+e2GxwGkKOYXDQk175d3WnpJBXaQScGHPC8Fv1YDZJ+rK2RS2Os+lJ4aRamw6X/yXOGDbMvNOntbvWBc/KTnVNp++KJWkmZzueHDv8lKKbVxcJM5hxKWS6+RkO7So6i2t8ip9TJ/R3WlrPRS2yOkJENWUcpLlGOWuAnNry2OLfpb98cvqJ+TxuxZ4xUmrynnOCRukd8BZsxCSMcb5edcO1Hy3m+gw41SBAOroBH/s3x+4n6S1Z62fSgTu5sRQlbHA3kPVlfIcVn6lHxdlAYjXrMWQjCZpLAljBAxRIbHBbSTomviZulpVROCSJ+HbJPbF2fIRO5x8+Rz4+ILE2fL5POXCOURchnz6vgOPDmyDe6OdjjY6dA0+GnXWQb+dwPtX11FzzfX8N2OM5e6mwqFQqFQKK4yXr++Iy08pRu7l4s913WRCUcHtPYDYP6eZNYfy8JOp/HyuHZ0qimzeyC54E+9r8kkSCuosLxOL6xoonUThPaGPvc3Xf2qOQx6Gu5ZWV8EATlxG/IC3PaTTGoc1AmeOwVD6lcqssHeGUa80vw4fXsneDxO5g2p7e3yZzDnVAjqaFNZph7txsPzZ6ToobeXkywXX3BvAe2vl+FNLj5SlOg5TYbFBNYkmjZXzKqd2NtcQcbRTQod131YvzpGUCcY81b9imrdp8jPo7anTY9pclIY2NEaimQOS+k4yeqZkHVYJr/9sIv0aPAMlWXPH9kFL56VuT/MhNccU1ZTztYcotGi67mrbXS4UU4gq0pg/p2AkGKRT4ScbI6tJSAEdZIiC9iGZbn6NXzu4M4Q2EkKYuZ8H5MXynExh2qB9JooyZDj3mqA7MO2D+U+/xh5DUOeleFFPWrCi/Z/J/scPkh+3i5+1lLLYA3nqp30tMMNst8uvtLT47nEmsnxf6VAFdBBConm8J6AdnIMzF5PXqGW0C3ajpUhVOZExmYxa8ATYM5wEzFEVjwxX2vnW+T92Hac9PJw9Zfvf3uN98TpjbZlm0Her2YPs2NL5eR9dU1+GfP9emq9DIGZPQhm9bCKSuYqQRvegq9GWTxZtJwEnI/VCtXZ/pEUFIozrKE0NkJIjTdUbc8To8EavmL2jMk9afViSdktBYryfCmoDavp8+4vZDiT+fxHlsjqQyYjHFsmPT/M4Wdh/WDUv6QHV9p+WPUP6d1VW4hLWCbz7mx+G74dL72r9s2Bd6Kl55JZBAE4scr6/9Jc+Hq0PJ/5uSnLhZ9ukaE8lygUR7kUXMY42Ol4fGQ0Dw+LwmgSzFp/klkbTpJaIFdCckqqeHXxYYI9nRnVXlY5WH04gyVxaTw5qg05xZWsOZLJw8Na4+N69dSEVigUCoVC8dcS4uXMj/f15bUlh7mhWwuc7OVk2SyEFFVIt+cp/VoR6e9G11AvdiXmEZdcwC095USnoKyKH3edJbOogv5RfozpGNTwm9Uiu6SSqlphwhl/VAi5GPi1hmEXSJg4Fx4tZCjIhaLL7XIi1mv6udvqaq2rereS5ejR6ocSmel8q0zYaZ40+7eF8e/L0B3dBV6j9W8DMw7I8BshZK6M4jSZ6yRquHw/sxdG8k7rce2ua1zUCO0jPS3M+WDMBHc9d3/sHGSo0vw75UTZxQ8GPmXdHz1ShqYcWwoTP5UeOcVpcpK6uKb6TWMeSiATnK560XoN5pCY1iOkSOIbKSe98QtkKFNwF5kfxZzDpa641OkW6fkCMn/F7fOk8NZ2rMx5UVUs88mE9oZqEL3vR6sqkfdPWJ/6/avtIfBwjReOnaPMW9NQ5Z5h/5ACT3iNYNn9Lun9gIBr35Xj5ddG5vvpPlUKGfetk94crUdJQe32n2QYhqaz3l+tR8o2ID15TNUyjMg3Wl6bppNhJAumScEnuCvc/C283Vp613zUgEgZ3EV6w5i9eaJHy3vo+Ep0Zk8aexdZLWfpE9Izp7JIVsYxJ/z1CrOGpWXGW/OEpO2XXhj2rtKryMW3fnLkrTX5T7pPleLXxv/IJLI7PrK2MRlkDh9DOWx5t5bQ1ls+rw6u0iNo/p014oSQHiInVsuQF3PeETsn6T0SPVp6xBSlyGeq4yQ5fl9dI5+pgrNSWPl5qhRyvFrJ76mWveR9te8btPzE+mN5kVBCyBWAvV6HvR6eGBmNm5Mdro52jO4QyEfrTvL9ziQe+mEf3cO8cXbQs+m4zCh9LKOYjMIKSiqriU0u4Md7+1iMlLqsO5rJL/tT+Nf1HVWFGoVCoVAoFM0iws+V7+6xraTi5+ZIu2APjqYX4elsz+MjZFhF55ZeAMSlFCCEoNokuPubPRYPkXm7k9nx4nB83RzZfiqH7OJKJnRpgVZnMppSExZjJqPoMhZCrmTc/GVVjT9CQ2EbtdHbWRODmul5zx97r+bgEWz9/5i36u+PGSdX6cP6ywlxToI10WpDONRMRpN3SVEnfoHMZVE3P0hjOHnI8rQmY8PeNhM/AfGxddJurhR242fnPnenm2WOCFO1NWkuyIooD9XyMBj3rqzWYzLaluP1ryOEeIXK6iR5iTD6LSmCALSbIIUQTQeTvpJiUlaWTDx83QfNGQUrUcNlDp6G0OmlZ5EZFx9ZTUqntwpVEz+ROUA63ChfO7pLb5Ta6OtMeW+eA3PGSbGj0ySZo+PEKinKufpJsevsDuk9o7OX3kEuPtJLy5yrJaQndL0d1rwmBajayU073gQ3filDbGryowifKLR+j8Cyp6QYYWbr+zV9dJSCpt5e5gfKPgprXpWhS6VZso1vpLzuoM7W0tJRw62ViZy85L3r7C3vhf3fwvZZNWNXU8p58zvWZLZmb6baz2PMOJl3pyRLerbU9uwAGT706F7pfRLQDqpKpZBj9iYCmT8peZdMYnt8pQzTcXCXIW/m0LXrPoDIoYjo0ZBXJ7HrRUIJIVcQdnodDw6Jsrx+9br2pBeWs/ZoFrvPWB8+J3sdJ7OsMXz7kvIZ88FmWng5k5BRjL+7I35ujjja6RgaE8C/lx2hwmCitb8bT11jdZ37fPMp8koNPDe6LTrdOVz9FAqFQqFQKIDru7bgaHoRL4yNwctFeqR2CZXhD4dSi4h4cTkB7o5kFVfi4WSHj6sDZ3LL+H5nEsfSi1l5WLq9ezjZMywmwObcKfly5Vqv0zCaxOXtEaK4Mhj+ikzM2aKbnGALce4Ql7H/lWEhg56WyVuTtsp8I+dDYyFHmnbu928MN3+YtlwKIXW9O2pjDkfS20HPu2UVHpAT8LoMeLz+ttYjpUAS0EF6ZZguYjGHuqJGy562iYubg6M7TFsBx5ZD9CgZpuIZYg2fihlXk6xUgxs/t+au6XWfzJvS5wFZlUlvL4UHvb2sSHOophrRuHelkBU1HGHvgmYokyEvvaZL0WDr+9CiuwwXi/1Rfm6dbrGWKR72ovSiiP3ett/mSlHBtYSQ/jOkR1V1pRSizJ5Yve+TQoioET2GPCcFE3PiWrMwArLEcN338WpV421Tk0jXvYX0ThrwuBQXzQKjo5tV3DATOVQKIbs+la89w6RgVrddh4kX996pgxJCrmDs9Tq+mNqTpNwy9pzJo9xgpH2wB+mFFTw2NxZnez2vjG/Pm8uOcCa3jDO50njILa0CigFYdyzLcr5l8ek8OaoNmqax7mimpXRv55aeXNtJ3uxpBeU8NjeWrqFevHRtOyWQKBQKhUKhsOH+QZHc1L0l/u5WL9MQL2eL+AFY/v3fpM7klxl48dd4PlhrW3FhSVwaw2IC2HMmj5krjnEyq4TCcgMAHVp4cDClkPRCWw+RpjCZBKuO5WF3poI7+rSq522iuEqxc7SdSDfnvmjRzZpgdOjzwPOWXcl5ZXy1NZHpAyMI9TlHIt6/gvMVBbrfDbs+l94Irr7nbA7ISX5DAsmVhIMrdL5Z/t/ZS4oJZrpNkV4mMeNkclIzXW6VuUdq3yNm8aLnNFniuOtkq1eUg4v0Don9HtF2nMxmMvKfUvTwbS1DpcyVi2rT/noZKhT7gxQs+j0sBZOuNeFDlkpOmvRSqZ1nx0xQJwjtaw35Cu0tr2vBXTI8587fZAnl6kopytRF06RAuPl/0mvo0d1SMGooH1JdIoZYyx4Hd5EVtc7lKXYJUELIFY6maYT7uRLuZ43DFEJgr9cI8nSma6gX4zoFs+N0LgVlVcQEe5BXWklhuYH4lCLmbE8kyMOJnNIqTmWXkpBZTEtvF15eZC0F9X/rTjCmQxAmIXhi3gH2JeWzLykfRzsdz1zTluKKahzsdDg7NJFMS6FQKBQKxVWBTqfZiCAg7ZUPbuvKnsR8RrQL4Eh6ER5OdozpGExJZTVvLj1CaZURJ3sdT49qy7+XH2XNkUy2nczhvu/2UlZltDlf9zBvDqYUUlRRTWllNa6ODZu0OSWVuDrYUVlt5J45e9h/tgCACD83+rduJOlkMzAYTexPyic60N0mD1u10cSuxDxyS6vo0MKDKH+3Js6iuJjEJRfw6Nz9TO0bzn2DmzGZ+4O8/vth1h7NYv/ZfH59qD92+r+2NkW10fTn3sPNX+Z1sVPh8RacveDmbxre15hQ5uwtPYXqIMb+j5w2t+Mb3c+6samqUWaufUfmJokcJsOjBj1t3Rc+SIofIT0bFkHM9L5PCiHmhMF6e5m42WSSYtbNc5ruQ7+HpddI18lSOPKNarq9mZa9rCWzJy+8LEUQUELI3xJN0xjT0RoP6eli32ACshu6wQNDInGy1/PMgjjWHMlk2cF0iiuqSS+sINTHmYJSA8cyivlo/UnO5pWx+0weDnY6qqpNfLLxFD/uOktRhQF7vY7nRrdFr9MI9XZhZE3y1tosO5JL7oECHhsejbODnt2JeWw/lcPd/cMtrrN/lAqDEYPRhLuTPQajCTudplZ6FAqFQqG4jOgf5Uf/KCk+dAyxGu9ujnZMHxTJl1tO8/6tXRnVLpCvtyWSXljB5C93ATAo2o9Hh7XmxV/jOZ1TSr8oXxbuS6GkspqvtyYSE+yBh5Md+WVV+Lo5EhPkTlxyIfd8u4c2gW50D/O2iCAAiw+kWYSQ/NIqPlx3grZB7oztGMQHa08wpI0/g9v4sy8pn04hnjjZ69iXlM+qwxmcyCrhUGohOSVVhHg589sj/Qlwl7kT3l1znE83ykoQXi72bH9hOC4OjZvbsWfzcXeyo3WAbUnhCoMRB73O4nmbX1qFXq/h4dSMUsF/kuS8MnJKKukW9tdNXoQQrDmSibODnkHR/phMoiYi5K+x3YoqDDw6dz/JeeV8tTWRewdF/OH3EkKw/lgWxzKKmTYg3ObzTcottXhbH0wp5LPNp3lkWOsLcg0Nsf5YJo/9FMvNPUP554QOf/xETh4XrlNXKUKIhu8pOyeM3s0UEGpj72ytklMX90B48rBMfNsU7a+Xni0BMVbPFWh+UmJnb1tPmeZi5wAPbZNhZhc6AfIFRAkhVzmBHvKHe3znYNYcyeTzzact2dhn3tiZfUn5vLfmOO+vPW455u1JnckuruTDdScsLqpV1SbeXHYUkELp9/f0YWC0NDCEEPzfuhN8sO4MABsTsnFztLPkNTmdXcqN3UNYfSST50fH4OkiH9RT2SWsOpyBh5M9t/QMpbzKiIOdDid7HeuPZdHS24W2Qe5UGIxc+39byC2p4l8TO/LWsqMEeznx60P9630hHcsoorDMQJ9IW9e/wnIDrg76BhX10spqdJpm8XgRQlBWZbRZfTIYTTz9cxxGk+D/bu+G/gKEDAkhar4/tL/UQCitlB499n/xioVCoVAoFI3x1Kg2PD4i2vL7eW2nYL7aKqsJjGwXwEe3d8fZQc/yxwdxMquEDi08aOHlxPHMEt5dc7ze+Zzsdeg1japqE4dSiziUWgTAXb2C+HZPBisOpfPGxA6cyipl+rd7LGV4v9mWyPHMEn7adZb+rX3ZmJBNTJA7EX6urDiUUe99UgvKuWfOHhY+2J/8sipLn10c9BSUGVgen8GkHi3rHZdRWMGzC+PYciIHZ3s9a54aTEtvGUax50wek7/cRQtPJx4cEsXgNv6M/2grVdUmvrqrZz0bpi7HM4v5dOMpvF0cGNspiF7hPo22rao28cIvB/F2teeWjp48/fVutp2U1SgeGRbFM9e0PaftUVlt5P01J8gpqeTNiR0bTc5fe8yenH+A3Yl56HUay2cMYvq3e/Bzc+Slce34emsiPVp5M33gHxcr6vLG70dIzpNhVBlFFZzIKqFNoPs5jqpPpcHI9O/2sf2UHKOU/HL+c2Mny/45288ghEwanFNSydurEkjIKOa/N3WmtKqa+JRCfFwdyCyqwN/d8Q+LTYVlBpYfSue1JYepqjbx066zPD4iGm9VJfKiU1BWxWNzYzmRWcLSGQPxu1iFJxybcf/q7RtOENwIyXllrD2ayZ19W/35ecGfyXVzkVBCiAKQBseSA2kWFXtSj5YMaO1Hv0hffN0ceHf1cdyd7PjPjZ0sqzlT+4VzKK2QEC9nfo9L44edSWiaRmJOKTPmxRLm44Knsz2F5QZLVngXBz1H0qUxYk50tiQujZWHMqgymjBUm7h/cCT/XZnA2qOZlv7NWn+SrOIKWge4ce/ASJ775SA6De7s2wp/N0dOZ8usxzPmxgLyRy4+tZD9Sfl4ONvTO8KHubvP8unGU5gETB8YwYtjY9hyMofXFh/mbF4ZfSJ8mHtfX4xCEJdcgE6n4elsz62f7aDaJPjqrp70aOXD0wviWBSbyv2Do3hqVBsc7HS8syqBJXFpAEzsFkJhuYG80koCPZzIKqqkX5QvQZ5OLNibwvjOwZaY0b1n8qiqNhLhals/+2h6EU//HEdOSSW39Axl4b4UHO11/PO6DpbEcasPZ/Du6uMMaO3H82Pb4mh3/qFJB1MKuPPLXQR4OLHggX4N/oDuTszjp11JPDq8db0Vq4uF6Q/WF88pqWTaN3sY2tafp2slAlacP3/a9fYyICGjmFcXH2Jqv3DGdQ4+9wFXGNtP5vDo3Fj+OaEDE7q0uNTdUSjOm9qLCA8MiSSjqIL+Ub7c0TvMMiF2stdbvEmevqYt83afRa/TkVZQTllVNd6uDmQUVliEjRaeTqTV/L9HmBf392vByoR8MosqWXskiw/WHie9sAJXBz2lVUaOZ8pk81VGExsTrJX4jmUUY6/XGN+5Bb0jfGjl60KAuxO3fraDQ6lFfLjuBFlFlVRVm+gd4cOQNv68vSqB+XvO1hNCqqpNPPDDPuJqbKNyg5H/LD/Gx5O7I4TgzWVHqao2cSa3jBd+jSfA3ZG80ioA7vpmN3Pv61tvAl1YZmDFoXRGtg/ktcWH2XFaTtR/3pvM7pdG4GinZ+7usxxKLaRvpC/jOgdjr9fx7fYz/BqbCsCGo06czq1Ap4FJwMcbTmGv1/HEyDYIIfhqayI5JVWMah9I9zAvNE2jsNzA3d/sJrbG2yYmyJ3JfVphFAK3BsKVjmcWM/Wr3ZZqP0aT4NmFcaTkl5OSX87Ns2X1kBWHMth/Np8Pbu2Gg1393x4hBEfTiykoq0Kn03C219MpxNMmd12Fwci+pHw8ne35Zb+sihLu68KZ3DI2H8/+Q0LIysOZbD+Vi5O9jgqDibm7zzK2YxCD2/hTUlnNgr3yfd65uTO7EvP4bNMplsSlEeDuyOYT2Zb7C+T9vvLxQUSfZz9+3Z/CK4sOUVoTLqZp8n79LTaVewZGnPc1KZomo7CC/606xj0DImw82UwmwZqjmfx35THLPGTloQzu7NvqUnX1T/PoT/uJSynETqcxpV/4pe7OX44mxB+cYVzBFBUV4enpSWFhIR4eF8YVzGQykZWVRUBAALrL2AWoKYwmwaz1JzmeVcy/J3a0CVepNprQado5k6OWVxm5/uOtNl/0IFdmHh4QwvgeEXy97QxR/m6MbBfIu6sTWHQgzaatg15HldGEToOB0f7EpxSQX2aw7DcLKHUxiy5mogPcOJFVUq+dmdEdAtlxKpeiCmsd+Ml9wlhxKMNicDja6aisNlmu4a7+4Xy26bSlfacQTwZF+/FJjRssYJMMzoydTsPH1YGs4kpigtxZPmMQp7JLGP3BZkwCgtwdMJjgui4tuLZTMHd+ucvimVOXsR2D0Gkay+LTLdtigtx5eFhrru0Y1ORk9WRWMbsS8wjycKLaJHh50SGya/raN9KHL+/qhZujHUaTYMuJbA6nFfHh2hNUGU10bunJoocHnPMeWBGfTrnByLWdghtdFTqbW0ZLb2dAilYtvJxt9qcVlFNYbsDBTseMubEcyygi1NuFZ0a3ZXzn5k/wPlx7gvfXHsder7HtheGsPpzJkDb+FiFqy4lsXBzs6NHq/Fdk4lMK+S02lSBPR8Z2DL6gCdGOphfx8I/7ubVXqE2lqIZo6Lun2mgivbCClt7O9VbTKgxGtp3MoVeEj8XFusJgJKuoksziCo5lFBMd4EafCB/LsfN2n+WNpUd4cEgUjw1vfUFW6Ewm8ZcnW649NvllBibM2kZqQTl+bg5sfX74OVcta5NXWoVe0ywea5cjj8+LZfGBNFp4OrHpuWFNruZIt3vtgv5u/RW/rX9nlC3y1yGEYOfpPA4kF3BH7zBmzItl68kcfrinFxFuRr7Ym8tXW89gr9cwGAW+rg6sfGIwj8+LZefpXF4e154528+QnF/Gc6NjmL/nLOUGIx/f0Z2edbwr1hzJ5L7v9tps++Wh/rT0dqbff9ZhErD0sYGWCVRpZTVv/H6E+XuT8XCyY+ZNnXn0p/2YhEwoG+zpxN6kfFwc9NwzIIJZG04C0jbqGurF7jN5xAS5894tXVl/LJOqahNVRsGv+1PIKq4k1MeZ5Lxy9DoNPzcHMosqeeP6Diw7mM6uRGuFwZu6t+SFsTEMf2cjxZVWO0jTYMED/TiSXsSriw/jZK9jy3PDOZFZzB01YUoA4zoH89bETry7JoHvdiRZxtLDyQ4hwNXRjt8fG4i/uyPFFQYSMorxcnHg1s92kFtaRXSAG30jffl+Z5LlnGYBpkMLD45nFmMwCh4YEsmLY20rTcQlF/DG0iPsS8q32T6gtS/XdW7B55tP88SoNizYm8yWEzmWkO5xnYLpFubFm8uOMriNf73Sz7UpqjDg5mBHmcHIwr3JuDnaEelu4u1N6ew4ncsTI6PJK63iux1JOOh1zBjRGldHO17//QiR/q6sfXIIOp3G8vh0Hv5xv+W8TvY6PGrCuPPLDNzaM5Q+kT5UGEy0DXJnyYFU7PQ6hrb1Z2BrP8vv7ansEsJ9Xflkw0mLB1TrADcmdm2Bk72eN5cdpW2gOyufGNTob3SjoRtNkJhTSqi38zkXQiqqqvnnb7EUGXS8c0uXJsPBzkVhuYHDaYW0C/Kot0BnNAleXXwIX1cHnhzVhuySStwd7f/SPIXPLohjwb4UWge4seqJwRbB9sVfDzJ3d7JN2xExAXx1dy+bbVfK9/KB5AImfrwNgKFt/ZkzrfHn40JyocfnfH5blRCijI8LTlpBOb/HpRHi7Ux+aRWlVUZu6NoCUV5Yb3yS88q4btZWWno70ybA3bIqMaytPy+Pb0+UvxvZxZWsO5pJYbmB/6yQlWz83Bx564aO/OO3eHJKqojyd2Xe/f1YcySTsqpqS5gOYFHtu4R68cDgSISQE4bqGjGlc0tPRsQE2oT/eLvYU1plpKraRJiPCxF+rmw6nm3ZP7iNP3HJBTbCy7jOwSw7aBUnuod5yR8OgU15Y4D/u70bexLzbAyA2u+dX2ZgULQf/aJ8WRybxvjOwRRVGPh62xkbEWhSj5asPZpJQY1QFB3gxusTOtgkgCssNzBzxTE2H88mtaB+dv0of1cyCisorTLi6WzPPQMiOJZR1KAL8NOj2tA6wI1R7QMtP4qlldV8svEkheUGuod589TPcQD4ujrw/JgYimoMoMeGRxPq48wriw/xw86z9K4xJnefyePxEdE8OaoNGYUVzJgbW2+8anNXv1bcMzCCvWfy8Xd3JCmvjC+3nKZ3uA+39ArFxUGPg15HiLczo97bbLnmSD9XTueUEuThxK8P92fhvhTeW3McvU5j3v196dLSi9eWHGLX6TzevrkzK+IzOJNbxhMjo3Fx0PN7XDrbTuWgId16U/KtY6nTYGLXEF4YG0OAhxMHkgt4bclh8kur6NTSk2evaUu4nyuV1Ua+257ED7uSKCgz0D/Kl8dHRhMTZP0eEkJw2+c7LQbr/yZ15paeoZb9BWVV/H4wHU9ne0a1C8RBDwt2HKccRyZ2a8kv+1P4ZtsZUgvKGdkugDcndiLIU4bAbUzI4qXfDpFaUE4rXxc+m9KD8ioj9367t6aalJWOIR58O603BqNgxLsbLStPDw+N4s6+rXh8XiyDov2ZMSK63mckhGDd0Szm7TnLrsQ8RncI4p2buyCE4MN1J5i7+ywFZQamDYiwKc+983Quqw9nMrJ9AH0jfCmurGZjQhYtvZ3pGuptMT7iUwrZkJDFtZ2CbLyUDEYTQmBZPaz9vXzPt3stq7sgn51yg5GHhkTZrPA0xNojmTw2NxY7vcaXU3vSNcyrWR5YheUGHO10FsHldHYJxzNLGBTtZwmtu5CCUP//rLOsfH94W1eu7xpi2ZdVVMH7NXkPWno7M/3bPfznhk609xZKCLlEKFvk4lFVbSK/rAp/NweysrKwc/Xirm/2cDhNeqi+PakzN/cMxWQSZJdIb87SymrySqsI9XGhumZhorHJ4APf72XV4Ux0Grw8rr1lVf7+7/ay+kgmHk52RAe6czq7hAqDiXKD/D79fEoPrukQxJtLj/BlTUiNmUeHteaZ0W35addZ3lmdwJOj2jC+UzDD3t1o+c1viuu6tKC1vxvvrz1uERhcHfRM6BrC3N1n0TToFe7D7sQ8OoZ4YDRJD4tpA8J57boOCCG44ZPtHEgu4L5BERxKLWLH6VxaB7hxJqeUapMgyMOJrOIKTAJ+mN6HV5ccsqyMA4zrFMz7t3Zl0uztHEwptGzv0MKDH+/tQ15pFcPf3WTZvuiRAeSXVTGotR9rj2by4A9SQJjQpQXJ+WWcyiphcBt/1h3Notwgw6XDfV0wmgQp+eWWhSuwiiq1X69+cggmIbjm/c042unY/dJIPJ3tSS8s55d9KeSWVlFcUc3JrBIOJBfQK9wbDc1ik5jFHk2DLc8Nw8fVgcd+irV4U5v3/+v6DpbVdCEEEz/ZbvH+eeP6DkztF87eM3lMqvF+aYwXx8bwwJAo3l9znA/XnaBTiCeH0woxCXh8RDQzakLJCssM9H5rLZXVJl67rj3TBkQghKDCYMLZQU+10cSc7Wf4v3UniPB347FhrRvM5VeXlYfSefCH/fSL9OWbab0aXDwoq6pm8/EcvttxxhIudN+gCF4aVz8ZqBCCE1kleDnbU1RRzS/7U+gX6cugaD8qq02kFZTz3prjLItPRwhoF+zBkkcH2Ij6645mMv1bKTxe2ymIVYczcbLTcUP3EP5xbTtcHOwoqjCwMj6D0R2CGl28MJkE6UUVeLvYNynaFJYb6PPWWioM8t5675Yu3Ni9JYdSCxn/0VYAHhoaxcDWfkz+chdO9joOvHqNzVg19b2cV1rFDzuTiPBzZWhbf9ybkQOoqMLA4dQi+kT41LMfzGN4Z99WdA31Oue5QJYk/3HXWQ6mFFjC4hztdMS9dk2TC0Ymk+DH3WdpH+xOj1ZWgfhwWiFL4tK4o3cYrXxd6x1nNAkb7z8lhFxklPFx8WlqfCoMRvQ6jQqDkXdXH6djiCc3dQ+pp1oLIbh59g72JuVbfmQyCiuYu/ssE7q2sGRmLyirosebazGaBO6Odmx5Xq6M1s7p8ev+FJ76OQ57vcbvjw0kws+V0e9v5kxumeWHO7OoguXx6VzXpQUB7o78e/lRvtl2Bn93R9Y9PYTSymr+8Ws8p7JLeWZ0W67rHMzUr3ez5UQOnUI8+e1hmSlcCMG8PckcTS/C0U7HF1sSCfVxJq9EikSzbu+KsaKUPWmV/LDrLIDlPeomRTucVsh7q4/j7+7I1H7htG/hQU5JJT/sTGLO9jMUlBnQ6zQ+vqMbYzoGU15lZMpXu9hbs2pir9fo2cqH3FLpBdI7wocZw6M5lV3KS4vibQwYh5oVie6tvKkwGG3KGt7eO5QKg4k1RzLRwGY1CbC4GNfdFunvRnxqIQ3x2nXtWXownX1J+WgaONvrKasy0jXUk+eGhrApqYLPNp9u8NiGaKgPZjRN5m8y4+/uSAsvZ4uhUnd/Q+h1GmM7BpFbUmVxQY70d2VClxbMWn/SIrSBTAR436BINiRkWcLEzDjZ6/j3xE4MbuPPv5cdodokWFpLULPTaSx+dABZRZUsOpBaI/YZLdcY7udqMeYb6neUvyurnxzC/rP53PHFTgxGawNNk59zZbUJRzsdPq4ORPm7sf9sPmVVRku1qNVHMgn0cCSzSN435v9rGvz6UH+6hXljMJrILKrgaHoxH60/YWP0AiybMZDDaUU8t/CgzfboADe8XR24s28rXvotnuIaD61QH2cqDCaLx1KbQDd+uq8vsWcLePSn/RaDt1+kL3cPCKdvpC83fbqdlPwyBkf74+ygJ8TLmT4tHNA5uTHl6z3Y6zXu6B3GtzusAmSwpxPLZwwit7SSx+cdoG+kLw8PjbKIrlnFlWw9kU1dJ7Re4d58PLk7RpMgMacUX1dH2ga5YzQJjCZBZlEF1364BX8PR35+oB/xKYU88tN+ymqqYtzRuxUllQaWxKUxY0Q0Dw2JIr/MwI87kwj1caHcYOSzTae4q3840wbISVV1zQqiq6O+nuGWWlDOgJnrLa/bBXuw6JH+5JRUkZRTyiuLD3Gq5vk2Pxu9w7358PoIAgMDlRByCVC2yMWn9viUG0y8vSoBBzsdL4yJ+VOCZF5pFZ9uPMmwmABL+DBAdnElD3y/1yZJK0ArXxdeHBtjSWwvhOBsTYLS7SdzKSg38PQ1bSzPee2V/B93JfHSb7Ky34DWvrT2d0Ov09HS2xk/d0dLiPCiRwbg6+rAoP9tAKQQ8PMD/egZ7sOD3+9j5WG52GGn0/jlof4EuDuwbN9p7hwUg1PN+25IyGLaN3ssooK9XmPjs8PIKa7k8XmxnMktA2BMhyBmT+nBtpM5PLsgjgGt/fg1NhWjSdAl1Mvy2woQ5uPCLw/1t1QVGvHuRk5ll9KlpSeLHx1oM04v/RbPjzV2UV0GRfvx7s1dCKjJdbfpeDb3zNmDsUagMYfeTOnbitzSSnqF+1gEgmHvbORMbhldQr24Z0A4/1p6lJySygbfB8Dd0Y5wP1eL/TIo2o/vp/exfDZzdyfz0qJ4hAB3Jzt2vjjCxubcdjKHO7/aRXSAG8tmDMK+xjY0C00g7Yek3DLGdAjCXq9ZvKWnD4zgm22JNr9BN3QL4f1bu9r08eMNJ3l7VQIg8/6dyS3lUGoRMUHu5JVW1fNUfnlcO+4dZFs557fYFObtTuax4dEMaO3L2A+3cCyjGJCiw0e3d7eZwB5KLeShH/dZcq846DWqjHKS+88JHejS0hNPZ3vcnexJzivj/9adYN2xLDQNdJrVu9vsCV4bs/f3s6PbcnPPlvi7OaJpmkVcbIjeET58eVdP7v9uLztP59E11IufH+iHvV722fwMZRRWMPnLnZzKLkXT4MZuLXl5XDuL98nm49nEpxZyd/9wFu5L4bUlhy3PQEtvZ5Y/PoiHf9jP1pM5TOzagg9u64YQgv4z15NeWMGcab0Y2jbA0q+zuSXEn05ndLdI7Oz0Ngsgj/y43+LhHeXvyo/39mXG3Fg6hnjywtgYNh3Ppkcrb0tlqk3Hs3luYRyZRZUNCk4P/bCPFYcy8HS257kxbTmdXcrIdoH0i/KltLKaFYcy6NHKm4iaaqOV1UYmfrydozVpC0Da3+UGY73rqMv3O5N4ZdEh3BztWPPUYPzdHPnfqgS+3HIak5DXs/SxQTjZ61h7NItgTydyS6t49Kf99ImQz+MXW05zd79WxHhdmkUZJYQo4+OicKHGp7DMwMHUAht3wYaY/OVOtp3MbdCl0sy+pDwc7ayxxlnFFRw4W8CIdoGNJjs9lFqIn5ujZYW9LqeyS/hqayIPDYlqMFSipLKaEe9utEwoWwe4serxgWRnZ+Ph7cv4Wds4nV3KJ5O7c22n88thUFhm4JXFh1gSl4a9XmNK33B2nM7laE2Jwndv6Uq/KN8GY3ZBKrTL49P5eMNJsoormXVHN4tBV1ZVzV1f7yazqJLk/LJ6k+0QL2cqq03klFTSMcSDBQ/0Z872M7y/9jh+rg4EejpZ4oc1DZ4d3Za1RzLRaRrRge7M3W01dNwd7fjtkQGE+jhzLL2YtoFuFOTlEBAQwNaTubz++2FOZZfSLliKQFXVJu4dGEFcSiFH04swGE2UVRkpqRFnxnUKZuXhDIwmQc9W3iTnl5FZVImjnYx7Xrgv2TJBdLaXwsLR9CIc7HT0i/Rl0/FsHOx0dA/zYmLXEFwd7fB1c6BDsKdlpSEuuYCHfthnWY0HaYjc1iuM/1t3wsbDxdPZnhfHxtAmyJ0P1p5gc42nUd3QrvsGRXAmt4w1RzLxdXWw8diICXKnpLLa4pVip9MI8HAkraCCIA8nHh8ZTccWnkz5ehcFZQZeHBvDZ5tPk1daxegOgbx6XQdeW3yItUflKlbvCB++ubuXxXA7lFrI9R9vsxgpmgZLHhnI5hPZFkPLTKSfK+2CPdh8PNtGEHNx0DOlbyuOZxazIUH+kB9JK6LcYGTG8NaEeDvzj98O1QtzC/FyprDcYPn8QrycKSo3UFxZTbCnkyXuP8LPlaTcUotx2NLb2cZLpzZujnpKKo3c3T+cF8bGMOLdTaQXluPtIse1U4gnOSWVlnObvYdqc3vvMPJKK1l12GqA2ek0G8Hrpu4t2XQ8Gyd7HW0C3Vlfs0ro6+pAXlmVNJId7eoJhyA9yE5mldiE6oGcvPx0X18CPZyY8tUuUvLLsddrPDy0NQI4klbEnX3DKCgz8MT8A0T6u5JVVElJZTWtA9w4lV1ieV5dHPQWEa1HK2++uqsHFUX5yiPkEqFskYvPpRifymojP+w8i4uDnq6hXtjpNML9XP9wIkKjSfDt9jP4ujkwoUuLerbQvN1nMZgEU2ryFJjtoQeHRPHC2BhAfm9c+39bAHhhbAwPDolqcGyEEDw+74AlB9rtvcMsiUFLK6uZueIYR9KL+PC2rpZEr2ZmrT/BO6utnrYf3tYVX1dHOrSwDXf4YvNp/r38qMUrpzbVRhPLD2WQXlCOt6sDgR5OzNmWSKCHE69f36GeZ97eM3lkF1fSN9KX27/YiYeTPT/c26dejpEjaUVM/nKnTdh120B3hrcLwN3JDn83RyL9XfnHr4dIKyzn67t70T3Uk3eXx7P0aB7/vakL/aJsE9Yu2JvMK4sPMWNENA8PrV8l5khaEUGeTjallncn5vHq4kM8OCSK67vKsF9N0xBC8NqSw3xXS7QfFO1HUm4ZzvZ6fn6wH57OtgtlQghe//0Ic7afqffeIH+HnhjVhpOZxZbFgJk3dmJEu0CWHUzD3k7Hq4sPY6xJzj+0jT8bErJxttdjNAmqjCam9G3Fw8OimL8nmV/3p3I2TwphgR6ODG3jz7g27syPz2dZfH2PYjO1w9t7hXtzOK3I8rukadAnwodXxrfnSFoRz9ZaOAn1cWZ85xZ8sfk01SZB30gfdiXm8djwaLqFeTHjp1iKK6stk3gztRdxYoLc6Rvpy/pjWZa+m/Fzc+DBIVFsP5Vr+e3uGOJBRmElOSWVPDemLd/vSCK9UCa5zS6uxF6vsf7poRZ7/8Vf45m7+yyj2gfy2nXt+X5HEuuPZVnC9IfH+JNfZuBgSiGtfFwY0zHIElpvtgEj/FxJrLE/zKH2kf6uLH5kAMl55UyYtdXG7vhiak86hXiy+Xg2Op3GMwviGhz3CD9XisoN5JZW4ePqwHf39OZYRjEbjmWxLF56Gfu4OtClpSfODnrm7k6ma6gXfSJ8iAl255r2QTbiXn5plY13Wp8IH+z1OraezAGs3vg3dgshxNuZj9afRKdJj12zd42ZHq28+fiGSCWEXCyU8XHxudjjcyanlBWHMri7f/hfGjf4R0jJL+OdVQmsO5bF25O6cE37AJs8Bsn55c12Z6uL0SR4cr7VaAH55fr13T1t3NbORVPu+rM3nWLmimO4Odrx/q1d8Xd3tKw4LD6Qxo3dQyzViIorDDjb69E0jc0nsimtrKZNoLtNgjKTSfDpplN8s+0M+WVVFm8W637be8doEhRXGPByccD89VXXEDQYTXy7/Qz7z+bzz+s68P7aE6w5ksm8+/vi7+ZIdkkFrXylIZpaUM6SA2k42EkPmAB3R77bkcTA1n50CfWiqMKAq4PdOSsBncwq5tbPdlJuMPL6hA5M6tESTdOoNppYuC+FDQlZ2Ol1PD86hjBfF8vn9dH6E3y47gSiZqWhT4QvZVXVzLypM1XVJq55f5PFWLujTxg3dAuhZytvhIAj6UXEJecT6S7oFh3KwdQiOoV4Wu75d1cn8NH6k5Y+dgrx5OcH+ln2J+WWciC5gGvaB9V7TsyuuP7ujvx7Ykeu6RBkSeL3W2wqL13bjn/+ftjiwQFyVcfb1Z6JXUO4f3Akvm6ONu6jII25b6f1RqfTOJVdwonMEn7Zn8KaI5k42ulY/vggWng6s+aojH2/rkswyXnl3PjJNotIMKVvK167rj1ZxZXM2X6Gz2s8hex0Gm/f3JmsGm+V/Un5rDmaidEkRYDNzw3Dz00mHayqNpFbWsmNn2y3eJfUzgnkaKfjoaFRuDnaMSwmwOJxllFYQUF5FQ/9sJ/EnFL0Oo0QL+d6RpUZdyc7yxjd3juU1yd0ZOfpXN5ZnUBVtYmBrf1sXOLbBLpRUGagoMxAu2B34lIK8XS2x9leb1nhbIp7B0YwPCaAaXP2WK4l3NeFMF9X3pjQgY0JWSTmlPLsmBhc7HUqR8glRNkiF5+rcXwyiyrYnZjH2Do5xH7YmURuSRWPDW9dU52u8bE5m1vG0YwihrTxP6/cSttP5fDllkQ6hXjy5Kg2DbYRQpBRVEGwp3OD+/8qEjKKeW9NAsl55bRv4cFr17WvF5YghKCy2oSTvb5Z905dl/8/g9Ek+HlvMgv2JiOAr+/qhZeLPUaTaDRESwjBrsQ8dp3Ow9VRz8h2gew/m4+Hkz2D2/jjYCc9UWauPMZnm06jaVIgySmxLrRE+rvaeAc/MDiSTi09eWxubIOesqM7BPK/m7rg7qQnKysLV08fvth6hh2nckjJL6eo3EBplRFvF3t6hvvw7Oi2uDjoqao2EenvZglB83C2x93RzmJ7CiGY/u1eiyhRm25hXvz6UH8KygwWUS32bD6P/hRrCYe+o08YPzXiTQTS3pp3f18yiyp54ZeDNjkF9TXJd80LMq0D3Pjt4f4k5ZZx8+wdlNd4sr91Q0du7RVmOe5AcgGTPt1Odc19YBZ89DoNDWwEjNqM6xRMj1bevLH0SKP9HdbWn9zSKg6mFDKsrT8B7k7M35vcYNshbfxJzisjv6yKflG+rDmSafEGbizP4mdTejC6QxDQcN6jtoHu3D0gnHVHMwnydGJ3Yh7HM0to5etCWkG55fxO9jrev6Urbk52TPlqd4P969HKm4zCCjKKKrixWwgPD43E2ViqhJCLhTI+Lj5qfBrnQo+NySTr28/bc5aW3i48Nrw1vhewlJcQgi0ncojwc72gCUKrqk0UVRjqlR27UOPzR5KEnS9FFVKwqBvSdC62n8phY0I29w6MsLj5mtmQkMVby45yV//wBjORNzU+2cWVDPjveqqqTQR6OLL4kYGNejPVRQjB/rP5RAe617ses1C2OzGPdUcz8XJxoFe4N93DvBsU0B75cT8rDqVz76BInhrVpp4hXW008fPeFNoEutVLRGgm9mw+324/wy29Qm1czwGWx6fz3prj3Dswgtt6W40Sk8nEnmNnWX6ihEHR/g3GRCfllrIsPp3kvDIeGBzFtDl7SMwp5c2JHZvM/F5aWc2JrBLaBrrj7KBn8YFUPlp/kmFt/fktNo2ckkrGdAjimdFt2ZiQxTXtgywCWF3ikgs4nVOCj6sjA1v7YRJCGlqaxs2zd1gqbZldyjcmZPHq4sMEejjSv7UfC/elUFUjepiNme2ncpi/J5nbe4fRt5FSm5cyLlehbJFLgRqfxlFj0zR/p/ERQljytYH0vDQYZbLWL6b2JC65wLI49cnk7vi6OfLTrrP8e9kRSquMtAv24KGhUQxt62+xD5oan2qjSYoB52mDmfOcCARrjmTyy/5UDqYU8P6tXRnWQMiGwWhi7ZFMNA3GdAxm+6kcCssMdA3zAmBjQjanskoI9XFhfOdgi21cWW3k042n2JCQTfcwLyb3CcNogjeWHqZrqBePDou2LBZtPp7NV1sTuW9QJAOj/er1YVFsKk/MPwDICf+0AeEMiPIl9kQK721Jo22gBw8OkaHS/12ZgAYsmzGIUB9nBsxcT36Zgd4RPkzuE8aWEzkMbevPk/MPWIQGd0c71j49BHcnO174JZ7VRzKoMJjo0MKDE1kl6DWN3x8bQLivq6XIRW5JJUfTi6msNtIm0J2bZ+8go6iCNoFu9Gjlw5A2fnUWIAXfbD9DTkklZZXVLIvPaDB0zN3Rjm+n9+Z0dilLD6bRyseF23qH0S5Y/p6tiE9n5spjJOWWMWNENG0D3Yk9m89jw6NxtNdRVmXEx9VB5Qi52Cjj4+Kjxqdx1Ng0jRqfpjnX+Mxaf4KF+1L46PbudGrZdFLQv4pqo4nKapONW+XF4I/cO1lFFZzMLqFfpO8fFs4SMor5aVcSDw9rbfGO+qNUVZvYfDybvUn5TO4TZhEfZdUXHTqdxuG0Qh75cT/FFdWsf2ZoPZfpxlBCyKVF2SIXHzU+jaPGpmn+buNjMgk+WHeCwrIqnhndtllJOo0mgU6r74Urz/f3Gp8/w6bj2RSVGxjXKbhJb6vT2SWUG4x0aCFts1/2pTB70yk+uK2rZRvIxbI5285wMKWQf4xrx4Qu1uqJldVGSiqq8XVzpLDMQGW1sd6CWl1ySypJLSinU4hns+ycs7llTP16F9nFldw9IJyqahN+bo7c1ivsnJX0qo0mMooq6oXO1UYJIRcZZXxcfNT4NI4am6ZR49M0anwa52oaG6NJYDCazsttXQkhlxZli1x81Pg0jhqbplHj0zRqfBrn7zA2BqMJkxDNqph3vlxKW+TiLs8pFAqFQqG44Oh1Gnrd5ZUPSaFQKBQKxZXPH03ufLnz97wqhUKhUCgUCoVCoVAoFIoGUEKIQqFQKBQKhUKhUCgUiqsGJYQoFAqFQqFQKBQKhUKhuGpQQohCoVAoFAqFQqFQKBSKqwYlhCgUCoVCoVAoFAqFQqG4alBCiEKhUCgUCoVCoVAoFIqrBiWEKBQKhUKhUCgUCoVCobhqUEKIQqFQKBQKhUKhUCgUiqsGu0vdgUuBEAKAoqKiC3ZOk8lEcXExTk5O6HRKX6qLGp/GUWPTNGp8mkaNT+OosWmaCz0+5t9U82+sommULXLxUePTOGpsmkaNT9Oo8WkcNTZNcyltkatSCCkuLgYgNDT0EvdEoVAoFIq/F8XFxXh6el7qblz2KFtEoVAoFIq/hubYIpq4CpduTCYTaWlpuLu7o2naBTlnUVERoaGhJCcn4+HhcUHO+XdCjU/jqLFpGjU+TaPGp3HU2DTNhR4fIQTFxcW0aNFCrXo1A2WLXHzU+DSOGpumUePTNGp8GkeNTdNcSlvkqvQI0el0tGzZ8i85t4eHh7rJm0CNT+OosWkaNT5No8ancdTYNM2FHB/lCdJ8lC1y6VDj0zhqbJpGjU/TqPFpHDU2TXMpbBG1ZKNQKBQKhUKhUCgUCoXiqkEJIQqFQqFQKBQKhUKhUCiuGpQQcoFwdHTktddew9HR8VJ35bJEjU/jqLFpGjU+TaPGp3HU2DSNGp+/H+ozbRo1Po2jxqZp1Pg0jRqfxlFj0zSXcnyuymSpCoVCoVAoFAqFQqFQKK5OlEeIQqFQKBQKhUKhUCgUiqsGJYQoFAqFQqFQKBQKhUKhuGpQQohCoVAoFAqFQqFQKBSKqwa7S92BvwMmk4nDhw8D0KFDB3S6q1NfOnjwIEVFRTbbAgICaNOmTb22CQkJlJaW0qFDh7918qDU1FQSExPp0qUL7u7uDbZJSkoiOzubtm3b/qk2VyIHDx6ksrKSXr161du3Y8cOjEajzbbw8HBatmxps81oNHL48GE0TftbPX+pqank5uYSGRmJm5tbg20KCws5ceIEQUFB9cblfNpcaVRXV3P8+HEcHR0JDw9Hr9fb7D9+/DhZWVk22zw8POjcuXO9c505c4acnBxiYmIaHecrjYqKChISEnB3dyc8PLzBZ6K6uprDhw9jZ2dH+/bt0TTtD7VRXD4oW0SibJH6KFukaZQt0jjKFmkcZYs0zRVhiwjFn+LAgQMiIiJCBAcHixYtWoiIiAhx4MCBS92tS0KfPn1EWFiYGDBggOXvjTfesGmTlpYmevToIby9vUVkZKTw9fUVy5cvv0Q9/uvYuXOnuP7664Wfn58AxI4dO+q1KS0tFePHjxcuLi4iJiZGuLi4iM8+++y821yJfPbZZ6JTp07Cy8tLhISENNjG1dVVtGvXzuZ++uGHH2za7N+/X7Rq1UqEhISIoKAgERUVJeLj4y/GJfxlLF26VHTu3FmEhISITp06CRcXF/HSSy/Va/f+++8LJycn0a5dO+Hs7CwmTZokKioqzrvNlUR1dbV49dVXhb+/v2jfvr0IDQ0V4eHhYs2aNTbtJk+eLAICAmzunfvvv9+mTUlJiRg7dqxwdXUVbdu2FS4uLuLLL7+8mJdzwSkvLxdPPfWU8PX1Fd26dROBgYEiOjpabNu2zabdrl27RMuWLUVoaKgIDAwUbdq0EUePHj3vNorLB2WLWFG2iBVlizSNskUaR9kijaNskaa5kmwRJYT8CQwGg4iOjhaTJ08WJpNJmEwmcdttt4no6GhRXV19qbt30enTp4/417/+1WSbMWPGiP79+4vy8nIhhBCvvfaa8PDwENnZ2RejixeNL774Qvz666/i6NGjjRofTzzxhAgPDxeZmZlCCCHmzp0rNE0TsbGx59XmSuTZZ58VcXFx4j//+U+Txsdvv/3W6DmqqqpEZGSkuOuuu4QQQphMJnHzzTeLmJgYYTQa/4JeXxw++ugjGwNq69atwsHBQfz444822zRNE8uWLRNCCJGcnCyCgoLEK6+8cl5trjSKi4vF66+/LgoKCoQQ8jN/5plnhIeHh8jPz7e0mzx5suW+aIxHH31UREZGWr57vv/+e6HT6a5o4zUjI0PMnj1bVFZWCiGksTZlyhQRFhZmaVNRUSFatmxpMcaMRqOYMGGC6Ny583m1UVw+KFvEFmWLWFG2SNMoW6RxlC3SOMoWaZoryRZRQsifYP369QIQx44ds2w7dOiQAMSGDRsuXccuEX369BHPPPOM2L17t0hJSam3PzU1VWiaJhYtWmTZVlJSIpydncWnn356Mbt60Thx4kSDxofRaBTe3t5i5syZNtujo6PF448/3uw2VzrnMj5mz54t9uzZ06Bxunr1agGIkydPWrYdOHBAAGLLli1/WZ8vBT179hQPPfSQ5fU999wjevbsadPmhRdesBnL5rT5O3Dy5EkBiE2bNlm2TZ48Wdxyyy1i79694vTp0/WMUYPBIDw8PMQ777xjsz0iIkI8/fTTF6XfF4vPP/9cODo6WsZgyZIlAhDJycmWNjt37hSA2LNnT7PbKC4flC1ii7JF6qNskaZRtkjzULZI4yhbpGkuV1vk7xHAdomIjY3F1dWVtm3bWrZ16NABFxcXYmNjL2HPLh2ffPIJ9913H+3bt6d79+4cPHjQsu/AgQMIIejRo4dlm6urK+3atbvqxuvMmTPk5+fbjAVAr169LGPRnDZ/d1544QWmT59OaGgoY8eOJS0tzbIvNjYWT09PoqKiLNu6dOmCg4PD32p8zHG1rVu3tmyLjY2td1/07t2b1NRUsrOzm93m78CePXvQNI3IyEib7b/99hv33HMPvXr1onXr1qxfv96y7/Tp0xQVFf1tn61jx46xefNm5syZw1tvvcXrr79uic2NjY0lMDDQJka7Z8+eaJpmufbmtFFcPihbpD7KFmkeyhZpHsoWUbbIuVC2SH2uBFtECSF/gry8PHx9fett9/X1JS8v7xL06NLyyCOPkJOTw4EDB0hNTSU0NJSJEydSVlYGYBmTumN2NY5Xc8biah+vDz74gNzcXOLi4jh9+jTp6elMmTLFsv9qef4efPBB3NzcmDZtmmVbQ9dufl37/jlXmyudtLQ0nnrqKaZNm2bzQzlx4kQyMjKIi4sjPT2da6+9lhtuuIGUlBTg7/9s/fjjjzz//PM899xzhISEcP3111v2NXRf6PV6vLy8mrx36rZRXD5cLd+FzUXZIs1H2SLnRtkiEmWLNI6yRRrmSrBFlBDyJ7C3t6eioqLe9vLychwcHC5Bjy4tU6ZMwdnZGQA3NzfeffddEhMT2bVrFyDHC6g3ZlfjeDVnLK728br33nstynFwcDD//Oc/Wb9+vWUF4Wp4/p588klWrlzJ77//jre3t2V7Q9deXl4OYHP/nKvNlUxOTg6jR4+mbdu2zJo1y2bfpEmT8PHxAeQ4vPvuu1RUVLBixQrLNvj7Plv/+te/2LFjB6mpqXTq1Ilhw4ZRWloKNP7cVFRUNHnv1G2juHy4Gr4LzwdlizQfZYucG2WLKFukKZQt0jhXgi2ihJA/QatWrcjNzbX5kMrLy8nPzycsLOwS9uzyIDAwEJClt0COV+3XZlJTU6+68WrOWKjxsqWh+yknJ4eqqipLm9LSUgoLC/8W4/Pss88yZ84c1qxZQ7du3Wz2tWrVqsH7Qq/X06JFi2a3uVLJzc1l5MiR+Pj4sHTpUsukpzEcHR3x8vK66r6L7O3teeKJJ8jIyLC4kbZq1YrMzEybcpB5eXmUl5fbfPecq43i8kHZIk2jbJHGUbbI+aNsESvKFlG2SHO4nG0RJYT8CUaMGIEQguXLl1u2LV26FCEEw4cPv4Q9u/iUl5djMplstq1evRqAjh07AtCjRw98fHxYsmSJpU18fDyJiYmMGjXq4nX2MsDLy4uePXvajEVhYSEbN260jEVz2vxdMSvGtVm9ejVOTk6W+NQRI0ZgMBhYuXKlpc2SJUvQ6XRX/PP33HPP8cUXX7B69Wp69uxZb/+oUaNYs2aNzcRn8eLFDB48GEdHx2a3uRLJy8tj5MiReHp6snz5clxdXW32V1dXU1lZabMtLi6OrKwsy3eRn58fXbt2tXm28vPz2bx58xX9bDX03Jw8eRKwut6OHDmS0tJS1q1bZ2mzePFi7O3tGTJkSLPbKC4flC1iRdki54eyRZpG2SLKFmkMZYs0zhVli1yQlKtXMY899pgICAgQ3377rfj222+Fv7+/mDFjxqXu1kUnLi5O9O7dW8yePVusWrVK/O9//xNeXl5iypQpNu0+/vhj4eTkJD788EPx888/i3bt2olrrrnmEvX6ryM9PV1s2bJFzJs3TwDis88+E1u2bLHJfLx69WphZ2cnXnnlFbFo0SIxZMgQ0bZtW1FWVnZeba5E4uPjxZYtW8SDDz4o/P39xZYtW8SWLVsspQznzZsnrr32WjFnzhyxYsUK8fzzzwsHBwfx3//+1+Y8Dz30kAgKChLfffed+Oabb4Svr6946qmnLsUlXTBef/11oWmaeO+99yzjsmXLFnHkyBFLm4KCAhEeHi7GjBkjFi9eLJ555hlhb28vtm7del5trjTKyspE9+7dRUhIiFi5cqXN+Jiz+RcUFIiOHTuKDz74QKxcuVJ8+umnIiQkRAwaNEgYDAbLuZYvXy70er147bXXxKJFi8SgQYNE+/btLffglchXX30lbrzxRvHdd9+J1atXi/fff18EBgaKW2+91abdtGnTRMuWLcUPP/wgvvzyS+Hl5SX+8Y9/nHcbxeWDskUkyhaxRdkiTaNskcZRtkjjKFukaa4kW0QTQogLI6lcnZhMJmbPns3SpUsBGD9+PA8++KAlnvBq4tChQ8yePZvjx4/TokULJkyYwI033liv3YIFC/jxxx8pKytj8ODBPPXUU7i4uFyCHv91LF68mLfffrve9oceeojJkydbXm/atIlPP/2U7OxsunbtygsvvIC/v7/NMc1pc6Xx5JNPsmfPnnrb58+fT0hICAAbN27k+++/JyUlhfDwcKZOncqAAQNs2huNRj799FOWLVuGpmlMmDCB+++//4p+/h544AEOHz5cb/vgwYN56623LK/T09OZOXMmhw4dIigoiEcffZR+/frZHNOcNlcSGRkZTJo0qcF9r7/+OiNGjAAgOTmZjz76iIMHD+Lr68vw4cO5++670ev1Nsds2LCB2bNnk5ubS7du3Xj++efx8/P7y6/jr2TNmjXMnTuXlJQUQkJCuO6667jhhhvQNM3Sprq6mlmzZrFy5Urs7OyYOHEi06dPP+82issHZYtYUbaIFWWLNI2yRRpH2SKNo2yRc3Ol2CJKCFEoFAqFQqFQKBQKhUJx1XDlSpUKhUKhUCgUCoVCoVAoFOeJEkIUCoVCoVAoFAqFQqFQXDUoIUShUCgUCoVCoVAoFArFVYMSQhQKhUKhUCgUCoVCoVBcNSghRKFQKBQKhUKhUCgUCsVVgxJCFAqFQqFQKBQKhUKhUFw1KCFEoVAoFAqFQqFQKBQKxVWDEkIUCsXfkhMnTrB8+fJL3Q2FQqFQKBRXKcoWUSguX5QQolAo/pasWrWKp5566lJ3Q6FQKBQKxVWKskUUissXJYQoFAqFQqFQKBQKhUKhuGqwu9QdUCgUfz+SkpI4cOAAvr6+dO/eHRcXF8u+EydOcOLECUaNGkVcXBypqan06dOHoKCgeuc5ePAgJ0+eJDg4mD59+qDT1dduk5OTiY2NJTAwkJ49e6LX6232V1dXc/DgQdLT0+natSshISEX/oIVCoVCoVBcVihbRKFQNIUSQhQKxQVDCMETTzzBDz/8QN++fcnJySE9PZ1ffvmFXr16AdJN9M033yQkJARnZ2dMJhMHDhxg3rx5TJgwAZAGwy233MLGjRvp27cvBw8eJCgoiBUrVuDv7295r8cff5wvv/ySPn36UFFRgZ2dHcuWLcPDwwOAwsJCBg0ahKOjIwC7du1i/vz5lvdRKBQKhULx90LZIgqFolkIhUKhuEB8/vnnIioqSuTk5Fi2vfnmmyImJsby+qOPPhKAePvtty3bXnvtNREUFCTKysqEEELMmjVL+Pj4iKSkJCGEEEVFRaJz587ivvvusxzz8ccfCxcXFxEXF2fZtn37dpGVlWXzPgsXLrTsf+aZZ0Tnzp0v8FUrFAqFQqG4XFC2iEKhaA4qR4hCobhgfPPNN3Tu3JkNGzawYMECfv75Z9zc3Dh27Bjp6emWdo6Ojjz22GOW18888wxZWVls3rwZgHnz5nHnnXcSFhYGgLu7OzNmzGD+/PmWY7799lumTp1K586dLdv69etnWaUB8Pf356abbrK8Hjp0KAkJCRf+whUKhUKhUFwWKFtEoVA0BxUao1AoLhhnzpyhqqqKhQsX2my/9dZbqaqqsrwODg62uIgCuLm54e/vT1JSEiDjeidNmmRzjqioKIqKisjPz8fb25uzZ89y2223NdkfHx8fm9eOjo5UVlb+oWtTKBQKhUJx+aNsEYVC0RyUEKJQKC4YHh4eDB8+nP/9739NtisoKLB5LYSgoKAAPz8/APz8/MjLy7Npk5eXh729vSXm1svLi9zc3AvXeYVCoVAoFFc8yhZRKBTNQYXGKBSKC8aYMWP48ccfKS4uttmemppq87qgoICNGzdaXi9fvhyTyWRJYjZw4EAWLVqEyWSytFmwYAH9+vWzZGK/5pprmD9/vs3qTmlpKWVlZRf6shQKhUKhUFwhKFtEoVA0B+URolAoLhivvvoq69ato1evXtx33324uLiwa9cuTp8+bYm5BXB1dWXq1KnMmDEDk8nEzJkzmTFjBqGhoQC8/PLLLFiwgGuvvZYbb7yRHTt2sHjxYhuD5ZVXXmHlypX069ePu+66i4qKCubOncvy5cttSuQpFAqFQqG4elC2iEKhaA7KI0ShUFwwfHx82L17N08//TRHjx7l8OHDjBw5kvXr19u0a9myJcuWLSM/P5+jR4/y3nvv8fbbb1v2BwQEcODAAfr378/WrVvx9/dn//799O7d29LGz8+PvXv3MnXqVGJjYyksLGThwoUEBwcD0KZNG8aNG2fzvkFBQdx6661/4QgoFAqFQqG4lChbRKFQNAdNCCEudScUCsXVw6xZs5g1axbHjh271F1RKBQKhUJxFaJsEYVCoTxCFAqFQqFQKBQKhUKhUFw1KCFEoVBcVBpyE1UoFAqFQqG4WChbRKFQqNAYhUKhUCgUCoVCoVAoFFcNyiNEoVAoFAqFQqFQKBQKxVWDEkIUCoVCoVAoFAqFQqFQXDUoIUShUCgUCoVCoVAoFArFVYMSQhQKhUKhUCgUCoVCoVBcNSghRKFQKBQKhUKhUCgUCsVVgxJCFAqFQqFQKBQKhUKhUFw1KCFEoVAoFAqFQqFQKBQKxVWDEkIUCoVCoVAoFAqFQqFQXDUoIUShUCgUCoVCoVAoFArFVcP/A8LQS6q6EQNGAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1100x400 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Plot distillation loss curves.\n",
     "fig, axes = plt.subplots(1, 2, figsize=(11, 4))\n",
@@ -1058,18 +672,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "regret of exact minimax  : 0.0000 (must be 0.0)\n",
-      "regret of uniform random : 0.4212\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def exact_regret(action_fn, states=all_states):\n",
     "  \"\"\"Computes fraction of positions where agent move worsens optimal outcome.\"\"\"\n",
@@ -1098,23 +703,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Greedy agreement with teacher (all positions)  : 0.931\n",
-      "Greedy agreement (held-out validation set)    : 0.917\n",
-      "\n",
-      "Exact regret (student)     : 0.0872\n",
-      "Exact regret (teacher-raw) : 0.0867\n",
-      "Exact regret (teacher+MCTS): 0.0033\n",
-      "Exact regret (random)      : 0.4212\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Compute agreement and exact regret for student model.\n",
     "student_raw_agent = make_raw_agent(student_forward)\n",
@@ -1141,18 +732,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Student vs random    93W   6D   1L   (score 0.960)\n",
-      "Student vs minimax    0W  97D   3L   (score 0.485)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Evaluate student model in matches against random and minimax.\n",
     "student_results = {}\n",
@@ -1171,18 +753,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "teacher: inference() 2.24 ms | jitted 0.1289 ms\n",
-      "student: inference() 1.37 ms | jitted 0.0993 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def measure_latency(model, repeats=200):\n",
     "  \"\"\"Returns (Model.inference ms/state, jitted forward ms/state).\"\"\"\n",
@@ -1213,22 +786,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "agent                     params  infer ms   jit ms  vs random  vs minimax  exact regret\n",
-      "----------------------------------------------------------------------------------------\n",
-      "random baseline                -         -        -      0.440       0.055        0.4212\n",
-      "student (distilled)        3,338      1.37   0.0993      0.960       0.485        0.0872\n",
-      "teacher-raw              338,698      2.24   0.1289      0.960       0.485        0.0867\n",
-      "teacher+MCTS             338,698         -        -      0.950       0.500        0.0033\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def score(record):\n",
     "  w, d, _ = record\n",


### PR DESCRIPTION
## Add a teacher-student policy distillation colab (AlphaZero, Tic-Tac-Toe)

Adds `open_spiel/colabs/alpha_zero_policy_distillation.ipynb`: trains an AlphaZero
teacher from scratch, distills it into a much smaller network, and measures how
much strength survives. Uses the existing `alpha_zero.alpha_zero()` loop and the
existing `model_nnx.py` `Model` for both teacher and student.

| agent | params | vs minimax | exact regret |
|---|---|---|---|
| random baseline | - | 0.055 | 0.4212 |
| student (distilled) | 3,338 | 0.485 | 0.0872 |
| teacher-raw | 338,698 | 0.485 | 0.0867 |
| teacher+MCTS | 338,698 | 0.500 | 0.0033 |

- Student matches its teacher at **101.5x fewer parameters** (0.0872 vs 0.0867).
- **Search accounts for a ~26x blunder reduction** that win/draw/loss cannot see —
  those two agents differ by 3 games in 100, and the direction flips between runs.