### PR TITLE
Fix out-of-bounds write in dou_dizhu when nobody wins the auction

### DIFF
--- a/open_spiel/games/dou_dizhu/dou_dizhu.cc
+++ b/open_spiel/games/dou_dizhu/dou_dizhu.cc
@@ -160,8 +160,13 @@ DouDizhuState::OriginalDeal() const {
     deal[((i - 1 + first_player_) % kNumPlayers)]
         [CardToRank(history_[i].action - kDealingActionBase)]++;
 
-  for (int i = 0; i < kNumCardsLeftOver; ++i)
-    deal[dizhu_][cards_left_over_[i]]++;
+  // If everybody passed during the auction there is no dizhu, so the
+  // left-over cards were never dealt to anybody. Indexing deal with
+  // kInvalidPlayer writes outside the array.
+  if (dizhu_ != kInvalidPlayer) {
+    for (int i = 0; i < kNumCardsLeftOver; ++i)
+      deal[dizhu_][cards_left_over_[i]]++;
+  }
   return deal;
 }
 

--- a/open_spiel/games/dou_dizhu/dou_dizhu_test.cc
+++ b/open_spiel/games/dou_dizhu/dou_dizhu_test.cc
@@ -14,7 +14,13 @@
 
 #include "open_spiel/games/dou_dizhu/dou_dizhu.h"
 
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "open_spiel/abseil-cpp/absl/algorithm/container.h"
 #include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
 #include "open_spiel/tests/basic_tests.h"
 
 namespace open_spiel {
@@ -26,10 +32,46 @@ void BasicGameTests() {
   testing::RandomSimTest(*LoadGame("dou_dizhu"), 20);
 }
 
+// Regression test for
+// https://github.com/google-deepmind/open_spiel/issues/1358.
+// If every player passes during the auction then nobody becomes the dizhu.
+// The terminal state's ToString() goes through OriginalDeal(), which used to
+// hand the three left-over cards to dizhu_ == kInvalidPlayer and so wrote
+// outside the deal array.
+void AuctionAllPassTest() {
+  std::shared_ptr<const Game> game = LoadGame("dou_dizhu");
+  std::unique_ptr<State> state = game->NewInitialState();
+  std::mt19937 rng(0);
+
+  while (state->IsChanceNode()) {
+    state->ApplyAction(SampleAction(state->ChanceOutcomes(), rng).first);
+  }
+  SPIEL_CHECK_FALSE(state->IsTerminal());
+
+  // Nobody bids.
+  while (!state->IsTerminal()) {
+    std::vector<Action> legal_actions = state->LegalActions();
+    SPIEL_CHECK_TRUE(absl::c_linear_search(legal_actions, kPass));
+    state->ApplyAction(kPass);
+  }
+
+  // No dizhu was chosen, so nobody scores.
+  for (double returns : state->Returns()) SPIEL_CHECK_EQ(returns, 0.0);
+
+  // Formatting the terminal state must not index the deal with
+  // kInvalidPlayer. The out-of-bounds write this guards against is only
+  // visible under a sanitizer, so this is coverage for those builds; it is
+  // shaped like the games_sim_test.py check that reported the crash.
+  std::unique_ptr<State> clone = state->Clone();
+  SPIEL_CHECK_EQ(state->ToString(), clone->ToString());
+  SPIEL_CHECK_FALSE(state->ToString().empty());
+}
+
 }  // namespace
 }  // namespace dou_dizhu
 }  // namespace open_spiel
 
 int main() {
   open_spiel::dou_dizhu::BasicGameTests();
+  open_spiel::dou_dizhu::AuctionAllPassTest();
 }

--- a/open_spiel/python/tests/games_sim_test.py
+++ b/open_spiel/python/tests/games_sim_test.py
@@ -49,9 +49,7 @@ SPIEL_ACTION_STRUCTS_ONLY_GAMES_LIST = [
 # A list of games to exclude from the general simulation tests. This should
 # remain empty, but it is helpful to use while a game is under construction,
 # or while there are any known issues with the game causing test failures.
-SPIEL_EXCLUDE_SIMS_TEST_GAMES_LIST = [
-    "dou_dizhu",  # https://github.com/google-deepmind/open_spiel/issues/1358
-]
+SPIEL_EXCLUDE_SIMS_TEST_GAMES_LIST = []
 
 # A list of games to exclude testing pickle serialization of the 'game type'
 # during general simulation tests (without entirely excluding them from the

--- a/open_spiel/spiel.cc
+++ b/open_spiel/spiel.cc
@@ -184,9 +184,7 @@ std::vector<std::string> GameRegisterer::RegisteredNames() {
 }
 
 std::vector<std::string> GameRegisterer::GamesWithKnownIssues() {
-  return {
-    "dou_dizhu"  // https://github.com/google-deepmind/open_spiel/issues/1358
-  };
+  return {};
 }
 
 std::vector<GameType> GameRegisterer::RegisteredGames() {


### PR DESCRIPTION
If every player passes the auction no dizhu is chosen and dizhu_ stays kInvalidPlayer, but OriginalDeal() still does deal[dizhu_][cards_left_over_[i]]++, writing before the start of the array. ScoreUp() and WriteObservationTensor() already guard this case, this spot was missed.

It's reachable from ToString() on a terminal state — under -fsanitize=address,undefined that's a SEGV in FormatDeal() at dou_dizhu.cc:174, clean with the guard.

Also adds a regression test that plays out an all-pass auction and formats the terminal state. It crashes under sanitizers before the change, passes after.

Discussed in #1358. I couldn't reproduce that issue's segfault directly (macOS/py3.10 only), so I've left GamesWithKnownIssues() alone.