### PR TITLE
Fix BoltzmannQLearner sampling illegal actions from the softmax

### DIFF
--- a/open_spiel/python/algorithms/boltzmann_tabular_qlearner.py
+++ b/open_spiel/python/algorithms/boltzmann_tabular_qlearner.py
@@ -68,10 +68,11 @@ class BoltzmannQLearner(tabular_qlearner.QLearner):
     probs = np.zeros(self._num_actions)
 
     if temperature > 0.0:
-      probs += [
-          np.exp((1 / temperature) * self._q_values[info_state][i])
-          for i in range(self._num_actions)
-      ]
+      logits = np.array(
+          [self._q_values[info_state][a] / temperature for a in legal_actions])
+      # Subtract the max so large Q-values or a small temperature cannot
+      # overflow the exponential.
+      probs[legal_actions] = np.exp(logits - np.max(logits))
       probs /= np.sum(probs)
     else:
       # Temperature = 0 causes normal greedy action selection

--- a/open_spiel/python/algorithms/boltzmann_tabular_qlearner_test.py
+++ b/open_spiel/python/algorithms/boltzmann_tabular_qlearner_test.py
@@ -17,6 +17,7 @@ from absl.testing import absltest
 import numpy as np
 
 from open_spiel.python import rl_environment
+from open_spiel.python import rl_tools
 from open_spiel.python.algorithms import boltzmann_tabular_qlearner
 import pyspiel
 
@@ -60,6 +61,40 @@ class BoltzmannQlearnerTest(absltest.TestCase):
           time_step = env.step([agent_output.action])
           total_eval_reward += time_step.rewards[0]
       self.assertGreaterEqual(total_eval_reward, 250)
+
+  def test_softmax_ignores_illegal_actions(self):
+    game = pyspiel.load_game("tic_tac_toe")
+    env = rl_environment.Environment(game=game)
+    agent = boltzmann_tabular_qlearner.BoltzmannQLearner(
+        1, game.num_distinct_actions())
+
+    time_step = env.reset()
+    time_step = env.step([4])  # Player 0 takes the center; it is now illegal.
+    legal_actions = time_step.observations["legal_actions"][1]
+    self.assertNotIn(4, legal_actions)
+
+    agent_output = agent.step(time_step)
+    self.assertIn(agent_output.action, legal_actions)
+    self.assertEqual(agent_output.probs[4], 0.0)
+    self.assertAlmostEqual(np.sum(agent_output.probs[legal_actions]), 1.0)
+
+  def test_softmax_is_stable_for_large_q_values(self):
+    game = pyspiel.load_game("tic_tac_toe")
+    env = rl_environment.Environment(game=game)
+    agent = boltzmann_tabular_qlearner.BoltzmannQLearner(
+        0, game.num_distinct_actions(),
+        temperature_schedule=rl_tools.ConstantSchedule(1e-3))
+
+    time_step = env.reset()
+    info_state = str(time_step.observations["info_state"][0])
+    legal_actions = time_step.observations["legal_actions"][0]
+    for action in legal_actions:
+      agent._q_values[info_state][action] = 1e6 * (action + 1)
+
+    agent_output = agent.step(time_step)
+    self.assertTrue(np.all(np.isfinite(agent_output.probs)))
+    self.assertAlmostEqual(np.sum(agent_output.probs), 1.0)
+    self.assertIn(agent_output.action, legal_actions)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`BoltzmannQLearner._softmax` builds the Boltzmann distribution over `range(self._num_actions)` instead of `legal_actions`, so every illegal action gets weight `exp(Q/T)` (with the `defaultdict` giving `Q = 0`, that is weight 1) and can be sampled. In any game where legality depends on the state (e.g. `tic_tac_toe`), the agent returns an action that `rl_environment.Environment.step` forwards to C++ and the game rejects:

    pyspiel.SpielError: tic_tac_toe.cc:129 board_[move] == CellState::kEmpty

Even when the sampled action happens to be legal, `StepOutput.probs` carries non-zero mass on illegal actions and the normaliser is wrong.

The `temperature <= 0` branch of the same method and the parent `QLearner._epsilon_greedy` already restrict themselves to `legal_actions`, and the docstring promises "a valid soft-max selected action and valid action probabilities". This change fills only the legal entries of `probs` before normalising, matching those two paths.

The existing test uses a two-action EFG in which both actions are always legal, which is why it never caught this.

## Tests

- Added `test_softmax_ignores_illegal_actions` on `tic_tac_toe`: after player 0 takes the center, asserts the agent's probability on that cell is exactly 0, the sampled action is legal, and the legal probabilities sum to 1. Fails on master (`probs[4] == 1/9`), passes with the fix.
- `boltzmann_tabular_qlearner_test.py`, `tabular_qlearner_test.py`, `tests/rl_environment_test.py` pass; `ruff check` (repo config) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
