### PR TITLE
Cache Python game tensor shapes

### DIFF
--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -351,10 +351,13 @@ std::vector<int> TensorShape(const TrackingVectorAllocator& allocator) {
 }  // namespace
 
 std::vector<int> PyGame::InformationStateTensorShape() const {
-  TrackingVectorAllocator allocator;
-  auto state = NewInitialState();
-  info_state_observer().WriteTensor(*state, kDefaultPlayerId, &allocator);
-  return TensorShape(allocator);
+  if (!information_state_tensor_shape_.has_value()) {
+    TrackingVectorAllocator allocator;
+    auto state = NewInitialState();
+    info_state_observer().WriteTensor(*state, kDefaultPlayerId, &allocator);
+    information_state_tensor_shape_ = TensorShape(allocator);
+  }
+  return *information_state_tensor_shape_;
 }
 
 void PyState::ObservationTensor(Player player, absl::Span<float> values) const {
@@ -366,10 +369,13 @@ void PyState::ObservationTensor(Player player, absl::Span<float> values) const {
 }
 
 std::vector<int> PyGame::ObservationTensorShape() const {
-  TrackingVectorAllocator allocator;
-  auto state = NewInitialState();
-  default_observer().WriteTensor(*state, kDefaultPlayerId, &allocator);
-  return TensorShape(allocator);
+  if (!observation_tensor_shape_.has_value()) {
+    TrackingVectorAllocator allocator;
+    auto state = NewInitialState();
+    default_observer().WriteTensor(*state, kDefaultPlayerId, &allocator);
+    observation_tensor_shape_ = TensorShape(allocator);
+  }
+  return *observation_tensor_shape_;
 }
 
 py::dict PyDict(const State& state) {

--- a/open_spiel/python/pybind11/python_games.h
+++ b/open_spiel/python/pybind11/python_games.h
@@ -108,6 +108,8 @@ class PyGame : public Game, public py::trampoline_self_life_support {
   // Used to implement the old observation API.
   mutable std::shared_ptr<Observer> default_observer_;
   mutable std::shared_ptr<Observer> info_state_observer_;
+  mutable absl::optional<std::vector<int>> observation_tensor_shape_;
+  mutable absl::optional<std::vector<int>> information_state_tensor_shape_;
 };
 
 // Trampoline for using Python-defined states from C++.


### PR DESCRIPTION
Fixes #1068.

Cache observation and information-state tensor shapes after their first computation for Python-defined games. Optional caches preserve support for valid empty shapes while avoiding repeated initial-state creation and observer writes.

Validation:
- Built the `pyspiel` target.
- Passed focused runtime checks for observation, information-state, and empty tensor shapes.
- Passed all 17 Python Tic-Tac-Toe tests.
- Passed `git diff --check`.