### PR TITLE
Issue 1586 stochastic minimax

### DIFF
--- a/open_spiel/algorithms/minimax.cc
+++ b/open_spiel/algorithms/minimax.cc
@@ -14,15 +14,56 @@
 
 #include "open_spiel/algorithms/minimax.h"
 
-#include <algorithm>  // std::max
+#include <algorithm>  // std::find, std::max
 #include <limits>
 #include <memory>
+#include <random>
+#include <utility>
+#include <vector>
 
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
 
 namespace open_spiel {
 namespace algorithms {
+
+Action BestActions::Single() const {
+  return this->actions.empty() ? kInvalidAction : this->actions[0];
+}
+
+Action BestActions::SampleUniformly(std::mt19937& rng) const {
+  if (this->actions.empty()) {
+    return kInvalidAction;
+  }
+
+  std::uniform_int_distribution<int> dist(0, this->actions.size() - 1);
+  return this->actions[dist(rng)];
+}
+
+size_t BestActions::Size() const { return this->actions.size(); }
+
+bool BestActions::ContainsAction(Action action) const {
+  return std::find(this->actions.begin(), this->actions.end(), action) !=
+         this->actions.end();
+}
+
+bool BestActions::Equals(const std::vector<Action>& action_list) const {
+  if (this->actions.size() != action_list.size()) {
+    return false;
+  }
+
+  for (Action action : action_list) {
+    if (!this->ContainsAction(action)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void BestActions::Clear() { this->actions.clear(); }
+
+void BestActions::Add(Action action) { this->actions.push_back(action); }
+
 namespace {
 
 // An alpha-beta algorithm.
@@ -48,7 +89,7 @@ namespace {
 //   The optimal value of the sub-game starting in state (given alpha/beta).
 double _alpha_beta(State* state, int depth, double alpha, double beta,
                    std::function<double(const State&)> value_function,
-                   Player maximizing_player, Action* best_action,
+                   Player maximizing_player, BestActions* best_actions,
                    bool use_undo) {
   if (state->IsTerminal()) {
     return state->PlayerReturn(maximizing_player);
@@ -64,9 +105,12 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
     return value_function(*state);
   }
 
+  const double kInf = std::numeric_limits<double>::infinity();
+  const bool is_root = best_actions != nullptr;
+
   Player player = state->CurrentPlayer();
   if (player == maximizing_player) {
-    double value = -std::numeric_limits<double>::infinity();
+    double value = -kInf;
 
     for (Action action : state->LegalActions()) {
       double child_value = 0;
@@ -87,12 +131,16 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
 
       if (child_value > value) {
         value = child_value;
-        if (best_action != nullptr) {
-          *best_action = action;
+        if (is_root) {
+          best_actions->Clear();
+          best_actions->Add(action);
         }
+      } else if (is_root && child_value == value) {
+        best_actions->Add(action);
       }
 
-      alpha = std::max(alpha, value);
+      alpha = is_root ? std::max(alpha, std::nextafter(value, -kInf))
+                      : std::max(alpha, value);
       if (alpha >= beta) {
         break;  // beta cut-off
       }
@@ -121,12 +169,16 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
 
       if (child_value < value) {
         value = child_value;
-        if (best_action != nullptr) {
-          *best_action = action;
+        if (is_root) {
+          best_actions->Clear();
+          best_actions->Add(action);
         }
+      } else if (is_root && child_value == value) {
+        best_actions->Add(action);
       }
 
-      beta = std::min(beta, value);
+      beta = is_root ? std::min(beta, std::nextafter(value, kInf))
+                     : std::min(beta, value);
       if (alpha >= beta) {
         break;  // alpha cut-off
       }
@@ -153,7 +205,8 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
 //   The optimal value of the sub-game starting in state.
 double _expectiminimax(const State* state, int depth,
                        std::function<double(const State&)> value_function,
-                       Player maximizing_player, Action* best_action) {
+                       Player maximizing_player, BestActions* best_actions,
+                       double tolerance) {
   if (state->IsTerminal()) {
     return state->PlayerReturn(maximizing_player);
   }
@@ -168,58 +221,68 @@ double _expectiminimax(const State* state, int depth,
     return value_function(*state);
   }
 
+  const bool is_root = best_actions != nullptr;
+
+  // in root, store the true action values for each action
+  std::vector<std::pair<Action, double>> action_values;
+
   Player player = state->CurrentPlayer();
+  double value;
   if (state->IsChanceNode()) {
-    double value = 0;
+    value = 0;
     for (const auto& actionprob : state->ChanceOutcomes()) {
       std::unique_ptr<State> child_state = state->Child(actionprob.first);
-      double child_value =
-          _expectiminimax(child_state.get(), depth, value_function,
-                          maximizing_player, /*best_action=*/nullptr);
+      double child_value = _expectiminimax(child_state.get(), depth,
+                                           value_function, maximizing_player,
+                                           /*best_action=*/nullptr, tolerance);
       value += actionprob.second * child_value;
     }
-    return value;
   } else if (player == maximizing_player) {
-    double value = -std::numeric_limits<double>::infinity();
+    value = -std::numeric_limits<double>::infinity();
 
     for (Action action : state->LegalActions()) {
       std::unique_ptr<State> child_state = state->Child(action);
       double child_value = _expectiminimax(child_state.get(),
                                            /*depth=*/depth - 1, value_function,
                                            maximizing_player,
-                                           /*best_action=*/nullptr);
+                                           /*best_action=*/nullptr, tolerance);
 
-      if (child_value > value) {
-        value = child_value;
-        if (best_action != nullptr) {
-          *best_action = action;
-        }
+      value = std::max(value, child_value);
+
+      if (is_root) {
+        action_values.push_back({action, child_value});
       }
     }
-    return value;
   } else {
-    double value = std::numeric_limits<double>::infinity();
+    value = std::numeric_limits<double>::infinity();
 
     for (Action action : state->LegalActions()) {
       std::unique_ptr<State> child_state = state->Child(action);
       double child_value = _expectiminimax(child_state.get(),
                                            /*depth=*/depth - 1, value_function,
                                            maximizing_player,
-                                           /*best_action=*/nullptr);
+                                           /*best_action=*/nullptr, tolerance);
 
-      if (child_value < value) {
-        value = child_value;
-        if (best_action != nullptr) {
-          *best_action = action;
-        }
+      value = std::min(value, child_value);
+      if (is_root) {
+        action_values.push_back({action, child_value});
       }
     }
-    return value;
   }
+
+  if (is_root) {
+    for (const auto& [a, v] : action_values) {
+      if (std::abs(v - value) <= tolerance) {
+        best_actions->Add(a);
+      }
+    }
+  }
+
+  return value;
 }
 }  // namespace
 
-std::pair<double, Action> AlphaBetaSearch(
+std::pair<double, BestActions> AlphaBetaSearch(
     const Game& game, const State* state,
     std::function<double(const State&)> value_function, int depth_limit,
     Player maximizing_player, bool use_undo) {
@@ -246,16 +309,16 @@ std::pair<double, Action> AlphaBetaSearch(
   }
 
   double infinity = std::numeric_limits<double>::infinity();
-  Action best_action = kInvalidAction;
-  double value = _alpha_beta(
-      search_root.get(), /*depth=*/depth_limit, /*alpha=*/-infinity,
-      /*beta=*/infinity, value_function, maximizing_player, &best_action,
-      use_undo);
+  BestActions best_actions = BestActions();
+  double value =
+      _alpha_beta(search_root.get(), /*depth=*/depth_limit, /*alpha=*/-infinity,
+                  /*beta=*/infinity, value_function, maximizing_player,
+                  &best_actions, use_undo);
 
-  return {value, best_action};
+  return {value, best_actions};
 }
 
-std::pair<double, Action> ExpectiminimaxSearch(
+std::pair<double, BestActions> ExpectiminimaxSearch(
     const Game& game, const State* state,
     std::function<double(const State&)> value_function, int depth_limit,
     Player maximizing_player) {
@@ -282,12 +345,12 @@ std::pair<double, Action> ExpectiminimaxSearch(
     maximizing_player = search_root->CurrentPlayer();
   }
 
-  Action best_action = kInvalidAction;
+  BestActions best_actions = BestActions();
   double value =
       _expectiminimax(search_root.get(), /*depth=*/depth_limit, value_function,
-                      maximizing_player, &best_action);
+                      maximizing_player, &best_actions, 1e-9);
 
-  return {value, best_action};
+  return {value, best_actions};
 }
 
 }  // namespace algorithms

--- a/open_spiel/algorithms/minimax.h
+++ b/open_spiel/algorithms/minimax.h
@@ -12,16 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OPEN_SPIEL_ALGORITHMS_MINMAX_H_
-#define OPEN_SPIEL_ALGORITHMS_MINMAX_H_
+#ifndef OPEN_SPIEL_ALGORITHMS_MINIMAX_H_
+#define OPEN_SPIEL_ALGORITHMS_MINIMAX_H_
 
 #include <memory>
+#include <random>
 #include <utility>
+#include <vector>
 
 #include "open_spiel/spiel.h"
 
 namespace open_spiel {
 namespace algorithms {
+
+// The actions that achieve the optimal value at the search root, in
+// legal-action order. Empty only when the search root is terminal.
+class BestActions {
+ private:
+  std::vector<Action> actions;
+
+ public:
+  // The first optimal action, which is the one the search returned before tie
+  // collection was added. kInvalidAction when the set is empty.
+  Action Single() const;
+
+  // A uniformly drawn optimal action, kInvalidAction when the set is empty.
+  Action SampleUniformly(std::mt19937& rng) const;
+
+  size_t Size() const;
+  bool ContainsAction(Action action) const;
+
+  // Set equality: same size and same members, ignoring order.
+  bool Equals(const std::vector<Action>& action_list) const;
+
+  void Clear();
+  void Add(Action action);
+};
 
 // Solves deterministic, 2-players, perfect-information 0-sum game.
 //
@@ -37,12 +63,12 @@ namespace algorithms {
 //   maximizing_player_id: The id of the MAX player. The other player is assumed
 //     to be MIN. Passing in kInvalidPlayer will set this to the search root's
 //     current player.
-
+//   collect_actions: collect all actions that achieve the best value.
 //   Returns:
 //     A pair of the value of the game for the maximizing player when both
-//     players play optimally, along with the action that achieves this value.
+//     players play optimally, along with the actions that achieve this value.
 
-std::pair<double, Action> AlphaBetaSearch(
+std::pair<double, BestActions> AlphaBetaSearch(
     const Game& game, const State* state,
     std::function<double(const State&)> value_function, int depth_limit,
     Player maximizing_player, bool use_undo = true);
@@ -66,7 +92,7 @@ std::pair<double, Action> AlphaBetaSearch(
 //     A pair of the value of the game for the maximizing player when both
 //     players play optimally, along with the action that achieves this value.
 
-std::pair<double, Action> ExpectiminimaxSearch(
+std::pair<double, BestActions> ExpectiminimaxSearch(
     const Game& game, const State* state,
     std::function<double(const State&)> value_function, int depth_limit,
     Player maximizing_player);
@@ -74,4 +100,4 @@ std::pair<double, Action> ExpectiminimaxSearch(
 }  // namespace algorithms
 }  // namespace open_spiel
 
-#endif  // OPEN_SPIEL_ALGORITHMS_MINMAX_H_
+#endif  // OPEN_SPIEL_ALGORITHMS_MINIMAX_H_

--- a/open_spiel/algorithms/minimax_test.cc
+++ b/open_spiel/algorithms/minimax_test.cc
@@ -15,6 +15,9 @@
 #include "open_spiel/algorithms/minimax.h"
 
 #include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "open_spiel/games/pig/pig.h"
 #include "open_spiel/games/tic_tac_toe/tic_tac_toe.h"
@@ -29,9 +32,15 @@ namespace {
 
 void AlphaBetaSearchTest_TicTacToe() {
   std::shared_ptr<const Game> game = LoadGame("tic_tac_toe");
-  std::pair<double, Action> value_and_action =
+  std::pair<double, BestActions> value_and_actions =
       AlphaBetaSearch(*game, nullptr, {}, -1, kInvalidPlayer);
-  SPIEL_CHECK_EQ(0.0, value_and_action.first);
+
+  const float value = value_and_actions.first;
+  SPIEL_CHECK_EQ(0.0, value);
+
+  const BestActions& actions = value_and_actions.second;
+  std::vector<Action> true_best_actions = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SPIEL_CHECK_TRUE(actions.Equals(true_best_actions));
 }
 
 void AlphaBetaSearchTest_TicTacToe_Win() {
@@ -44,9 +53,17 @@ void AlphaBetaSearchTest_TicTacToe_Win() {
   // .o.
   // .x.
   // ...
-  std::pair<double, Action> value_and_action =
+  // Optimal actions: 0 (R1C1), 2 (R1C3), 3 (R2C1), 5 (R2C3), 6 (R3C1),
+  // 8 (R3C3). Action 7 (R3C2) is legal but only draws.
+  std::pair<double, BestActions> value_and_actions =
       AlphaBetaSearch(*game, state.get(), {}, -1, kInvalidPlayer);
-  SPIEL_CHECK_EQ(1.0, value_and_action.first);
+
+  const float value = value_and_actions.first;
+  SPIEL_CHECK_EQ(1.0, value_and_actions.first);
+
+  const BestActions& actions = value_and_actions.second;
+  std::vector<Action> true_best_actions = {0, 2, 3, 5, 6, 8};
+  SPIEL_CHECK_TRUE(actions.Equals(true_best_actions));
 }
 
 void AlphaBetaSearchTest_TicTacToe_Loss() {
@@ -57,14 +74,45 @@ void AlphaBetaSearchTest_TicTacToe_Loss() {
   // ...
   // xox
   // ..o
+  // Optimal actions: 0 (R1C1), 1 (R1C2), 2 (R1C3), 6 (R3C1), 7 (R3C2).
   state->ApplyAction(5);
   state->ApplyAction(4);
   state->ApplyAction(3);
   state->ApplyAction(8);
 
-  std::pair<double, Action> value_and_action =
+  std::pair<double, BestActions> value_and_actions =
       AlphaBetaSearch(*game, state.get(), {}, -1, kInvalidPlayer);
-  SPIEL_CHECK_EQ(-1.0, value_and_action.first);
+
+  const float value = value_and_actions.first;
+  SPIEL_CHECK_EQ(-1.0, value);
+
+  const BestActions& actions = value_and_actions.second;
+  std::vector<Action> true_best_actions = {0, 1, 2, 6, 7};
+  SPIEL_CHECK_TRUE(actions.Equals(true_best_actions));
+}
+
+void AlphaBetaSearchTest_TicTacToe_SingleAction() {
+  std::shared_ptr<const Game> game = LoadGame("tic_tac_toe");
+  std::unique_ptr<State> state = game->NewInitialState();
+
+  // Construct:
+  // xox
+  // ...
+  // ...
+  // Optimal actions: 4 (R2C2) only. Every other legal action loses.
+  state->ApplyAction(0);
+  state->ApplyAction(1);
+  state->ApplyAction(2);
+
+  std::pair<double, BestActions> value_and_actions =
+      AlphaBetaSearch(*game, state.get(), {}, -1, kInvalidPlayer);
+
+  const float value = value_and_actions.first;
+  SPIEL_CHECK_EQ(0.0, value);
+
+  const BestActions& actions = value_and_actions.second;
+  std::vector<Action> true_best_actions = {4};
+  SPIEL_CHECK_TRUE(actions.Equals(true_best_actions));
 }
 
 int FirstPlayerAdvantage(const State& state) {
@@ -75,19 +123,26 @@ int FirstPlayerAdvantage(const State& state) {
 void ExpectiminimaxSearchTest_Pig() {
   std::shared_ptr<const Game> game =
       LoadGame("pig", {{"diceoutcomes", GameParameter(3)}});
-  std::pair<double, Action> value_and_action = ExpectiminimaxSearch(
+  std::pair<double, BestActions> value_and_actions = ExpectiminimaxSearch(
       *game, nullptr, FirstPlayerAdvantage, 2, kInvalidPlayer);
-  SPIEL_CHECK_EQ(1.0 / 3 * 2 + 1.0 / 3 * 3, value_and_action.first);
-  SPIEL_CHECK_EQ(/*kRoll=*/0, value_and_action.second);
+
+  const double value = value_and_actions.first;
+  const double true_value = 1.0 / 3 * 2 + 1.0 / 3 * 3;
+  SPIEL_CHECK_EQ(true_value, value);
+
+  const BestActions& actions = value_and_actions.second;
+  const std::vector<Action> true_best_actions = {/*kRoll=*/0};
+  SPIEL_CHECK_TRUE(actions.Equals(true_best_actions));
 }
 
 }  // namespace
 }  // namespace algorithms
 }  // namespace open_spiel
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   open_spiel::algorithms::AlphaBetaSearchTest_TicTacToe();
   open_spiel::algorithms::AlphaBetaSearchTest_TicTacToe_Win();
   open_spiel::algorithms::AlphaBetaSearchTest_TicTacToe_Loss();
+  open_spiel::algorithms::AlphaBetaSearchTest_TicTacToe_SingleAction();
   open_spiel::algorithms::ExpectiminimaxSearchTest_Pig();
 }

--- a/open_spiel/bots/pimc_bot.cc
+++ b/open_spiel/bots/pimc_bot.cc
@@ -104,13 +104,13 @@ std::pair<std::vector<int>, Action> PIMCBot::Search(const State& root_state) {
         root_state.NumPlayers() == 2) {
       // Special case for two-player zero-sum deterministic games: use
       // alpha-beta.
-      std::pair<double, Action> search_result = algorithms::AlphaBetaSearch(
+      std::pair<double, algorithms::BestActions> search_result = algorithms::AlphaBetaSearch(
           *state->GetGame(), state.get(),
           [this, player](const State& state) {
             return this->value_function_(state, player);
           },
           depth_limit_, player, /*use_undo*/ false);
-      action_counts[search_result.second] += 1;
+      action_counts[search_result.second.Single()] += 1;
     } else {
       std::pair<std::vector<double>, Action> search_result =
           algorithms::MaxNSearch(*state->GetGame(), state.get(),

--- a/open_spiel/examples/minimax_example.cc
+++ b/open_spiel/examples/minimax_example.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iostream>
 #include <memory>
+#include <utility>
 
 #include "open_spiel/algorithms/minimax.h"
 #include "open_spiel/games/breakthrough/breakthrough.h"
@@ -20,7 +22,8 @@
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
 
-inline constexpr int kSearchDepth = 2;
+inline constexpr int kSearchDepthTicTacToe = 9;
+inline constexpr int kSearchDepthBreakthrough = 2;
 inline constexpr int kSearchDepthPig = 10;
 inline constexpr int kWinscorePig = 30;
 inline constexpr int kDiceoutcomesPig = 2;
@@ -35,29 +38,62 @@ int BlackPieceAdvantage(const State& state) {
          bstate.pieces(breakthrough::kWhitePlayerId);
 }
 
-void PlayBreakthrough() {
+void PlayTicTacToe(std::mt19937& rng, bool sample_actions = true) {
   std::shared_ptr<const Game> game =
-      LoadGame("breakthrough", {{"rows", GameParameter(6)},
-                                {"columns", GameParameter(6)}});
+      LoadGame("tic_tac_toe");
   std::unique_ptr<State> state = game->NewInitialState();
   while (!state->IsTerminal()) {
     std::cout << std::endl << state->ToString() << std::endl;
 
     Player player = state->CurrentPlayer();
-    std::pair<double, Action> value_action = algorithms::AlphaBetaSearch(
-        *game, state.get(), [player](const State& state) {
-            return (player == breakthrough::kBlackPlayerId ?
-                    BlackPieceAdvantage(state) :
-                    -BlackPieceAdvantage(state));
-            },
-        kSearchDepth, player);
+    std::pair<double, algorithms::BestActions> value_action =
+        algorithms::AlphaBetaSearch(
+            *game, state.get(),
+            nullptr,
+            kSearchDepthTicTacToe, player);
 
-    std::cout << std::endl << "Player " << player << " choosing action "
-              << state->ActionToString(player, value_action.second)
-              << " with heuristic value (to black) " << value_action.first
+    const double value = value_action.first;
+    const double action = sample_actions ? value_action.second.SampleUniformly(rng) : value_action.second.Single();
+
+    std::cout << std::endl
+              << "Player " << player << " choosing action "
+              << state->ActionToString(player, action)
+              << " with heuristic value (to black) " << value
               << std::endl;
 
-    state->ApplyAction(value_action.second);
+    state->ApplyAction(action);
+  }
+}
+
+void PlayBreakthrough(std::mt19937& rng, bool sample_actions = true) {
+  std::shared_ptr<const Game> game =
+      LoadGame("breakthrough",
+               {{"rows", GameParameter(6)}, {"columns", GameParameter(6)}});
+  std::unique_ptr<State> state = game->NewInitialState();
+  while (!state->IsTerminal()) {
+    std::cout << std::endl << state->ToString() << std::endl;
+
+    Player player = state->CurrentPlayer();
+    std::pair<double, algorithms::BestActions> value_action =
+        algorithms::AlphaBetaSearch(
+            *game, state.get(),
+            [player](const State& state) {
+              return (player == breakthrough::kBlackPlayerId
+                          ? BlackPieceAdvantage(state)
+                          : -BlackPieceAdvantage(state));
+            },
+            kSearchDepthBreakthrough, player);
+
+    const double value = value_action.first;
+    const double action = sample_actions ? value_action.second.SampleUniformly(rng) : value_action.second.Single();
+
+    std::cout << std::endl
+              << "Player " << player << " choosing action "
+              << state->ActionToString(player, action)
+              << " with heuristic value (to black) " << value
+              << std::endl;
+
+    state->ApplyAction(action);
   }
 
   std::cout << "Terminal state: " << std::endl;
@@ -69,7 +105,7 @@ int FirstPlayerAdvantage(const State& state) {
   return pstate.score(0) - pstate.score(1);
 }
 
-void PlayPig(std::mt19937& rng) {
+void PlayPig(std::mt19937& rng, bool sample_actions = true) {
   std::shared_ptr<const Game> game =
       LoadGame("pig", {{"winscore", GameParameter(kWinscorePig)},
                        {"diceoutcomes", GameParameter(kDiceoutcomesPig)}});
@@ -86,20 +122,25 @@ void PlayPig(std::mt19937& rng) {
                 << std::endl;
       state->ApplyAction(action);
     } else {
-      std::pair<double, Action> value_action = algorithms::ExpectiminimaxSearch(
-          *game, state.get(),
-          [player](const State& state) {
-            return (player == Player{0} ? FirstPlayerAdvantage(state)
-                                        : -FirstPlayerAdvantage(state));
-          },
-          kSearchDepthPig, player);
+      std::pair<double, algorithms::BestActions> value_actions =
+          algorithms::ExpectiminimaxSearch(
+              *game, state.get(),
+              [player](const State& state) {
+                return (player == kDefaultPlayerId
+                            ? FirstPlayerAdvantage(state)
+                            : -FirstPlayerAdvantage(state));
+              },
+              kSearchDepthPig, player);
+
+      const double value = value_actions.first;
+      const Action action = sample_actions ? value_actions.second.SampleUniformly(rng) : value_actions.second.Single();
 
       std::cout << std::endl
                 << "Player " << player << " choosing action "
-                << state->ActionToString(player, value_action.second)
-                << " with heuristic value " << value_action.first << std::endl;
+                << state->ActionToString(player, action)
+                << " with heuristic value " << value << std::endl;
 
-      state->ApplyAction(value_action.second);
+      state->ApplyAction(action);
     }
   }
 
@@ -110,8 +151,9 @@ void PlayPig(std::mt19937& rng) {
 }  // namespace
 }  // namespace open_spiel
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   std::mt19937 rng(kSeed);  // Random number generator.
-  open_spiel::PlayBreakthrough();
-  open_spiel::PlayPig(rng);
+  open_spiel::PlayTicTacToe(rng, true);
+  open_spiel::PlayBreakthrough(rng, true);
+  open_spiel::PlayPig(rng, true);
 }

--- a/open_spiel/python/algorithms/minimax.py
+++ b/open_spiel/python/algorithms/minimax.py
@@ -21,10 +21,41 @@ See for example https://en.wikipedia.org/wiki/Alpha-beta_pruning
 """
 
 import pyspiel
+import numpy as np
 
 
-def _alpha_beta(state, depth, alpha, beta, value_function,
-                maximizing_player_id):
+class BestActions:
+
+  def __init__(self):
+    self.actions: list[int] = []
+
+  def single(self) -> int:
+    return self.actions[0] if self.actions else -1
+
+  def sample_uniformly(self, rng: np.random.RandomState) -> int:
+    return rng.choice(self.actions) if self.actions else -1
+
+  def __len__(self) -> int:
+    return len(self.actions)
+
+  def __contains__(self, other_action: int) -> bool:
+    return other_action in self.actions
+
+  def __eq__(self, other_actions: list[int]) -> bool:
+    if len(self.actions) != len(other_actions):
+      return False
+
+    return all(action in self.actions for action in other_actions)
+
+  def clear(self):
+    self.actions.clear()
+
+  def add(self, action: int):
+    self.actions.append(action)
+
+
+def _alpha_beta(state, depth, alpha, beta, value_function, maximizing_player_id,
+                is_root):
   """An alpha-beta algorithm.
 
   Implements a min-max algorithm with alpha-beta pruning.
@@ -61,36 +92,54 @@ def _alpha_beta(state, depth, alpha, beta, value_function,
   if depth == 0:
     return value_function(state), None
 
+  best_actions = BestActions()
   player = state.current_player()
-  best_action = -1
+
   if player == maximizing_player_id:
     value = -float("inf")
     for action in state.legal_actions():
       child_state = state.clone()
       child_state.apply_action(action)
       child_value, _ = _alpha_beta(child_state, depth - 1, alpha, beta,
-                                   value_function, maximizing_player_id)
+                                   value_function, maximizing_player_id, False)
       if child_value > value:
         value = child_value
-        best_action = action
-      alpha = max(alpha, value)
+        if is_root:
+          best_actions.clear()
+          best_actions.add(action)
+      elif is_root and child_value == value:
+        best_actions.add(action)
+
+      alpha = max(alpha, np.nextafter(value, -np.inf)) if is_root else max(
+          alpha, value)
+
       if alpha >= beta:
         break  # beta cut-off
-    return value, best_action
+
+    return value, best_actions
   else:
     value = float("inf")
     for action in state.legal_actions():
       child_state = state.clone()
       child_state.apply_action(action)
       child_value, _ = _alpha_beta(child_state, depth - 1, alpha, beta,
-                                   value_function, maximizing_player_id)
+                                   value_function, maximizing_player_id, False)
+
       if child_value < value:
         value = child_value
-        best_action = action
-      beta = min(beta, value)
+        if is_root:
+          best_actions.clear()
+          best_actions.add(action)
+      elif is_root and child_value == value:
+        best_actions.add(action)
+
+      beta = min(beta, np.nextafter(value, np.inf)) if is_root else min(
+          beta, value)
+
       if alpha >= beta:
         break  # alpha cut-off
-    return value, best_action
+
+    return value, best_actions
 
 
 def alpha_beta_search(game,
@@ -146,10 +195,16 @@ def alpha_beta_search(game,
       alpha=-float("inf"),
       beta=float("inf"),
       value_function=value_function,
-      maximizing_player_id=maximizing_player_id)
+      maximizing_player_id=maximizing_player_id,
+      is_root=True,
+  )
 
 
-def expectiminimax(state, depth, value_function, maximizing_player_id):
+def expectiminimax(state,
+                   depth,
+                   value_function,
+                   maximizing_player_id,
+                   is_root=True):
   """Runs expectiminimax until the specified depth.
 
   See https://en.wikipedia.org/wiki/Expectiminimax for details.
@@ -173,34 +228,57 @@ def expectiminimax(state, depth, value_function, maximizing_player_id):
   if depth == 0:
     return value_function(state), None
 
+  action_values: list[tuple[int, float]] = []
+
+  player = state.current_player()
   if state.is_chance_node():
     value = 0
     for outcome, prob in state.chance_outcomes():
       child_state = state.clone()
       child_state.apply_action(outcome)
-      child_value, _ = expectiminimax(child_state, depth, value_function,
-                                      maximizing_player_id)
+      child_value, _ = expectiminimax(
+          child_state,
+          depth,
+          value_function,
+          maximizing_player_id,
+          is_root=False)
       value += prob * child_value
     return value, None
-  elif state.current_player() == maximizing_player_id:
+  elif player == maximizing_player_id:
     value = -float("inf")
     for action in state.legal_actions():
       child_state = state.clone()
       child_state.apply_action(action)
-      child_value, _ = expectiminimax(child_state, depth - 1, value_function,
-                                      maximizing_player_id)
-      if child_value > value:
-        value = child_value
-        best_action = action
-    return value, best_action
+      child_value, _ = expectiminimax(
+          child_state,
+          depth - 1,
+          value_function,
+          maximizing_player_id,
+          is_root=False)
+      value = max(value, child_value)
+      if is_root:
+        action_values.append((action, child_value))
   else:
     value = float("inf")
     for action in state.legal_actions():
       child_state = state.clone()
       child_state.apply_action(action)
-      child_value, _ = expectiminimax(child_state, depth - 1, value_function,
-                                      maximizing_player_id)
-      if child_value < value:
-        value = child_value
-        best_action = action
-    return value, best_action
+      child_value, _ = expectiminimax(
+          child_state,
+          depth - 1,
+          value_function,
+          maximizing_player_id,
+          is_root=False)
+      value = min(value, child_value)
+      if is_root:
+        action_values.append((action, child_value))
+
+  if not is_root:
+    return value, None
+
+  best_actions = BestActions()
+  for a, v in action_values:
+    if np.abs(value - v) <= 1e-9:
+      best_actions.add(a)
+
+  return value, best_actions

--- a/open_spiel/python/algorithms/minimax_test.py
+++ b/open_spiel/python/algorithms/minimax_test.py
@@ -20,21 +20,30 @@ from open_spiel.python.algorithms import minimax
 import pyspiel
 
 
+def first_player_advantage(state):
+  # PigState::score is not bound in Python; parse ToString:
+  # "Scores: 0 0, Turn total: 0\nCurrent player: 0"
+  scores = [int(x) for x in str(state).split(",")[0].split()[1:]]
+  return scores[0] - scores[1]
+
+
 class MinimaxTest(absltest.TestCase):
 
   def test_compute_game_value(self):
     tic_tac_toe = pyspiel.load_game("tic_tac_toe")
 
-    game_score, _ = minimax.alpha_beta_search(tic_tac_toe)
+    game_score, best_actions = minimax.alpha_beta_search(tic_tac_toe)
     self.assertEqual(0., game_score)
+    self.assertEqual(best_actions, [0, 1, 2, 3, 4, 5, 6, 7, 8])
 
   def test_compute_game_value_with_evaluation_function(self):
     # We only check it runs
     tic_tac_toe = pyspiel.load_game("tic_tac_toe")
 
-    game_score, _ = minimax.alpha_beta_search(
+    game_score, best_actions = minimax.alpha_beta_search(
         tic_tac_toe, value_function=lambda x: 0, maximum_depth=1)
     self.assertEqual(0., game_score)
+    self.assertEqual(best_actions, [0, 1, 2, 3, 4, 5, 6, 7, 8])
 
   def test_win(self):
     tic_tac_toe = pyspiel.load_game("tic_tac_toe")
@@ -44,10 +53,14 @@ class MinimaxTest(absltest.TestCase):
     # .o.
     # .x.
     # ...
+    # Optimal actions: 0 (R1C1), 2 (R1C3), 3 (R2C1), 5 (R2C3), 6 (R3C1),
+    # 8 (R3C3). Action 7 (R3C2) is legal but only draws.
     state.apply_action(4)
     state.apply_action(1)
-    game_score, _ = minimax.alpha_beta_search(tic_tac_toe, state=state)
+    game_score, best_actions = minimax.alpha_beta_search(
+        tic_tac_toe, state=state)
     self.assertEqual(1., game_score)
+    self.assertEqual(best_actions, [0, 2, 3, 5, 6, 8])
 
   def test_loss(self):
     tic_tac_toe = pyspiel.load_game("tic_tac_toe")
@@ -57,12 +70,40 @@ class MinimaxTest(absltest.TestCase):
     # ...
     # xox
     # ..o
+    # Optimal actions: 0 (R1C1), 1 (R1C2), 2 (R1C3), 6 (R3C1), 7 (R3C2).
     state.apply_action(5)
     state.apply_action(4)
     state.apply_action(3)
     state.apply_action(8)
-    game_score, _ = minimax.alpha_beta_search(tic_tac_toe, state=state)
+    game_score, best_actions = minimax.alpha_beta_search(
+        tic_tac_toe, state=state)
     self.assertEqual(-1., game_score)
+    self.assertEqual(best_actions, [0, 1, 2, 6, 7])
+
+  def test_single_action(self):
+    tic_tac_toe = pyspiel.load_game("tic_tac_toe")
+    state = tic_tac_toe.new_initial_state()
+
+    # Construct:
+    # xox
+    # ...
+    # ...
+    # Optimal actions: 4 (R2C2) only. Every other legal action loses.
+    state.apply_action(0)
+    state.apply_action(1)
+    state.apply_action(2)
+    game_score, best_actions = minimax.alpha_beta_search(
+        tic_tac_toe, state=state)
+    self.assertEqual(0., game_score)
+    self.assertEqual(best_actions, [4])
+
+  def test_expectiminimax(self):
+    pig = pyspiel.load_game("pig", {"diceoutcomes": 3})
+    state = pig.new_initial_state()
+    value, best_actions = minimax.expectiminimax(state, 2,
+                                                 first_player_advantage, 0)
+    self.assertEqual(1.0 / 3 * 2 + 1.0 / 3 * 3, value)
+    self.assertEqual([0], best_actions)
 
 
 if __name__ == "__main__":

--- a/open_spiel/python/games/heuristics_test.py
+++ b/open_spiel/python/games/heuristics_test.py
@@ -67,13 +67,14 @@ class HeuristicsTest(absltest.TestCase):
       if player == 0:
         action = np.random.choice(state.legal_actions(state.current_player()))
       else:
-        _, action = minimax.alpha_beta_search(
+        _, best_actions = minimax.alpha_beta_search(
             game=game,
             state=state,
             value_function=functools.partial(heuristics.evaluate_state,
                                              player=player),
             maximum_depth=2,
             maximizing_player_id=player)
+        action = best_actions.single()
       print(f"State is: \n{state.debug_string()}\n")
       print(f"Taking action: {state.action_to_string(player, action)}\n")
       state.apply_action(action)


### PR DESCRIPTION
This PR adds stochasticity to MiniMax (both AlphaBeta pruning and Expectiminimax searches) for both Python and C++. Both algorithms return now a set of actions in the root, that achieve the same value of the game, hence are equally good. The callers of these algorithms then can either take the `Single()` action, which corresponds to the original algorithm taking the first action found, or `UniformlySample(rng)` which samples an action uniformly at random. Changes are reflected in example scripts and unit tests.