### PR TITLE
Validate weights carried by WeightedVote

### DIFF
--- a/open_spiel/python/voting/base.py
+++ b/open_spiel/python/voting/base.py
@@ -123,6 +123,8 @@ class PreferenceProfile(object):
     # For now support only integral weights (counts). Makes some things easier,
     # like N(x,y) and the margin matrices can be integers. Should be easy to
     # extend if we need to.
+    if isinstance(vote, WeightedVote):
+      weight = vote.weight
     assert isinstance(weight, int)
     assert weight > 0
     if isinstance(vote, WeightedVote):

--- a/open_spiel/python/voting/base_test.py
+++ b/open_spiel/python/voting/base_test.py
@@ -59,6 +59,15 @@ class BaseTest(absltest.TestCase):
     self.assertLen(profile.votes, 3)
     self.assertEqual(profile.total_weight(), 6)
 
+  def test_weighted_vote_validates_weight(self):
+    for weight in [0, -1, 1.5]:
+      with self.subTest(weight=weight):
+        with self.assertRaises(AssertionError):
+          base.PreferenceProfile([base.WeightedVote(weight, ["a", "b"])])
+
+    profile = base.PreferenceProfile([base.WeightedVote(2, ["a", "b"])])
+    self.assertEqual(profile.total_weight(), 2)
+
   def test_preference_profile_incremental_group(self):
     # Create a weighted preference profile from preferences:
     #


### PR DESCRIPTION
## Summary

Apply the existing positive-integer weight validation to `WeightedVote` inputs.

Previously, `add_vote()` validated only its separate `weight` argument, which defaults to 1, while storing the weight embedded in `WeightedVote`. This allowed zero, negative, and non-integral counts into preference profiles.

## Tests

- Added rejection coverage for weights `0`, `-1`, and `1.5`
- Added a valid weighted-vote control case
