### PR TITLE
Pin scs==3.2.11 to fix least_core_lp and wvg test failures

### DIFF
--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -54,22 +54,22 @@ if verlt $PY_VER 3.12; then
   echo "Detected Python version 3.11"
   export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==2.9.1"
   export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.8.1 jaxlib==0.8.1 flax==0.12.1 dm-haiku==0.0.16 optax==0.2.6 chex==0.1.91 rlax==0.1.8 distrax==0.1.7"
-  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 networkx==3.2 matplotlib==3.10.7 mock==4.0.2 nashpy==0.0.43 scipy==1.16.3 testresources==2.0.1 cvxpy==1.7.5 ecos==2.0.14 osqp==1.0.4 pokerkit==0.6.3 fastmcp==3.3.1"
+  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 networkx==3.2 matplotlib==3.10.7 mock==4.0.2 nashpy==0.0.43 scipy==1.16.3 testresources==2.0.1 cvxpy==1.7.5 ecos==2.0.14 osqp==1.0.4 scs==3.2.11 pokerkit==0.6.3 fastmcp==3.3.1"
 elif verlt $PY_VER 3.13; then
   echo "Detected Python version 3.12"
   export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==2.9.1"
   export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.8.1 jaxlib==0.8.1 flax==0.12.1 dm-haiku==0.0.16 optax==0.2.6 chex==0.1.91 rlax==0.1.8 distrax==0.1.7"
-  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==8.23.0 networkx==3.3 matplotlib==3.10.7 mock==5.1.0 nashpy==0.0.43 scipy==1.16.3 testresources==2.0.1 cvxpy==1.7.5 ecos==2.0.14 osqp==1.0.4 pokerkit==0.6.3 fastmcp==3.3.1"
+  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==8.23.0 networkx==3.3 matplotlib==3.10.7 mock==5.1.0 nashpy==0.0.43 scipy==1.16.3 testresources==2.0.1 cvxpy==1.7.5 ecos==2.0.14 osqp==1.0.4 scs==3.2.11 pokerkit==0.6.3 fastmcp==3.3.1"
 elif verlt $PY_VER 3.14; then
   echo "Detected Python version 3.13"
   export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==2.9.1"
   export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.8.1 jaxlib==0.8.1 flax==0.12.1 dm-haiku==0.0.16 optax==0.2.6 chex==0.1.91 rlax==0.1.8 distrax==0.1.7"
-  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==8.23.0 networkx==3.3 matplotlib==3.10.7 mock==5.1.0 nashpy==0.0.43 scipy==1.16.3 testresources==2.0.1 cvxpy==1.7.5 ecos==2.0.14 osqp==1.0.4 pokerkit==0.6.3 fastmcp==3.3.1"
+  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==8.23.0 networkx==3.3 matplotlib==3.10.7 mock==5.1.0 nashpy==0.0.43 scipy==1.16.3 testresources==2.0.1 cvxpy==1.7.5 ecos==2.0.14 osqp==1.0.4 scs==3.2.11 pokerkit==0.6.3 fastmcp==3.3.1"
 else
   echo "Detected Python version > 3.13"
   export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==2.10.0"
   export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.9.0.1 jaxlib==0.9.0.1 dm-haiku==0.0.16 optax==0.2.7 chex==0.1.91 rlax==0.1.8 distrax==0.1.7 flax==0.12.3"
-  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==9.10.0 networkx==3.6.1 matplotlib==3.10.8 mock==5.2.0 nashpy==0.0.43 scipy==1.17.0 testresources==2.0.2 cvxpy==1.8.1 ecos==2.0.14 osqp==1.1.0 tensorflow_datasets==4.9.9 pokerkit==0.7.3 fastmcp==3.3.1"
+  export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==9.10.0 networkx==3.6.1 matplotlib==3.10.8 mock==5.2.0 nashpy==0.0.43 scipy==1.17.0 testresources==2.0.2 cvxpy==1.8.1 ecos==2.0.14 osqp==1.1.0 scs==3.2.11 tensorflow_datasets==4.9.9 pokerkit==0.7.3 fastmcp==3.3.1"
 fi
 
 


### PR DESCRIPTION
Fixes #1600.

### Cause

`scs` 3.3.0 was released 2026-08-30, the day before #1600 was filed. It reaches us as an **unpinned transitive dependency of cvxpy**, so CI picked it up on the next run.

3.3.0 switched the Linux BLAS backend from OpenBLAS to Intel MKL. The wheel bundles the MKL interface libraries but none of the CPU-dispatch kernel libraries that `libmkl_rt` loads at runtime, which produces the reported

```
INTEL oneMKL ERROR: .../scs.libs/libmkl_avx512.so.3: cannot open shared object file
Intel oneMKL FATAL ERROR: Cannot load libmkl_avx512.so.3 or libmkl_def.so.3.
```

Contents of the two `manylinux` `x86_64` cp314 wheels:

```
scs 3.2.11 (12.1 MB)   libopenblas, libgfortran, libquadmath        -> self-contained
scs 3.3.0  (52.4 MB)   libmkl_{rt,core,intel_lp64,intel_thread},
                       libiomp5                                     -> no kernel libs
```

None of `libmkl_avx512.so.3`, `libmkl_avx2.so.3` or `libmkl_def.so.3` is present among the 19 files in the 3.3.0 wheel, so `libmkl_rt` has nothing to dispatch to. This is an upstream packaging bug in scs, not something in OpenSpiel.

### Fix

Pin `scs==3.2.11`, the last OpenBLAS-based release. It ships cp39-cp314 wheels covering every Python version in the CI matrix, and satisfies cvxpy's `scs>=3.2.4.post1` for 1.7.5, 1.8.1 and 1.9.2 — so it is compatible with the cvxpy bump in #1599 as well.

This also restores the convention in `python_extra_deps.sh`: cvxpy's other solver backends `ecos` and `osqp` are already pinned there, and scs was the only one that was not. Applied to all four version blocks; macOS wheels link Accelerate (0.2 MB) and were never affected, but are pinned too for consistency.

The pin can be dropped once scs ships a release that includes the kernel libraries or reverts to OpenBLAS.

### Relationship to #1599

#1599 comments out `least_core_lp_test.py` and `wvg_test.py` in `python/CMakeLists.txt` to restore CI. This PR addresses the underlying cause, so those two tests can be re-enabled. I have deliberately kept this diff to the pin alone to avoid conflicting with #1599 — if it lands first, I am happy to rebase and re-enable the tests in this PR, or you may prefer to fold the one-line pin directly into #1599.

### Testing

Verified by inspecting the published wheel contents and by confirming the version constraints resolve. I was **not** able to reproduce the failure on Linux locally (no Docker available on my machine), so the green run needs to come from CI here.