### PR TITLE
Restore libtorch/libnop CMake files deleted in 86fe553c

### DIFF
--- a/open_spiel/libnop/CMakeLists.txt
+++ b/open_spiel/libnop/CMakeLists.txt
@@ -1,0 +1,4 @@
+# An integration test to make sure that we can link with libnop.
+add_executable(libnop_integration_test
+  libnop_integration_test.cc ${OPEN_SPIEL_OBJECTS})
+add_test(libnop_integration_test libnop_integration_test)

--- a/open_spiel/libnop/libnop_integration_test.cc
+++ b/open_spiel/libnop/libnop_integration_test.cc
@@ -1,0 +1,65 @@
+// Copyright 2021 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nop/serializer.h>
+#include <nop/structure.h>
+#include <nop/utility/stream_writer.h>
+
+#include <array>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+// Libnop example taken from
+// https://github.com/google/libnop/blob/master/README.md
+
+// Contrived template type with private members.
+template <typename T>
+struct UserDefined {
+ public:
+  UserDefined() = default;
+  UserDefined(std::string label, std::vector<T> vector)
+      : label_{std::move(label)}, vector_{std::move(vector)} {}
+
+  const std::string label() const { return label_; }
+  const std::vector<T>& vector() const { return vector_; }
+
+ private:
+  std::string label_;
+  std::vector<T> vector_;
+
+  NOP_STRUCTURE(UserDefined, label_, vector_);
+};
+
+void TestSerialization() {
+  using Writer = nop::StreamWriter<std::stringstream>;
+  nop::Serializer<Writer> serializer;
+
+  serializer.Write(UserDefined<int>{"ABC", {1, 2, 3, 4, 5}});
+
+  using ArrayType = std::array<UserDefined<float>, 2>;
+  serializer.Write(
+      ArrayType{{{"ABC", {1, 2, 3, 4, 5}}, {"XYZ", {3.14, 2.72, 23.14}}}});
+
+  const std::string data = serializer.writer().stream().str();
+  std::cout << "Wrote " << data.size() << " bytes." << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  TestSerialization();
+}

--- a/open_spiel/libtorch/.gitignore
+++ b/open_spiel/libtorch/.gitignore
@@ -1,0 +1,1 @@
+libtorch/

--- a/open_spiel/libtorch/CMakeLists.txt
+++ b/open_spiel/libtorch/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Now we can use #include "open_spiel/spiel.h"
+include_directories(../..)
+
+# An integration test to make sure that we can link with torchlib.
+add_executable(torch_integration_test
+  torch_integration_test.cc ${OPEN_SPIEL_OBJECTS})
+add_test(torch_integration_test torch_integration_test)
+
+target_link_libraries(torch_integration_test ${TORCH_LIBRARIES})

--- a/open_spiel/libtorch/torch_integration_test.cc
+++ b/open_spiel/libtorch/torch_integration_test.cc
@@ -1,0 +1,34 @@
+// Copyright 2021 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Examples of how to use the C++ API:
+// - https://github.com/pytorch/examples/tree/master/cpp
+// - https://github.com/prabhuomkar/pytorch-cpp
+
+#include "open_spiel/spiel_utils.h"
+#include "torch/torch.h"
+
+namespace {
+
+void TestMatrixMultiplication() {
+  at::Tensor mat = torch::rand({3, 3});
+  at::Tensor identity = torch::ones({3, 3});
+  at::Tensor multiplied = mat * identity;
+  int num_identical_elements = (mat == multiplied).sum().item().to<int>();
+  SPIEL_CHECK_EQ(num_identical_elements, 9);
+}
+
+}  // namespace
+
+int main() { TestMatrixMultiplication(); }


### PR DESCRIPTION
Restores the five CMake/test files deleted as a side effect in #1362. Contents byte-identical to their versions at the parent of 86fe553c. See issue #1591 for details.

Verified against current master:
- CMake configure passes with both flags ON (fails with "does not contain a CMakeLists.txt" without this PR)
- Full build passes; torch_integration_test and libnop_integration_test both pass
- alpha_zero_torch_example builds and runs