### PR TITLE
Fix gin_rummy observation struct revealing the defender's hand

### DIFF
--- a/open_spiel/games/gin_rummy/gin_rummy.cc
+++ b/open_spiel/games/gin_rummy/gin_rummy.cc
@@ -893,8 +893,11 @@ std::unique_ptr<ObservationStruct> GinRummyState::ToObservationStruct(
   obs_struct->observing_player = player;
 
   Player opponent = 1 - player;
+  // A hand becomes public only when its owner knocks (the knocker lays the
+  // hand face up) or at game end. The defender's hand stays private while
+  // they lay off, so the Layoff phase alone must not reveal it: during that
+  // phase the observer may be the knocker and the opponent the defender.
   bool hide_opponent_hand = !obs_struct->knocked[opponent] &&
-                            obs_struct->phase != "Layoff" &&
                             obs_struct->phase != "GameOver";
 
   if (hide_opponent_hand) {

--- a/open_spiel/games/gin_rummy/gin_rummy_test.cc
+++ b/open_spiel/games/gin_rummy/gin_rummy_test.cc
@@ -730,6 +730,48 @@ void TestStructs() {
                  GinRummyObservationStruct(obs_json).ToJson());
 }
 
+// The observation struct must not reveal a hand whose owner has not knocked.
+// During the Layoff phase the observer may be the knocker and the opponent the
+// defender, whose remaining cards are still private.
+void ObservationStructHidesDefenderHandTest() {
+  std::shared_ptr<const Game> game = LoadGame("gin_rummy");
+  std::unique_ptr<State> state = game->NewInitialState();
+  // Same deal as GameplayTest3: Player0 knocks, Player1 defends.
+  std::vector<Action> initial_actions = {
+      10, 11, 12, 22, 35, 48, 13, 26, 1, 40, 9,  8,
+      3,  16, 29, 42, 4,  17, 30, 43, 0, 52, 55, 1};
+  for (auto action : initial_actions) state->ApplyAction(action);
+  // Player0 lays its melds and passes, moving the hand into the Layoff phase.
+  for (Action action : {59, 101, 131, 54}) state->ApplyAction(action);
+
+  GinRummyState* gr_state = static_cast<GinRummyState*>(state.get());
+  auto knocker_obs = gr_state->ToObservationStruct(0);
+  auto* knocker_view =
+      static_cast<GinRummyObservationStruct*>(knocker_obs.get());
+  SPIEL_CHECK_EQ(knocker_view->phase, "Layoff");
+  SPIEL_CHECK_TRUE(knocker_view->knocked[0]);
+  SPIEL_CHECK_FALSE(knocker_view->knocked[1]);
+
+  // The defender has not knocked, so the knocker must not see its cards.
+  for (const std::string& card : knocker_view->hands[1]) {
+    SPIEL_CHECK_EQ(card, "XX");
+  }
+  SPIEL_CHECK_EQ(knocker_view->deadwood[1], -1);
+
+  // The knocker laid its hand face up, so the defender still sees it, and
+  // each player always sees its own cards.
+  auto defender_obs = gr_state->ToObservationStruct(1);
+  auto* defender_view =
+      static_cast<GinRummyObservationStruct*>(defender_obs.get());
+  SPIEL_CHECK_FALSE(defender_view->hands[0].empty());
+  for (const std::string& card : defender_view->hands[0]) {
+    SPIEL_CHECK_NE(card, "XX");
+  }
+  for (const std::string& card : defender_view->hands[1]) {
+    SPIEL_CHECK_NE(card, "XX");
+  }
+}
+
 }  // namespace
 }  // namespace gin_rummy
 }  // namespace open_spiel
@@ -749,5 +791,6 @@ int main(int argc, char** argv) {
   open_spiel::gin_rummy::ResampleFromInfostateTest();
   open_spiel::gin_rummy::ResampleFromInfostateKnownCardsTest();
   open_spiel::gin_rummy::TestStructs();
+  open_spiel::gin_rummy::ObservationStructHidesDefenderHandTest();
   std::cout << "Gin rummy tests passed!" << std::endl;
 }


### PR DESCRIPTION
While looking at the OpenSpiel 2.0 struct APIs I found that `GinRummyState::ToObservationStruct` returns the opponent's private hand in the Layoff phase.

### The bug

```cpp
bool hide_opponent_hand = !obs_struct->knocked[opponent] &&
                          obs_struct->phase != "Layoff" &&
                          obs_struct->phase != "GameOver";
```

The `Layoff` disjunct keys off the phase rather than off whose hand it is, so it applies to both observers symmetrically.

When player A knocks, A lays its hand face up, so revealing it to B is correct — but `knocked[A]` already covers that on its own. Player B, who is laying off, has *not* knocked, and its remaining cards are still private. The phase check revealed them anyway.

### Reproduction

Using the deal from the existing `GameplayTest3`, where Player0 knocks and Player1 defends, on master:

```
phase: Layoff   knocked: [true, false]

to_observation_struct(0)  -> what the KNOCKER sees of the DEFENDER
  hands[1]   : [As, 2s, 5s, Ac, 2c, Kc, 2d, 8d, 9d, 8h]
  deadwood[1]: 48

observation_string(0)     -> canonical view, Player1 section
  Player1:
  +--------------------------+
  |                          |
  |                          |
  |                          |
  |                          |
  +--------------------------+
```

The canonical observers never reveal an opponent's hand or deadwood in any phase — they expose only `layed_melds` and `layoffs`, which are genuinely public. So the struct API was strictly more permissive than the observers it mirrors.

In a 300-game random sweep, 6 playouts (2%) leaked a non-knocker's hand. That rate is low only because random play rarely reaches a knock; knocking is the normal way a hand ends in competent play.

### The fix

Tie hiding to whether the hand's owner has knocked, keeping the terminal reveal for scoring:

```cpp
bool hide_opponent_hand = !obs_struct->knocked[opponent] &&
                          obs_struct->phase != "GameOver";
```

Adds a regression test replaying that deal into the Layoff phase, asserting the knocker sees `"XX"` and deadwood `-1` for the defender, while the defender still sees the knocker's face-up hand and each player sees its own cards. Reverting the one-line fix fails the test on the leaked card.

### Testing

- Full `ctest`: 284/284 passing.
- The 300-game sweep goes from 6 leaking playouts to 0.
- `cpplint` clean on both files apart from the pre-existing `indent_namespace` finding at `gin_rummy.cc:67`.

### One design question

I have kept the `GameOver` reveal, on the assumption it is deliberate so a UI can show both hands for scoring. Note the canonical observers hide the opponent's hand even at `GameOver`, so a discrepancy remains there by choice rather than by accident — happy to align that too if you would prefer.

Likewise, if the Layoff reveal turns out to have been intentional for some use case I have not thought of, say so and I will close this.