### PR TITLE
Handle zero-sized LRU caches

### DIFF
--- a/open_spiel/python/utils/lru_cache.py
+++ b/open_spiel/python/utils/lru_cache.py
@@ -61,6 +61,8 @@ class LRUCache(object):
     except KeyError:
       self._misses += 1
       val = fn()
+      if not self._max_size:
+        return val
       if len(self._data) >= self._max_size:
         self._data.popitem(False)
     self._data[key] = val  # Insert/reinsert it at the back.

--- a/open_spiel/python/utils/lru_cache_test.py
+++ b/open_spiel/python/utils/lru_cache_test.py
@@ -74,5 +74,14 @@ class LruCacheTest(absltest.TestCase):
     self.assertEqual(cache.get(19), "19")
     self.assertEqual(cache.make(19, lambda: "20"), "19")
 
+  def test_make_with_zero_size(self):
+    cache = lru_cache.LRUCache(0)
+
+    self.assertEqual(cache.make(1, lambda: "first"), "first")
+    self.assertEqual(cache.make(1, lambda: "second"), "second")
+
+    self.assertEmpty(cache)
+    self.assertEqual(cache.info().misses, 2)
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Summary

Allow `LRUCache(0).make()` to compute values without attempting to evict from an empty cache.

Previously, every miss satisfied the eviction condition and called `popitem()` on an empty `OrderedDict`, raising `KeyError`. A zero-sized cache now returns the computed value, keeps no entries, and still records the miss.

## Tests

- Added coverage for repeated `make()` calls with `max_size=0`
- Verified both calls are misses and the cache remains empty
