### PR TITLE
Fix Quoridor forced-pass action: encode it relative, validate before reading board_

### DIFF
--- a/open_spiel/games/quoridor/quoridor.cc
+++ b/open_spiel/games/quoridor/quoridor.cc
@@ -269,9 +269,14 @@ std::vector<Action> QuoridorState::LegalActions() const {
     }
   }
 
-  // If no action is possible add 'pass' action to list of moves
+  // If no action is possible add 'pass' action to list of moves. Pawn
+  // actions are encoded relative to base_for_relative_, so the pass (stay in
+  // place) is the base itself: ActionToMove maps it back to the pawn's
+  // current position. Pushing the absolute cell id here instead would be
+  // decoded as a relative move and teleport the pawn (or index off the
+  // board).
   if (moves.empty()) {
-    moves.push_back(cur.xy);
+    moves.push_back(base_for_relative_.xy);
   }
 
   std::sort(moves.begin(), moves.end());
@@ -613,14 +618,15 @@ void QuoridorState::ObservationTensor(Player player,
 
 void QuoridorState::DoApplyAction(Action action) {
   Move move = ActionToMove(action);
+  // Check validity before reading board_[move.xy]: an invalid move's xy can
+  // lie outside the board_ array.
+  SPIEL_CHECK_TRUE(move.IsValid());
   // If players is forced to pass it is valid to stay in place, on a field where
   // there is already a player
   if (board_[move.xy] != current_player_) {
     SPIEL_CHECK_EQ(board_[move.xy], kPlayerNone);
   }
   SPIEL_CHECK_EQ(outcome_, kPlayerNone);
-
-  SPIEL_CHECK_TRUE(move.IsValid());
 
   if (move.IsWall()) {
     Offset offset = (move.IsHorizontalWall() ? Offset(1, 0) : Offset(0, 1));

--- a/open_spiel/games/quoridor/quoridor_test.cc
+++ b/open_spiel/games/quoridor/quoridor_test.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
@@ -57,8 +60,48 @@ void BasicQuoridorTests() {
       *LoadGame("quoridor(board_size=5,ansi_color_output=True,players=3)"), 3);
 }
 
+// A 4-player game in which one pawn ends up fully boxed in with no walls
+// left, so its only legal action is the forced pass. The pass must be encoded
+// as the relative "stay in place" action (base_for_relative_, cell (2,2) in
+// virtual coordinates, id 2 * 17 + 2 = 36 on a 9x9 board), not the pawn's
+// absolute cell id: the absolute id gets decoded as a relative move, which
+// teleports the pawn or indexes board_ out of bounds.
+void ForcedPassIsRelativeTest() {
+  std::shared_ptr<const Game> game = LoadGame("quoridor(players=4)");
+  std::unique_ptr<State> state = game->NewInitialState();
+  const std::vector<Action> actions = {
+      163, 215, 63,  87,  73,  199, 91,  141, 1,   267, 173, 185, 187, 195,
+      15,  19,  2,   111, 51,  25,  29,  247, 109, 177, 99,  255, 221, 253,
+      233, 137, 34,  81,  70,  133, 209, 57,  79,  159, 38,  11,  2,   70,
+      241, 70,  70,  2,   38,  2,   167, 70,  123, 34,  227, 2,   34,  38,
+      34,  2,   38,  34,  2,   2,   34,  38,  70,  38,  34,  34,  2,   38,
+      34,  38,  70,  2,   34,  34,  38,  34,  38,  34,  34,  38,  38,  38,
+      2,   34,  38,  34,  38,  38,  38,  38,  70,  70,  34,  34,  34,  34,
+      34,  2,   34,  38,  70,  2,   2,   34,  34,  70,  2,   34,  70,  2,
+      2,   70,  2,   70,  2,   2,   70,  2,   34,  38,  34,  70,  70,  68,
+      70,  70,  2,   38,  70,  38,  0,   68};
+  for (Action action : actions) {
+    state->ApplyAction(action);
+  }
+  // Player 2's pawn is boxed in at a6 with no walls left: the only legal
+  // action is the forced pass.
+  SPIEL_CHECK_FALSE(state->IsTerminal());
+  SPIEL_CHECK_EQ(state->CurrentPlayer(), 1);
+  std::vector<Action> legal = state->LegalActions();
+  SPIEL_CHECK_EQ(legal.size(), 1);
+  SPIEL_CHECK_EQ(legal[0], 36);
+  std::string before = state->ToString();
+  state->ApplyAction(legal[0]);
+  // A pass must not move any pawn or spend a wall.
+  SPIEL_CHECK_EQ(state->ToString(), before);
+  SPIEL_CHECK_EQ(state->CurrentPlayer(), 3);
+}
+
 }  // namespace
 }  // namespace quoridor
 }  // namespace open_spiel
 
-int main(int argc, char** argv) { open_spiel::quoridor::BasicQuoridorTests(); }
+int main(int argc, char** argv) {
+  open_spiel::quoridor::BasicQuoridorTests();
+  open_spiel::quoridor::ForcedPassIsRelativeTest();
+}


### PR DESCRIPTION
Fixes the root cause of the rare `games_sim_test` Quoridor crash in #1349.

PR #1229 moved all pawn actions to a relative encoding centered on `base_for_relative_` (2,2), but the forced-pass branch in `LegalActions()` still pushes the pawn's absolute cell id (`moves.push_back(cur.xy)`, quoridor.cc:274). `ActionToMove` (quoridor.cc:220-233) decodes every non-wall action as relative, so a pass by a pawn at virtual (x,y) resolves to (2x-2,2y-2), and when that square is occupied the jump branch doubles it to (3x-4,3y-4), whose xy index can leave the `board_` array. `DoApplyAction` then reads `board_[move.xy]` (quoridor.cc:618) before the `SPIEL_CHECK_TRUE(move.IsValid())` at quoridor.cc:623, an out-of-bounds read. When the decoded square happens to be on the board, the "pass" instead teleports the pawn through walls, silently corrupting the game.

The fix encodes the pass as `base_for_relative_.xy`, the relative stay-in-place id. `ActionToMove` round-trips it to the pawn's current square through either branch (offset zero, doubled or not), and `DoApplyAction` already permits `board_[move.xy] == current_player_` for staying in place. As defense in depth, the `IsValid()` check now runs before the `board_` read.

The regression test replays a 134-action 4-player game that ends with a pawn boxed in at a6 with no walls left. Without the source fix it fails deterministically: the single legal action is the absolute cell id 170 instead of the relative stay id 36. With the fix the pass is 36, applying it leaves the board string unchanged, and play continues.

One thing deliberately not addressed: action histories recorded under the old encoding that contain a forced pass will not replay after this change, since an absolute pass id is indistinguishable from a genuine relative move there is no safe back-compat decode. Given the old id corrupted the state anyway, those histories were already unsound.

Follows the same shape as #1567 (DoApplyAction fix with a replay regression test).